### PR TITLE
Create a pidfile before executing on_starting().

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -113,15 +113,15 @@ class Arbiter(object):
         Initialize the arbiter. Start listening and set pidfile if needed.
         """
         self.log.info("Starting gunicorn %s", __version__)
-        self.cfg.on_starting(self)
         self.pid = os.getpid()
+        if self.cfg.pidfile is not None:
+            self.pidfile = Pidfile(self.cfg.pidfile)
+            self.pidfile.create(self.pid)
+        self.cfg.on_starting(self)
         self.init_signals()
         if not self.LISTENER:
             self.LISTENER = create_socket(self.cfg, self.log)
 
-        if self.cfg.pidfile is not None:
-            self.pidfile = Pidfile(self.cfg.pidfile)
-            self.pidfile.create(self.pid)
         self.log.debug("Arbiter booted")
         self.log.info("Listening at: %s (%s)", self.LISTENER,
             self.pid)


### PR DESCRIPTION
This will let a standard init script (or any script that look for a
pidfile) know that gunicorn is already running and won't attempt to run
it twice.
This would also enable the script to stop gunicorn even in it's startup
phase.

(I have a use case where the startup script takes > 60s to run)
