### PR TITLE
IOError for chunk's exceptions

### DIFF
--- a/gunicorn/http/errors.py
+++ b/gunicorn/http/errors.py
@@ -6,7 +6,7 @@
 class ParseException(Exception):
     pass
 
-class NoMoreData(ParseException):
+class NoMoreData(IOError):
     def __init__(self, buf=None):
         self.buf = buf
     def __str__(self):
@@ -48,14 +48,14 @@ class InvalidHeaderName(ParseException):
     def __str__(self):
         return "Invalid HTTP header name: %r" % self.hdr
 
-class InvalidChunkSize(ParseException):
+class InvalidChunkSize(IOError):
     def __init__(self, data):
         self.data = data
 
     def __str__(self):
         return "Invalid chunk size: %r" % self.data
 
-class ChunkMissingTerminator(ParseException):
+class ChunkMissingTerminator(IOError):
     def __init__(self, term):
         self.term = term
 


### PR DESCRIPTION
If remote client send invalid data in request with "Transfer-Encoding:chunked" gunicorn can raised some exceptions (see http.body.ChunkedReader) as NoMoreData, ChunkMissingTerminator, InvalidChunkSize.

I think the user application shouldn't know about gunicorn specific exceptions and must catch standard IOError if want.

Example:

```
def app(env, start_response):

    body = env["wsgi.input"]

    chunk_size = 1024

    while True:
        try:
            chunk = body.read(chunk_size)
        except IOError:
            .. correct action for error

        if not chunk:
            break

        .. do somethink with chunk
```

Without it for line "body.read(chunk_size)" we can get gunicorn's exceptions (NoMoreData, ChunkMissingTerminator, InvalidChunkSize).

What do you think?
