### PR TITLE
gevent SSL socket support added to GGEventServer.

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -69,6 +69,7 @@ def create(req, sock, client, server, cfg):
     script_name = os.environ.get("SCRIPT_NAME", "")
 
     secure_headers = getattr(cfg, "secure_scheme_headers")
+    certfile = getattr(cfg, "certfile")
 
     for hdr_name, hdr_value in req.headers:
         if hdr_name == "EXPECT":
@@ -79,6 +80,8 @@ def create(req, sock, client, server, cfg):
             forward = hdr_value
         elif (hdr_name.upper() in secure_headers and
               hdr_value == secure_headers[hdr_name.upper()]):
+            url_scheme = "https"
+        elif certfile != None:
             url_scheme = "https"
         elif hdr_name == "HOST":
             server = hdr_value

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -55,7 +55,8 @@ class TCPSocket(BaseSocket):
     FAMILY = socket.AF_INET
     
     def __str__(self):
-        return "http://%s:%d" % self.sock.getsockname()
+        transport = (self.conf.certfile != None) and "https" or "http"
+        return transport + "://%s:%d" % self.sock.getsockname()
     
     def set_options(self, sock, bound=False):
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
@@ -66,8 +67,9 @@ class TCP6Socket(TCPSocket):
     FAMILY = socket.AF_INET6
 
     def __str__(self):
+        transport = (self.conf.certfile != None) and "https" or "http"
         (host, port, fl, sc) = self.sock.getsockname()
-        return "http://[%s]:%d" % (host, port)
+        return transport + "://[%s]:%d" % (host, port)
 
 class UnixSocket(BaseSocket):
     

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -37,6 +37,7 @@ BASE_WSGI_ENV = {
     'wsgi.run_once': False
 }
 
+
 class GeventWorker(AsyncWorker):
 
     server_class = None
@@ -61,8 +62,20 @@ class GeventWorker(AsyncWorker):
                 self.socket, application=self.wsgi, spawn=pool, log=self.log,
                 handler_class=self.wsgi_handler)
         else:
-            server = StreamServer(self.socket, handle=self.handle, spawn=pool)
-
+            if self.cfg.certfile != None:
+                server = StreamServer(self.socket, handle=self.handle,
+                                      spawn=pool,
+                                      keyfile=self.cfg.keyfile,
+                                      certfile=self.cfg.certfile,
+                                      cert_reqs=self.cfg.cert_reqs,
+                                      ssl_version=self.cfg.ssl_version,
+                                      ca_certs=self.cfg.ca_certs,
+                                      suppress_ragged_eofs=\
+                                          self.cfg.suppress_ragged_eofs,
+                                      ciphers=self.cfg.ciphers)
+            else:
+                server = StreamServer(self.socket, handle=self.handle,
+                                      spawn=pool)
         server.start()
         try:
             while self.alive:
@@ -97,6 +110,7 @@ class GeventWorker(AsyncWorker):
             gevent.core.dns_shutdown(fail_requests=1)
             gevent.core.dns_init()
             super(GeventWorker, self).init_process()
+
 
 class PyWSGIHandler(pywsgi.WSGIHandler):
 

--- a/tests/003-test-config.py
+++ b/tests/003-test-config.py
@@ -138,6 +138,36 @@ def test_callable_validation():
     t.raises(TypeError, c.set, "pre_fork", 1)
     t.raises(TypeError, c.set, "pre_fork", lambda x: True)
 
+def test_validate_cert_reqs():
+    c = config.Config()
+    try:
+        import ssl
+    except ImportError:
+        raise SkipTest()
+    t.eq(c.settings['cert_reqs'].get(), ssl.CERT_NONE)
+    c.set("cert_reqs", ssl.CERT_OPTIONAL)
+    t.eq(c.settings['cert_reqs'].get(), ssl.CERT_OPTIONAL)
+    c.set("cert_reqs", ssl.CERT_REQUIRED)
+    t.eq(c.settings['cert_reqs'].get(), ssl.CERT_REQUIRED)
+    t.raises(ValueError, c.set, "cert_reqs", -1)
+    t.raises(ValueError, c.set, "cert_reqs", 3)
+
+def test_validate_ssl_version():
+    c = config.Config()
+    try:
+        import ssl
+    except ImportError:
+        raise SkipTest()
+    t.eq(c.settings['ssl_version'].get(), ssl.PROTOCOL_SSLv23)
+    c.set("ssl_version", ssl.PROTOCOL_SSLv2)
+    t.eq(c.settings['ssl_version'].get(), ssl.PROTOCOL_SSLv2)
+    c.set("ssl_version", ssl.PROTOCOL_SSLv3)
+    t.eq(c.settings['ssl_version'].get(), ssl.PROTOCOL_SSLv3)
+    c.set("ssl_version", ssl.PROTOCOL_TLSv1)
+    t.eq(c.settings['ssl_version'].get(), ssl.PROTOCOL_TLSv1)
+    t.raises(ValueError, c.set, "ssl_version", -1)
+    t.raises(ValueError, c.set, "ssl_version", 4)
+
 def test_cmd_line():
     with AltArgs(["prog_name", "-b", "blargh"]):
         app = NoConfigApp()


### PR DESCRIPTION
config classes to parse gevent SSL related settings.

set url_scheme to "https" if certfile is configured.

reflect http/https status in socket log output at boot.

unit tests for gevent SSL config validation.
