### PR TITLE
Send a SIGABRT instead of a SIGKILL on timeouts

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -423,7 +423,7 @@ class Arbiter(object):
                 continue
 
             self.log.critical("WORKER TIMEOUT (pid:%s)", pid)
-            self.kill_worker(pid, signal.SIGKILL)
+            self.kill_worker(pid, signal.SIGABRT)
 
     def reap_workers(self):
         """\

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -110,6 +110,7 @@ class Worker(object):
         signal.signal(signal.SIGQUIT, self.handle_quit)
         signal.signal(signal.SIGTERM, self.handle_exit)
         signal.signal(signal.SIGINT, self.handle_exit)
+        signal.signal(signal.SIGABRT, self.handle_abrt)
         signal.signal(signal.SIGWINCH, self.handle_winch)
         signal.signal(signal.SIGUSR1, self.handle_usr1)
         # Don't let SIGQUIT and SIGUSR1 disturb active requests
@@ -120,6 +121,11 @@ class Worker(object):
 
     def handle_usr1(self, sig, frame):
         self.log.reopen_files()
+
+    def handle_abrt(self, sig, frame):
+        self.alive = False
+        self.log.info("".join(traceback.format_stack(frame)))
+        sys.exit(0)
 
     def handle_quit(self, sig, frame):
         self.alive = False


### PR DESCRIPTION
It give us a chance to log the stack trace before leaving the worker. Also, abort seems more appropriate than kill for finishing incomplete requests.
