### PR TITLE
Patch for systems without ctypes.

### DIFF
--- a/gunicorn/http/sendfile.py
+++ b/gunicorn/http/sendfile.py
@@ -3,16 +3,22 @@
 # This file is part of gunicorn released under the MIT license. 
 # See the NOTICE for more information.
 
-import ctypes
-import ctypes.util
 import errno
 import os
 import sys
 
-if sys.version_info >= (2, 6):
-    _libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
-    _sendfile = _libc.sendfile
-else:
+# Python on Solaris compiled with Sun Studio doesn't have ctypes.
+try:
+    import ctypes
+    import ctypes.util
+
+    if sys.version_info >= (2, 6):
+        _libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+        _sendfile = _libc.sendfile
+    else:
+        _sendfile = None
+
+except ImportError:
     _sendfile = None
 
 if _sendfile:

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -10,6 +10,9 @@ except MemoryError:
     # selinux execmem denial
     # https://bugzilla.redhat.com/show_bug.cgi?id=488396
     ctypes = None
+except ImportError:
+    # Python on Solaris compiled with Sun Studio doesn't have ctypes
+    ctypes = None
 
 import fcntl
 import os


### PR DESCRIPTION
A small patch to catch ctypes import errors on systems that don't have that module, such as Solaris when Python is compiled with Sun Studio.
