### PR TITLE
Made possible customize Arbiter class in base app.

### DIFF
--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -20,6 +20,7 @@ class Application(object):
     An application interface for configuring and loading
     the various necessities for any given web framework.
     """
+    arbiter_class = Arbiter
 
     def __init__(self, usage=None):
         self.usage = usage
@@ -121,7 +122,7 @@ class Application(object):
             util.daemonize()
 
         try:
-            Arbiter(self).run()
+            self.arbiter_class(self).run()
         except RuntimeError, e:
             sys.stderr.write("\nError: %s\n\n" % e)
             sys.stderr.flush()


### PR DESCRIPTION
Now not need to rewrite run() method in base application class to specify
custom arbiter type. Also factory function can be used to produce Arbiter
class in runtime.

Tips:

``` python
>>> class MyArbiter(Arbiter):
...     pass
...
>>> arbiter_factory = lambda x: MyArbiter(x)
>>> class MyApp1(Application):
...     arbiter_class = MyArbiter
... 
>>> class MyApp2(Application):
...     arbiter_class = arbiter_factory
```
