### PR TITLE
Update install.rst for Debian wheezy release

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -109,10 +109,31 @@ advantages:
    rolled back in case of incompatibility. The package can also be purged
    entirely from the system in seconds.
 
-Stable ("squeeze")
+Stable ("wheezy")
 ------------------
 
-The version of Gunicorn in the Debian_ "stable" distribution is 0.10.0 (July
+The version of Gunicorn in the Debian_ "stable" distribution is 0.14.5 (June
+2012). You can install it using::
+
+    $ sudo apt-get install gunicorn
+
+You can also use the most recent version by using `Debian Backports`_.
+First, copy the following line to your ``/etc/apt/sources.list``::
+
+    deb http://backports.debian.org/debian-backports wheezy-backports main
+
+Then, update your local package lists::
+
+    $ sudo apt-get update
+
+You can then install the latest version using::
+
+    $ sudo apt-get -t wheezy-backports install gunicorn
+
+Oldstable ("squeeze")
+---------------------
+
+The version of Gunicorn in the Debian_ "oldstable" distribution is 0.10.0 (July
 2010). It is not recommended that you use this version.
 
 However, you can use the most recent version by using `Debian Backports`_.
@@ -128,10 +149,10 @@ You can then install the latest version using::
 
     $ sudo apt-get -t squeeze-backports install gunicorn
 
-Testing ("wheezy") / Unstable ("sid")
+Testing ("jessie") / Unstable ("sid")
 -------------------------------------
 
-"wheezy" and "sid" contain the latest released version of Gunicorn. You can
+"jessie" and "sid" contain the latest released version of Gunicorn. You can
 install it in the usual way::
 
     $ sudo apt-get install gunicorn


### PR DESCRIPTION
I noticed on the gunicorn.org website that the documentation regarding Debian was aging, so I took the liberty of adding some new content and making modifications to the source here. I used the existing content as a template to expand the Debian installation section to account for the recent Debian changes.

Debian "wheezy" was released in May 2013 moving "squeeze" to "oldstable" status.

I hope this helps.
