### PR TITLE
when stopping the arbiter, close the listener asap

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -91,6 +91,7 @@ class Arbiter(object):
         self.num_workers = self.cfg.workers
         self.debug = self.cfg.debug
         self.timeout = self.cfg.timeout
+        self.kill_timeout = self.cfg.kill_timeout
         self.proc_name = self.cfg.proc_name
         self.worker_class = self.cfg.worker_class
         
@@ -318,12 +319,19 @@ class Arbiter(object):
         sig = signal.SIGQUIT
         if not graceful:
             sig = signal.SIGTERM
-        limit = time.time() + self.timeout
+        if self.kill_timeout == 0:
+            limit = time.time() + 5
+        elif self.kill_timeout < 0:
+            limit = time.time() + (-self.kill_timeout)
+        else:
+            limit = time.time() + self.kill_timeout
         while self.WORKERS and time.time() < limit:
             self.kill_workers(sig)
             time.sleep(0.1)
             self.reap_workers()
-        self.kill_workers(signal.SIGKILL)
+            time.sleep(1)
+        if self.kill_timeout > 0:
+            self.kill_workers(signal.SIGKILL)
 
     def reexec(self):
         """\

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -379,6 +379,20 @@ class Timeout(Setting):
         is not tied to the length of time required to handle a single request.
         """
 
+class KillTimeout(Setting):
+    name = "kill_timeout"
+    section = "Worker Processes"
+    cli = ["--kill-timeout"]
+    meta = "INT"
+    validator = validate_pos_int
+    type = "int"
+    default = 30
+    desc = """\
+        How many seconds to wait for worker to die before killing it with SIGKILL.
+
+        By default set to 30 seconds. If set to zero, SIGKILL is not sent all.
+        """
+
 class Keepalive(Setting):
     name = "keepalive"
     section = "Worker Processes"


### PR DESCRIPTION
setting self.LISTENER to None is not enough because
self.WORKERS also have references to it
