### PR TITLE
fix gevent graceful timeout for real

### DIFF
--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -79,7 +79,7 @@ class GeventWorker(AsyncWorker):
 
         try:
             # Stop accepting requests
-            server.kill()
+            server.close()
 
             # Handle current requests until graceful_timeout
             ts = time.time()


### PR DESCRIPTION
`server.kill()` is too aggressive. It sends a GreenletExit exception
to all the pool workers, causing them to exit immediately.

A simple one line fix is to use `server.stop()`. In my testing, it
appears that `server.stop_accepting()` will make the server stop
listening, but pending connections already in the `accept()` backlog
are still handled. With `server.stop()` the accept backlog is not
handled, the listener is closed in the worker, but existing requests
are allowed to exit gracefully.
