### PR TITLE
gunicorn does not kill old workers with TornadoWorker

### DIFF
--- a/gunicorn/workers/gtornado.py
+++ b/gunicorn/workers/gtornado.py
@@ -30,6 +30,10 @@ class TornadoWorker(Worker):
         web.RequestHandler.clear = clear
         sys.modules["tornado.web"] = web
         
+    def handle_quit(self, sig, frame):
+        super(TornadoWorker, self).handle_quit(sig, frame)
+        self.ioloop.stop()        
+    
     def watchdog(self):
         self.notify()
             


### PR DESCRIPTION
Yesterday, I used gunicorn with TornadoWorker (I am using Tornado 1.2.1 as latest stable).
In this case, I noticed that gunicorn reload does not kill old workers.
I read worker code and I found that TornadoWorker forget to call ioloop.stop() in handle_quit.

I applied this pacth and I checked that old workers are killed.
