### PR TITLE
Docs update to make keep-alive support clearer

### DIFF
--- a/doc/htdocs/design.html
+++ b/doc/htdocs/design.html
@@ -46,10 +46,10 @@ the failed worker.</p>
 <div class="section" id="sync-workers">
 <h3><a class="toc-backref" href="#contents">Sync Workers</a></h3>
 <p>The most basic and the default worker type is a synchronous worker class that
-handles a single request at a time. This model is the simplest to reason about
-as any errors will affect at most a single request. Though as we describe below
-only processing a single request at a time requires some assumptions about how
-applications are programmed.</p>
+handles a single request at a time, then closes the connection. This model is
+the simplest to reason about as any errors will affect at most a single request.
+However, as we describe below processing a single request at a time requires
+some assumptions about how applications are programmed.</p>
 </div>
 <div class="section" id="async-workers">
 <h3><a class="toc-backref" href="#contents">Async Workers</a></h3>
@@ -80,7 +80,8 @@ the servers. For the curious, <a class="reference external" href="http://ha.cker
 <p>Some examples of behavior requiring asynchronous workers:</p>
 <blockquote>
 <ul class="simple">
-<li>Applications making long blocking calls (Ie, external web services)</li>
+<li>Applications making long blocking calls (i.e. external web services)</li>
+<li>Applications which require persistent (keep-alive) connections</li>
 <li>Serving requests directly to the internet</li>
 <li>Streaming requests and responses</li>
 <li>Long polling</li>


### PR DESCRIPTION
Sorry about the slightly harsh tweet, someone told me (incorrectly) that keep-alive was a requirement for HTTP/1.1 :). This makes the docs a little clearer that sync doesn't support keep-alives.
