### PR TITLE
catch-all exception in arbiter absorbing bug

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -62,7 +62,7 @@ class Arbiter(object):
         try:
             a = os.stat(os.environ['PWD'])
             b = os.stat(os.getcwd())
-            if a.ino == b.ino and a.dev == b.dev:
+            if a.st_ino == b.st_ino and a.st_dev == b.st_dev:
                 cwd = os.environ['PWD']
             else:
                 cwd = os.getcwd()


### PR DESCRIPTION
When comparing PWD with the current working directory, incorrectly named attributes were being called on the returned stat results: `.ino` and `.dev` should be `.st_ino` and `.st_dev`, respectively. Normally this would raise an AttributeError, but the code is wrapped in a catch-all exception which was absorbing the error. 
