### PR TITLE
A subprocess of a gunicorn gevent worker cannot use the network

### DIFF
--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -65,9 +65,15 @@ class GeventWorker(AsyncWorker):
         try:
             while self.alive:
                 self.notify()
+
                 if self.ppid != os.getppid():
-                    self.log.info("Parent changed, shutting down: %s", self)
-                    break
+
+                    # allow subprocess to also leverage gevent (without tricking gunicorn into thinking a switch occurred)
+                    os_pppid = int(os.popen("ps -p %d -oppid=" % os.getppid()).read().strip())  # grandparent pid
+                    if self.ppid != os_pppid:
+
+                        self.log.info("Parent changed, shutting down: %s", self)
+                        break
 
                 gevent.sleep(1.0)
 


### PR DESCRIPTION
if a worker has a subprocess that attempts to make networks calls, and
that worker is a gevent worker class, then gunicorn gets tricked into
thinking a process switch has happened when in fact it hasn't.

this fixes that by forcing a check of the grandparent pid as well as
the parent pid to avoid getting tricked in this way
