### PR TITLE
Try to natively import import lib if using python2.7, otherwise fallback...

### DIFF
--- a/gunicorn/app/djangoapp.py
+++ b/gunicorn/app/djangoapp.py
@@ -219,7 +219,10 @@ class DjangoApplicationCommand(DjangoApplication):
 
     def reload_django_settings(self, settings_modname):
         from django.conf import settings
-        from django.utils import importlib
+        try:
+            import importlib
+        except ImportError:
+            from django.utils import importlib
         
         mod = importlib.import_module(settings_modname)
 


### PR DESCRIPTION
Try to natively import importlib if using python2.7, otherwise fallback to django bundled importlib.

Result: Enable support for older django releases
