### PR TITLE
Small typo fix in the examples.

### DIFF
--- a/examples/longpoll.py
+++ b/examples/longpoll.py
@@ -15,7 +15,7 @@ class TestIter(object):
             time.sleep(20)
 
 def app(environ, start_response):
-    """Application which cooperatively pauses 10 seconds before responding"""
+    """Application which cooperatively pauses 20 seconds (needed to surpass normal timeouts) before responding"""
     data = 'Hello, World!\n'
     status = '200 OK'
     response_headers = [


### PR DESCRIPTION
The docs in the `longpoll.py` example reference a 10 second delay while the actual `time.sleep` call sleeps for 20 seconds.  Changed the docs are correct.

_Update_: description to reflect new change.
