### PR TITLE
ArgumentParser no longer accepts version in Python 3.3

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -67,10 +67,13 @@ class Config(object):
     def parser(self):
         kwargs = {
             "usage": self.usage,
-            "version": "%(prog)s (version " +  __version__ + ")\n",
             "prog": self.prog
         }
         parser = argparse.ArgumentParser(**kwargs)
+        parser.add_argument("-v", "--version",
+                action="version", default=argparse.SUPPRESS,
+                version="%(prog)s (version " +  __version__ + ")\n",
+                help="show program's version number and exit")
         parser.add_argument("args", nargs="*", help=argparse.SUPPRESS)
 
         keys = list(self.settings)


### PR DESCRIPTION
I'm not actually using Python 3.3 yet but the tests fail with this error:

```
Error: __init__() got an unexpected keyword argument 'version'
```

Apparently argparse.ArgumentParser no longer accepts a version keyword argument (looks like it has been deprecated for a while).
