### PR TITLE
 Python 3 fix for PATH_INFO

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -8,8 +8,7 @@ import os
 import re
 import sys
 
-from gunicorn.six import (unquote, string_types, binary_type, reraise,
-        text_type)
+from gunicorn.six import unquote_to_wsgi_str, string_types, binary_type, reraise
 from gunicorn import SERVER_SOFTWARE
 import gunicorn.util as util
 
@@ -164,7 +163,7 @@ def create(req, sock, client, server, cfg):
     path_info = req.path
     if script_name:
         path_info = path_info.split(script_name, 1)[1]
-    environ['PATH_INFO'] = unquote(path_info)
+    environ['PATH_INFO'] = unquote_to_wsgi_str(path_info)
     environ['SCRIPT_NAME'] = script_name
 
     environ.update(proxy_environ(req))

--- a/gunicorn/six.py
+++ b/gunicorn/six.py
@@ -387,7 +387,10 @@ if PY3:
 
     import urllib.parse
 
-    unquote = urllib.parse.unquote
+    def unquote_to_wsgi_str(string):
+        return _unquote_to_bytes(string).decode('latin-1')
+
+    _unquote_to_bytes = urllib.parse.unquote_to_bytes
     urlsplit = urllib.parse.urlsplit
     urlparse = urllib.parse.urlparse
 
@@ -402,4 +405,4 @@ else:
     urlparse = orig_urlparse.urlparse
 
     import urllib
-    unquote = urllib.unquote
+    unquote_to_wsgi_str = urllib.unquote


### PR DESCRIPTION
PEP-3333 states that PATH_INFO is a "native" string (because it's a CGI variable) and that its content should be encodable to bytes using latin1.
