### PR TITLE
Add logging configuration support to gunicorn_paster

### DIFF
--- a/examples/log_app.ini
+++ b/examples/log_app.ini
@@ -1,0 +1,30 @@
+[app:main]
+paste.app_factory = log_app:app_factory
+
+[server:main]
+use = egg:gunicorn#main
+host = 127.0.0.1
+port = 8080
+
+
+[loggers]
+keys=root
+
+[handlers]
+keys=console
+
+[formatters]
+keys=default
+
+[logger_root]
+level=INFO
+qualname=root
+handlers=console
+
+[handler_console]
+class=StreamHandler
+formatter=default
+args=(sys.stdout, )
+
+[formatter_default]
+format=[%(asctime)s] [%(levelname)-7s] - %(process)d:%(name)s:%(funcName)s - %(message)s

--- a/examples/log_app.py
+++ b/examples/log_app.py
@@ -1,0 +1,14 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+def app_factory(global_options, **local_options):
+    return app
+
+def app(environ, start_response):
+    start_response("200 OK", [])
+    log.debug("Hello Debug!")
+    log.info("Hello Info!")
+    log.warn("Hello Warn!")
+    log.error("Hello Error!")
+    return ["Hello World!\n"]


### PR DESCRIPTION
`paster serve` supports python logging configuration within the paster ini-file. See example/log_app.(ini|py) for an example.
