### PR TITLE
Removed the installation requirement to setuptools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,6 @@ setup(
     packages = find_packages(exclude=['examples', 'tests']),
     include_package_data = True,
     
-    install_requires=['setuptools'],
-
     entry_points="""
     
     [console_scripts]


### PR DESCRIPTION
gunicorn already imports setuptools in its setup.py, so it doesn't require it as a install_requires line. Above all this prevented a user that chose to use distribute instead of setuptools to easily upgrade gunicorn.
