### PR TITLE
Add missing "traceback" import in djangoapp.py.

### DIFF
--- a/gunicorn/app/djangoapp.py
+++ b/gunicorn/app/djangoapp.py
@@ -5,6 +5,7 @@
 
 import os
 import sys
+import traceback
 
 from django.core.handlers.wsgi import WSGIHandler
 from django.core.servers.basehttp import AdminMediaHandler, WSGIServerException


### PR DESCRIPTION
An except block in DjangoApplicationCommand was referencing traceback module, which has not been imported.
