### PR TITLE
Fix to read the settings module specified while running via gunicorn command

### DIFF
--- a/gunicorn/app/wsgiapp.py
+++ b/gunicorn/app/wsgiapp.py
@@ -8,6 +8,7 @@ import sys
 
 from gunicorn import util
 from gunicorn.app.base import Application
+from gunicorn.app import djangoapp
 
 
 class WSGIApplication(Application):
@@ -24,6 +25,7 @@ class WSGIApplication(Application):
         sys.path.insert(0, cwd)
 
     def load(self):
+        djangoapp.make_default_env(self.cfg)
         return util.import_app(self.app_uri)
 
 


### PR DESCRIPTION
Fix to read the settings module specified by --settings or django_settings parameter via running the django application via the gunicorn command.
I debugged the code and found that while using the command run_gunicorn it resprects the --settings parameter but while running via gunicorn, it does not.
