### PR TITLE
Handle keepalive = 0 corrcetly for eventlet.

### DIFF
--- a/gunicorn/workers/geventlet.py
+++ b/gunicorn/workers/geventlet.py
@@ -30,7 +30,7 @@ class EventletWorker(AsyncWorker):
         super(EventletWorker, self).init_process()
 
     def timeout_ctx(self):
-        return eventlet.Timeout(self.cfg.keepalive, False)
+        return eventlet.Timeout(self.cfg.keepalive or None, False)
 
     def run(self):
         self.socket = GreenSocket(family_or_realsock=self.socket.sock)


### PR DESCRIPTION
There appears to be a race condition with the `timeout_ctx()` in AsyncWorker in the following code:

``` python
    req = None
    with self.timeout_ctx():
        req = parser.next()
    if not req:
        break
```

It appears that if `parser.next()` is still running when the keepalive timeout occurs (e.g. reading a request body) the client connection might be closed at an inappropriate time (before a response has been returned).

This probably needs a larger fix, but if you try to disabling keepalive by setting `keepalive = 0` it doesn't actually disable the timeout, it just sets the number of seconds it waits to `0`.

This fix allows the timeout for the `EventletWorker` to be disabled by setting `keepalive = 0`.

I only implemented it for `eventlet` because I don't have `gevent` or `tornado` installed.

This isn't a problem for the `sync` worker because it doesn't support keepalive.
