### PR TITLE
Validate files passed to --config option

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -372,6 +372,8 @@ def validate_post_request(val):
 
 def validate_isfile(val):
     val = validate_string(val)
+    if val is None:
+        return val
 
     if not os.path.isfile(val):
         raise ValueError("No such file: '%s'" % val)


### PR DESCRIPTION
Here's a quick implementation to address benoitc/gunicorn#469.  I apologize for not understanding pytest well enough to provide unit test coverage for it.

After the patch:

```
(venv)marmida@monolith:~/develop/gunicorn$ venv/bin/gunicorn -c path/doesnt/exist.py webapp:app

Error: No such file: 'path/doesnt/exist.py'
```
