### PR TITLE
Make graceful restarts/shutdowns more graceful

### DIFF
--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -110,6 +110,11 @@ class Worker(object):
         signal.signal(signal.SIGINT, self.handle_exit)
         signal.signal(signal.SIGWINCH, self.handle_winch)
         signal.signal(signal.SIGUSR1, self.handle_usr1)
+        # Don't let SIGQUIT and SIGUSR1 disturbe active requests
+        # by interrupting system calls
+        if hasattr(signal, 'siginterrupt'):  # python >= 2.6
+            signal.siginterrupt(signal.SIGQUIT, False)
+            signal.siginterrupt(signal.SIGUSR1, False)
 
     def handle_usr1(self, sig, frame):
         self.log.reopen_files()


### PR DESCRIPTION
While restarting gunicorn with a HUP or QUIT signal I've noticed that any active request is very likely to crash with an "Interrupted system call" error.

The interrupted system call in question is sometimes a third party module like MySQLdb.connect and something from within gunicorn itself (unreader.py for example)

This is caused by the arbiter telling the worker "Finish any active request then exit" by sending a SIGQUIT signal. However the default behaviour with an overridden signal in python is to interrupt any pending system call and then call the handler. This behaviour is fine for SIGTERM and SIGINT where we want the worker to terminate as soon as possible but not for SIGQUIT (and SIGUSR1).

Fortunately there's a function in Python 2.6 called "signal.siginterrupt" where you can tell the system to automatically and transparently restart an interrupted system after a signal is received.

http://docs.python.org/library/signal.html#signal.siginterrupt
http://linux.die.net/man/3/siginterrupt
