### PR TITLE
Updated documentation for access_log_format config directive

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -688,6 +688,8 @@ class AccessLogFormat(Setting):
 
 
         h: remote address
+        l: '-'
+        u: currently '-', may be user name in future releases
         t: date of the request
         r: status line (ex: GET / HTTP/1.1)
         s: status


### PR DESCRIPTION
Updated docstring in config.py for the access_log_format directive to cover all of the atoms used in the default format
