### PR TITLE
support rpm builds

### DIFF
--- a/rpm/install
+++ b/rpm/install
@@ -1,0 +1,13 @@
+%{__python} setup.py install --skip-build --root=$RPM_BUILD_ROOT
+
+%if ! (0%{?fedora} > 12 || 0%{?rhel} > 5)
+%{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+%{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
+%endif
+
+INSTALLED_FILES="\
+%{python_sitelib}/*
+%{_bindir}/*
+%doc doc
+"
+echo "$INSTALLED_FILES" > INSTALLED_FILES

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_rpm]
+packager = Randall Leeds <randall@meebo-inc.com>
+build-requires = python2-devel python-setuptools
+requires = python-setuptools >= 0.6c6 python-ctypes
+install_script = rpm/install


### PR DESCRIPTION
With this patch `python setup.py bdist_rpm` works and generates proper dependencies and installation procedures. Tested on CentOS5. I followed [PythonPackaging](https://fedoraproject.org/wiki/Packaging:Python) and [Eggs](http://fedoraproject.org/wiki/Packaging:Python_Eggs) pretty closely and the output matches the rpms I've been generating and deploying in production for a couple months now.
