### PR TITLE
allow bypassing of forwarded_allow_ips check

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -706,6 +706,10 @@ class ForwardedAllowIPS(Setting):
     desc = """\
         Front-end's IPs from which allowed to handle X-Forwarded-* headers.
         (comma separate).
+
+        Set to "*" to disable checking of Front-end IPs (useful for setups
+        where you don't know in advance the IP address of Front-end, but
+        you still trust the environment)
         """
 
 class AccessLog(Setting):

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -85,7 +85,8 @@ def create(req, sock, client, server, cfg):
 
     secure_headers = cfg.secure_scheme_headers
     x_forwarded_for_header = cfg.x_forwarded_for_header
-    if client and client[0] not in cfg.forwarded_allow_ips:
+    if '*' not in cfg.forwarded_allow_ips and client\
+            and client[0] not in cfg.forwarded_allow_ips:
         x_forwarded_for_header = None
         secure_headers = {}
 


### PR DESCRIPTION
I neded this change to keep my app running in heroku after upgrading from 0.14.6 to 0.15.0

In heroku we don't know the IP address of the frontend but we still trust the X-FORWARDED-\* headers we receive
