### PR TITLE
Reopen stderr and stdout after logrotate

### DIFF
--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -76,6 +76,16 @@ class LazyWriter(object):
                 self.lock.release()
         return self.fileobj
 
+    def close(self):
+        if self.fileobj:
+            self.lock.acquire()
+            try:
+                if self.fileobj:
+                    self.fileobj.close()
+                    self.fileobj = None
+            finally:
+                self.lock.release()
+
     def write(self, text):
         fileobj = self.open()
         fileobj.write(text)
@@ -238,6 +248,10 @@ class Logger(object):
 
 
     def reopen_files(self):
+        if self.cfg.errorlog != "-":
+            # Close stderr & stdout if they are redirected to error log file
+            sys.stderr.close()
+            sys.stdout.close()
         for log in loggers():
             for handler in log.handlers:
                 if isinstance(handler, logging.FileHandler):


### PR DESCRIPTION
To use the logrotate utility, a USR1 signal is sent, and the corresponding handler reopens the log files. However, sys.stdout and sys.stderr, which may be redirected to the error log file, are not updated. This commit fixes this, by closing the fileobj of the LazyWriter object. There is no need to reopen it, since the LazyWriter will open it when needed.
