### PR TITLE
Forwarded allow ips

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -218,7 +218,7 @@ def validate_string_to_list(val):
     if not val:
         return []
 
-    return [v.strip() for v in val.split(" ") if v]
+    return [v.strip() for v in val.split(",") if v]
 
 def validate_class(val):
     if inspect.isfunction(val) or inspect.ismethod(val):
@@ -698,7 +698,7 @@ class ForwardedAllowIPS(Setting):
     default = "127.0.0.1"
     desc = """\
         Front-end's IPs from which allowed to handle X-Forwarded-* headers.
-        (space separate).
+        (comma separate).
         """
 
 class AccessLog(Setting):

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -73,7 +73,8 @@ def create(req, sock, client, server, cfg):
     secure_headers = cfg.secure_scheme_headers
     x_forwarded_for_header = cfg.x_forwarded_for_header
     if client and client[0] not in cfg.forwarded_allow_ips:
-        x_forwarded_for_header = secure_headers = None
+        x_forwarded_for_header = None
+        secure_headers = {}
 
     for hdr_name, hdr_value in req.headers:
         if hdr_name == "EXPECT":

--- a/tests/003-test-config.py
+++ b/tests/003-test-config.py
@@ -133,7 +133,7 @@ def test_str_validation():
 def test_str_to_list_validation():
     c = config.Config()
     t.eq(c.forwarded_allow_ips, ["127.0.0.1"])
-    c.set("forwarded_allow_ips", "127.0.0.1 192.168.0.1")
+    c.set("forwarded_allow_ips", "127.0.0.1,192.168.0.1")
     t.eq(c.forwarded_allow_ips, ["127.0.0.1", "192.168.0.1"])
     c.set("forwarded_allow_ips", "")
     t.eq(c.forwarded_allow_ips, [])


### PR DESCRIPTION
Added forwarded_allow_ips option for restricted fronends who can send valid X-Forwarded-\* headers. By default allow from 127.0.0.1.

Reason: any request can set REMOTE_ADDR by X-Forwarded-For header and change wsgi.url_scheme - it's security issue.

Also it's linked with https://github.com/benoitc/gunicorn/issues/281
