### PR TITLE
fix for AttributeError: 'tuple' object has no attribute 'age' in manage_workers

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -420,7 +420,7 @@ class Arbiter(object):
             self.spawn_workers()
 
         workers = self.WORKERS.items()
-        workers.sort(key=lambda w: w.age)
+        workers.sort(key=lambda w: w[1].age)
         while len(workers) > self.num_workers:
             (pid, _) = workers.pop(0)
             self.kill_worker(pid, signal.SIGQUIT)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/bin/gunicorn_django", line 9, in <module>
    load_entry_point('gunicorn==0.12.2', 'console_scripts', 'gunicorn_django')()
  File "/usr/lib/pymodules/python2.6/gunicorn/app/djangoapp.py", line 209, in run
    DjangoApplication("%prog [OPTIONS] [SETTINGS_PATH]").run()
  File "/usr/lib/pymodules/python2.6/gunicorn/app/base.py", line 131, in run
    Arbiter(self).run()
  File "/usr/lib/pymodules/python2.6/gunicorn/arbiter.py", line 154, in run
    self.manage_workers()
  File "/usr/lib/pymodules/python2.6/gunicorn/arbiter.py", line 423, in manage_workers
    workers.sort(key=lambda w: w.age)
  File "/usr/lib/pymodules/python2.6/gunicorn/arbiter.py", line 423, in <lambda>
    workers.sort(key=lambda w: w.age)
AttributeError: 'tuple' object has no attribute 'age'
```
