### PR TITLE
Add GracefulTimeout.

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -463,7 +463,7 @@ class LimitRequestFields(Setting):
     validator = validate_pos_int
     type = "int"
     default = 100
-    desc= """\
+    desc = """\
         Limit the number of HTTP headers fields in a request.
 
         Value is a number from 0 (unlimited) to 32768. This parameter is
@@ -480,7 +480,7 @@ class LimitRequestFieldSize(Setting):
     validator = validate_pos_int
     type = "int"
     default = 8190
-    desc= """\
+    desc = """\
         Limit the allowed size of an HTTP request header field.
 
         Value is a number from 0 (unlimited) to 8190. to set the limit
@@ -517,7 +517,7 @@ class Spew(Setting):
 class ConfigCheck(Setting):
     name = "check_config"
     section = "Debugging"
-    cli = ["--check-config",]
+    cli = ["--check-config", ]
     validator = validate_bool
     action = "store_true"
     default = False
@@ -961,4 +961,20 @@ class WorkerExit(Setting):
 
         The callable needs to accept two instance variables for the Arbiter and
         the just-exited Worker.
+        """
+
+class GracefulTimeout(Setting):
+    name = "graceful_timeout"
+    section = "Worker Processes"
+    cli = ["--graceful-timeout"]
+    meta = "INT"
+    validator = validate_pos_int
+    type = "int"
+    default = 30
+    desc = """\
+        Timeout for graceful workers restart.
+        
+        Generally set to thirty seconds. How max time worker can handle 
+        request after got restart signal. If the time is up worker will
+        be force killed.
         """

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -75,9 +75,9 @@ class GeventWorker(AsyncWorker):
             pass
 
         try:
-            # Try to stop connections until timeout
+            # Try to stop connections until graceful_timeout
             self.notify()
-            server.stop(timeout=self.timeout)
+            server.stop(timeout=self.cfg.graceful_timeout)
         except:
             pass
 


### PR DESCRIPTION
I need different setting for worker timeout and timeout for graceful restart, because I set small value for worker timeout, but want have more time for handle request after graceful signal.

It's my patch for this, I think it general useful.

PS: tested gunicorn with gevent workers.
