### PR TITLE
Removed Python string formatting from log messages to enable grouping of log messages

### DIFF
--- a/examples/when_ready.conf.py
+++ b/examples/when_ready.conf.py
@@ -27,8 +27,8 @@ class MemoryWatch(threading.Thread):
         while True:
             for (pid, worker) in list(self.server.WORKERS.items()):
                 if self.memory_usage(pid) > self.max_mem:
-                    self.server.log.info("Pid %s killed (memory usage > %s)", (
-                        pid, self.max_mem))
+                    self.server.log.info("Pid %s killed (memory usage > %s)", 
+                        pid, self.max_mem)
                     self.server.kill_worker(pid, signal.SIGQUIT)
             time.sleep(self.timeout)
             

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -97,7 +97,7 @@ class Arbiter(object):
         if self.cfg.debug:
             self.log.debug("Current configuration:")
             for config, value in sorted(self.cfg.settings.iteritems()):
-                self.log.debug("  %s: %s", (config, value.value))
+                self.log.debug("  %s: %s", config, value.value)
         
         if self.cfg.preload_app:
             if not self.cfg.debug:
@@ -119,8 +119,8 @@ class Arbiter(object):
             self.pidfile = Pidfile(self.cfg.pidfile)
             self.pidfile.create(self.pid)
         self.log.debug("Arbiter booted")
-        self.log.info("Listening at: %s (%s)", (self.LISTENER,
-            self.pid))
+        self.log.info("Listening at: %s (%s)", self.LISTENER,
+            self.pid)
         self.log.info("Using worker: %s",
                 self.cfg.settings['worker_class'].get())
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -662,7 +662,7 @@ class PreRequest(Setting):
     validator = validate_callable(2)
     type = "callable"
     def def_pre_request(worker, req):
-        worker.log.debug("%s %s", (req.method, req.path))
+        worker.log.debug("%s %s", req.method, req.path)
     def_pre_request = staticmethod(def_pre_request)
     default = def_pre_request
     desc = """\


### PR DESCRIPTION
At Fashiolista we use Sentry to track errors. And Sentry is able to group messages like these:

```
logging.error('some message: %s', message)
```

But if you format the strings yourself like this:

```
logging.error('some message: %s' % message)
```

All of them will report as separate errors, while they are actually different instances from the same error.
