### PR TITLE
Update the MANIFEST.in file to include the dev requirements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE
 include NOTICE
 include README.rst
 include THANKS
+include requirements_dev.txt
 recursive-include tests *
 recursive-include examples *
 recursive-include doc *


### PR DESCRIPTION
It looks like the requirements_dev.txt file was not included within the MANIFEST.in file in gunicorn version 0.16.0.  This would cause `pip install` to fail with the following error.

```
~> pip install gunicorn --upgrade
Downloading/unpacking gunicorn from http://g.pypi.python.org/packages/source/g/gunicorn/gunicorn-0.16.0.tar.gz#md5=e821dcd1152728513cc868691bad1a45
Downloading gunicorn-0.16.0.tar.gz (130Kb): 130Kb downloaded
 Running setup.py egg_info for package gunicorn
    Traceback (most recent call last):
        File "<string>", line 14, in <module>
        File "~/gunicorn/dist/gunicorn-0.16.0/build/gunicorn/setup.py", line 43, in <module>
             with open(fname) as f:
        IOError: [Errno 2] No such file or directory: '~/gunicorn/dist/gunicorn-0.16.0/build/gunicorn/requirements_dev.txt'
```

This pull request will modify the MANIFEST.in file to include the requirements_dev text file.
