### PR TITLE
Workers won't be killed if timeout set to 0

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -385,6 +385,8 @@ class Arbiter(object):
         """\
         Kill unused/idle workers
         """
+        if not self.timeout:
+            return
         for (pid, worker) in self.WORKERS.items():
             try:
                 if time.time() - worker.tmp.last_update() <= self.timeout:


### PR DESCRIPTION
I think it is convenient that could make workers never timeout. 
If fact, if set timeout to 0, gunicorn will restart workers infinitely.
