### PR TITLE
Use a dynamic timeout to wait for the optimal time.

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -293,7 +293,7 @@ class Arbiter(object):
 
         timeout = 1.0
         if self.WORKERS:
-            oldest_update = min(worker.tmp.last_time() for worker in self.WORKERS.values())
+            oldest_update = min(worker.tmp.last_update() for worker in self.WORKERS.values())
             timeout = self.timeout - (time.time() - oldest_update)
             # The timeout can be reached, so don't wait for a negative value
             timeout = max(timeout, 1.0)


### PR DESCRIPTION
Trying to solve #374.

I hope it is clean enough. As @davisp said, the engineering should stay as simple as possible, and I guess that the math behind this change is quite simple.

The goal is just to get the worker that hadn't notified for the longest time, and then just wait for the remaining time, until the timeout should occurs.

If the timeout is too small or already reached, we just use 1.0 as before.
