### PR TITLE
Fixed Gunicorn.org Document Title

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Gunicorn &dash; Python WSGI HTTP Server for UNIX</title>
+  <title>Gunicorn - Python WSGI HTTP Server for UNIX</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <link rel="stylesheet" type="text/css" href="css/style.css" />
   <link rel="shortcut icon" href="images/favicon.png" type="image/x-icon">


### PR DESCRIPTION
Document titles expect text, not HTML. At this time, the `<title>` tag contains `&dash;` which is displayed literally in some places (eg. in Google results)
