### PR TITLE
Safer and more consistent umask handling

### DIFF
--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -117,6 +117,8 @@ class Application(object):
     def run(self):
         if self.cfg.spew:
             debug.spew()
+        if self.cfg.umask is not None:
+            os.umask(self.cfg.umask)
         if self.cfg.daemon:
             util.daemonize()
         else:

--- a/gunicorn/app/pasterapp.py
+++ b/gunicorn/app/pasterapp.py
@@ -29,7 +29,7 @@ class PasterBaseApplication(Application):
             cfg['bind'] = host
 
         cfg['workers'] = int(lc.get('workers', 1))
-        cfg['umask'] = int(lc.get('umask', 0))
+        cfg['umask'] = lc.get('umask')
         cfg['default_proc_name'] = gc.get('__file__')
 
         for k, v in gc.items():

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -494,7 +494,7 @@ class Umask(Setting):
     meta = "INT"
     validator = validate_pos_int
     type = "int"
-    default = 0
+    default = None
     desc = """\
         A bit mask for the file mode on files written by Gunicorn.
         

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -278,7 +278,6 @@ def daemonize():
         if os.fork():
             os._exit(0)
         
-        os.umask(0)
         maxfd = get_maxfd()
 
         # Iterate through and close all file descriptors.

--- a/gunicorn/workers/workertmp.py
+++ b/gunicorn/workers/workertmp.py
@@ -11,12 +11,10 @@ from gunicorn import util
 class WorkerTmp(object):
 
     def __init__(self, cfg):
-        old_umask = os.umask(cfg.umask)
         fd, name = tempfile.mkstemp(prefix="wgunicorn-")
         
         # allows the process to write to the file
         util.chown(name, cfg.uid, cfg.gid)
-        os.umask(old_umask)
 
         # unlink the file so we don't leak tempory files
         try:


### PR DESCRIPTION
# Old Behaviour

umask setting only controlled permissions on unix sockets and workertmp files.
And the default value for this setting is 0 (world writable files)
In addition to this enabling gunicorn daemon mode implicitly sets umask to 0
resulting in all other files created by gunicorn (log, pid) and all files
created by a wsgi app becoming world writable, regardless of the umask
setting.
# New behaviour

The umask default valueis None (instead of 0) meaning leaving umask
unmodified. If umask is specified it applies to all files created by
gunicorn (unix socket, pid file, log file, workertmp) as well as the wsgi app
itself.
