### PR TITLE
remove unnecessary condition check for daemon status

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -274,7 +274,7 @@ class Arbiter(object):
 
     def handle_winch(self):
         "SIGWINCH handling"
-        if os.getppid() == 1 or os.getpgrp() != os.getpid():
+        if os.getppid() == 1:
             self.log.info("graceful stop of workers")
             self.num_workers = 0
             self.kill_workers(signal.SIGQUIT)


### PR DESCRIPTION
``` python
    os.getpgrp() != os.getpid()
```

IMHO the above statement is unnecessary and may be wrong under circumstance described below:

The command to launch gunicorn is written in a bash script. something like this:

```
cat run.sh
gunicorn app:app --max-requests 5000 
```

We execute ./run.sh to start gunicorn, therefore it is started under a shell process. Then os.getpgrp() equals the process id of the shell, not the process id of gunicorn, which makes the statement True and kills all workers when SIGWINCH is recevied.
