### PR TITLE
TypeError when creating a pidfile

### DIFF
--- a/gunicorn/pidfile.py
+++ b/gunicorn/pidfile.py
@@ -36,7 +36,7 @@ class Pidfile(object):
         if fdir and not os.path.isdir(fdir):
             raise RuntimeError("%s doesn't exist. Can't create pidfile." % fdir)
         fd, fname = tempfile.mkstemp(dir=fdir)
-        os.write(fd, "%s\n" % self.pid)
+        os.write(fd, ("%s\n" % self.pid).encode('utf-8'))
         if self.fname:
             os.rename(fname, self.fname)
         else:


### PR DESCRIPTION
Hello!

I've discovered an issue when using gunicorn 0.17.2 on Python 3.3.0 with the following configuration settings:

`daemon = True`
`pidfile = '/some/path/...'`

Here's the stack trace:

```
Traceback (most recent call last):
  File "/srv/users/kevin/apps/five/venv/bin/gunicorn", line 9, in <module>
    load_entry_point('gunicorn==0.17.2', 'console_scripts', 'gunicorn')()
  File "/srv/users/kevin/apps/five/venv/lib/python3.3/site-packages/gunicorn/app/wsgiapp.py", line 34, in run
    WSGIApplication("%(prog)s [OPTIONS] APP_MODULE").run()
  File "/srv/users/kevin/apps/five/venv/lib/python3.3/site-packages/gunicorn/app/base.py", line 131, in run
    Arbiter(self).run()
  File "/srv/users/kevin/apps/five/venv/lib/python3.3/site-packages/gunicorn/arbiter.py", line 170, in run
    self.start()
  File "/srv/users/kevin/apps/five/venv/lib/python3.3/site-packages/gunicorn/arbiter.py", line 128, in start
    self.pidfile.create(self.pid)
  File "/srv/users/kevin/apps/five/venv/lib/python3.3/site-packages/gunicorn/pidfile.py", line 39, in create
    os.write(fd, "%s\n" % self.pid)
TypeError: 'str' does not support the buffer interface
```

Changing line 39 to `os.write(fd, ("%s\n" % self.pid).encode('utf-8'))` has solved the problem for me without any obvious errors in the last few days.
