### PR TITLE
give the initial global_conf to loadcontext to initialize the context pr...

### DIFF
--- a/gunicorn/app/pasterapp.py
+++ b/gunicorn/app/pasterapp.py
@@ -86,7 +86,7 @@ class PasterApplication(PasterBaseApplication):
         return self.app_config()
 
     def load(self):
-        return loadapp(self.cfgurl, relative_to=self.relpath)
+        return loadapp(self.cfgurl, relative_to=self.relpath, global_conf=self.gcfg)
 
 
 class PasterServerApplication(PasterBaseApplication):
@@ -140,7 +140,7 @@ class PasterServerApplication(PasterBaseApplication):
 
     def load(self):
         if hasattr(self, "cfgfname"):
-            return loadapp(self.cfgurl, relative_to=self.relpath)
+            return loadapp(self.cfgurl, relative_to=self.relpath, global_conf=self.gcfg)
 
         return self.app
 


### PR DESCRIPTION
Always give global_conf passed from the entrypoint to paste.deploy.loadwsgi.loadcontext() so that gunicorn can get reloaded correctly with the configuration file that contains placeholder referring to global_conf.
