### PR TITLE
little improvement for settings validation

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -212,6 +212,13 @@ def validate_string(val):
         raise TypeError("Not a string: %s" % val)
     return val.strip()
 
+def validate_class(val):
+    if inspect.isfunction(val) or inspect.ismethod(val):
+        val = val()
+    if inspect.isclass(val):
+        return val
+    return validate_string(val)
+
 def validate_callable(arity):
     def _validate_callable(val):
         if not callable(val):
@@ -338,7 +345,7 @@ class WorkerClass(Setting):
     section = "Worker Processes"
     cli = ["-k", "--worker-class"]
     meta = "STRING"
-    validator = validate_string
+    validator = validate_class
     default = "sync"
     desc = """\
         The type of workers to use.
@@ -672,7 +679,7 @@ class LoggerClass(Setting):
     section = "Logging"
     cli = ["--logger-class"]
     meta = "STRING"
-    validator = validate_string
+    validator = validate_class
     default = "simple"
     desc = """\
         The logger you want to use to log events in gunicorn.

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -23,6 +23,7 @@ import socket
 import sys
 import textwrap
 import time
+import inspect
 
 
 MAXFD = 1024
@@ -65,6 +66,8 @@ except ImportError:
         return
 
 def load_class(uri, default="sync", section="gunicorn.workers"):
+    if inspect.isclass(uri):
+        return uri
     if uri.startswith("egg:"):
         # uses entry points
         entry_str = uri.split("egg:")[1]


### PR DESCRIPTION
Now you able to use existed type instance or factory method to create and customize class during in-code configuration.

E.g.:

> > > settings.set('worker_class', MyWorkerClass)
> > > settings.set('worker_class', lambda: MyWorkerClass)

All other formats still valid.
