### PR TITLE
Close connection on error after sending started.

### DIFF
--- a/gunicorn/workers/async.py
+++ b/gunicorn/workers/async.py
@@ -104,6 +104,13 @@ class AsyncWorker(base.Worker):
                     respiter.close()
             if resp.should_close():
                 raise StopIteration()
+        except Exception:
+            if resp.headers_sent:
+                # If the requests have already been sent, we should close the
+                # connection to indicate the error.
+                sock.shutdown(socket.SHUT_RDWR)
+                sock.close()
+            raise
         finally:
             try:
                 self.cfg.post_request(self, req, environ, resp)

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -138,6 +138,11 @@ class SyncWorker(base.Worker):
         except socket.error:
             raise
         except Exception as e:
+            if resp.headers_sent:
+                # If the requests have already been sent, we should close the
+                # connection to indicate the error.
+                client.shutdown(socket.SHUT_RDWR)
+                client.close()
             # Only send back traceback in HTTP in debug mode.
             self.handle_error(req, client, addr, e)
             return


### PR DESCRIPTION
When the application starts yielding a body and then raises an error,
we should immediately close the connection to the client to indicate
the error.

This is meant to address the issue presented in this post:
http://rhodesmill.org/brandon/2013/chunked-wsgi/
