### PR TITLE
random.seeding is broken if urandom is absent

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -343,7 +343,7 @@ def seed():
     try:
         random.seed(os.urandom(64))
     except NotImplementedError:
-        random.seed(random.random())
+        random.seed('%s.%s' % (time.time(), os.getpid()))
 
 
 def check_is_writeable(path):


### PR DESCRIPTION
calling random.seed(random.random()) in every child process will leave the random number generator at identical state at each process (because random.random() will be the same), so I changed it to using the current time and process ID as seed which should fix things up.
