### PR TITLE
A fix to make the newest gunicorn work with older projects, that doesn't 

### DIFF
--- a/gunicorn/app/djangoapp.py
+++ b/gunicorn/app/djangoapp.py
@@ -271,7 +271,7 @@ class DjangoApplicationCommand(DjangoApplication):
             time.tzset()
 
         # Settings are configured, so we can set up the logger if required
-        if settings.LOGGING_CONFIG:
+        if getattr(settings, 'LOGGING_CONFIG', False):
             # First find the logging configuration function ...
             logging_config_path, logging_config_func_name = settings.LOGGING_CONFIG.rsplit('.', 1)
             logging_config_module = importlib.import_module(logging_config_path)


### PR DESCRIPTION
The newest version of gunicorn does no longer support older django projects, because its explicitly looking up settings.LOGGING_CONFIG that was introduced recently. I added a small check, that should enable you to use gunicorn with older projects.
