### PR TITLE
support TCP Fast Open option

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1292,3 +1292,33 @@ class SyslogFacility(Setting):
     desc = """\
     Syslog facility name
     """
+
+
+class AllowTCPFastOpen(Setting):
+    name = "allow_tcp_fast_open"
+    section = "Server Socket"
+    cli = ["--allow-tcp-fast-open"]
+    validator = validate_bool
+    default = False
+    action = "store_true"
+    desc = """\
+    Whether the server will allow the TCP Fast Open.
+
+    Available on Linux >= 3.7.1, Python>=  3.4
+
+    More info: http://research.google.com/pubs/pub37517.html
+    """
+
+
+class TCPFastOpenQueue(Setting):
+    name = "tcp_fast_open_queue"
+    section = "Server Socket"
+    cli = ["--tcp-fast-open-queue"]
+    meta = "INT"
+    validator = validate_pos_int
+    type = int
+    default = 5
+    desc = """\
+    The size of the TCP Fast Open queue. If the number of connections exceed
+    this value, the other connections are proceed with a normal 3-way.
+    """

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -67,6 +67,11 @@ class TCPSocket(BaseSocket):
 
     def set_options(self, sock, bound=False):
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
+        if hasattr(socket, 'TCP_FASTOPEN') and self.cfg.allow_tcp_fast_open:
+            sock.setsockopt(socket.SOL_TCP, socket.TCP_FASTOPEN,
+                    self.cfg.tcp_fast_open_queue)
+
         return super(TCPSocket, self).set_options(sock, bound=bound)
 
 


### PR DESCRIPTION
**Fast Open** is a optimization to the process of stablishing a TCP connection that
allows the elimination of one round time trip (RTT) from certain kinds of TCP
conversations. Fast Open could result in speed improvements of between 4% and
41% in the page load times on popular web sites.

Available on linux >= 3.7.1.

More info:

- https://lwn.net/Articles/508865/
- http://research.google.com/pubs/pub37517.html