### PR TITLE
Ignore negative CONTENT-LENGTH.

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -99,6 +99,8 @@ class Message(object):
             if name == "CONTENT-LENGTH":
                 try:
                     response_length = int(value)
+                    if response_length < 0:
+                        response_length = None
                 except ValueError:
                     response_length = None
             elif name == "TRANSFER-ENCODING":


### PR DESCRIPTION
Without it command:

```
$  curl http://localhost/ -X PUT -H "Content-Length: -1"
```

get trace:

```
[gunicorn.error:ERROR] Error handling request
Traceback (most recent call last):
File "/usr/lib/pymodules/python2.6/gunicorn/workers/async.py", line 37, in handle
req = parser.next()
File "/usr/lib/pymodules/python2.6/gunicorn/http/parser.py", line 35, in next
data = self.mesg.body.read(8192)
File "/usr/lib/pymodules/python2.6/gunicorn/http/body.py", line 214, in read
data = self.reader.read(1024)
File "/usr/lib/pymodules/python2.6/gunicorn/http/body.py", line 122, in read
raise ValueError("Size must be positive.")
ValueError: Size must be positive.
```
