### PR TITLE
Attempt to get a stack trace from timed out workers before killing them

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -402,13 +402,20 @@ class Arbiter(object):
             return
         for (pid, worker) in self.WORKERS.items():
             try:
-                if time.time() - worker.tmp.last_update() <= self.timeout:
-                    continue
+                time_passed = time.time() - worker.tmp.last_update()
+
+                if time_passed > self.timeout + 1:
+                    # It hasn't died 1s after SIGTERM, so kill it dead
+                    self.log.critical("WORKER TIMEOUT (pid:%s), NO STACKTRACE AVAILABLE", pid)
+                    self.kill_worker(pid, signal.SIGKILL)
+                
+                elif time_passed > self.timeout:
+                    # Attempt to kill the worker and get a stacktrace
+                    self.kill_worker(pid, signal.SIGABRT)
+
             except ValueError:
                 continue
 
-            self.log.critical("WORKER TIMEOUT (pid:%s)", pid)
-            self.kill_worker(pid, signal.SIGKILL)
 
     def reap_workers(self):
         """\


### PR DESCRIPTION
This changes the arbiter to send SIGUSR2 to the worker two seconds
before it sends SIGKILL, giving the new handle_usr2 handler time to
generate a clean stack trace of where the worker is blocked and log it.

Existing behaviour is maintained if the worker does not die, however the
log message has been changed to reflect that a stack trace was not
obtained.
