### PR TITLE
Print a warning message if we encounter a config file directive we don't understand

### DIFF
--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -69,8 +69,9 @@ class Application(object):
                 sys.exit(1)
 
             for k, v in cfg.items():
-                # Ignore unknown names
                 if k not in self.cfg.settings:
+                    if not k.startswith('_'):
+                        print "Warning - unrecognised configuration directive: %s" % k
                     continue
                 try:
                     self.cfg.set(k.lower(), v)


### PR DESCRIPTION
Recently found myself helping someone with an issue where they had a old config file (pre 66f7271c, where `logfile` became `accesslog`) and wondered why their logging had stopped. This patch adds warnings for 'unrecognised directives' (anything in `cfg.items()` not beginning with `_`).
