### PR TITLE
Fix doc links

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -52,7 +52,7 @@ you should use one of the async workers.
 
 .. _slowloris: http://ha.ckers.org/slowloris/
 .. _setproctitle: http://pypi.python.org/pypi/setproctitle
-.. _proc_name: /configure.html#proc-name
+.. _proc_name: configure.html#proc-name
 
 
 Worker Processes
@@ -87,9 +87,8 @@ To decrease the worker count by one::
 
     $ kill -TTOU $masterpid
 
-.. _design: /design.html
-.. _worker_class: /configure.html#worker-class
-.. _`number of workers`: /design.html#how-many-workers
+.. _worker_class: configure.html#worker-class
+.. _`number of workers`: design.html#how-many-workers
 
 Kernel Parameters
 =================


### PR DESCRIPTION
Make these links relative, to fix RTD.

On this page, http://docs.gunicorn.org/en/latest/faq.html try the proc_name relative document link. 

Should also fix this issue: https://github.com/benoitc/gunicorn/issues/484
