### PR TITLE
don't try to set the script as the process group. fix #355

### DIFF
--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -119,12 +119,7 @@ class Application(object):
             debug.spew()
         if self.cfg.daemon:
             util.daemonize()
-        else:
-            try:
-                os.setpgrp()
-            except OSError, e:
-                if e[0] != errno.EPERM:
-                    raise
+
         try:
             Arbiter(self).run()
         except RuntimeError, e:


### PR DESCRIPTION
Setting gunicorn as the process group prevent exit from the shell. This patch should fix it but need some tests. 
