### PR TITLE
Fix for 304 and chunked responses

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -204,6 +204,10 @@ class Response(object):
             return False
         elif self.req.version <= (1,0):
             return False
+        elif self.status.startswith("304"):
+            # Do not use chunked responses when the response is guaranteed to
+            # not have a response body.
+            return False
         return True
 
     def default_headers(self):


### PR DESCRIPTION
When the response is a 304 turn off chunked responses as there is a guarantee there is no response body (hence no Content-Length defined)

This can cause odd behavior with browsers not being able to parse the response
correctly (not sure if this is just a property of empty chunked responses or
something else)
