### PR TITLE
Add Upstart deployment example, remove Upstart from faq.

### DIFF
--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -201,6 +201,26 @@ Another useful tool to monitor and control Gunicorn is Supervisor_. A
     autorestart=true
     redirect_stderr=True
 
+Upstart
+-------
+Using gunicorn with upstart is simple. In this example we will run the app "myapp"
+from a virtualenv. All errors will go to /var/log/upstart/myapp.log.
+
+**/etc/init/myapp.conf**::
+
+    description "myapp"
+
+    start on (filesystem)
+    stop on runlevel [016]
+
+    respawn
+    console log
+    setuid nobody
+    setgid nogroup
+    chdir /path/to/app/directory
+
+    exec /path/to/virtualenv/bin/gunicorn myapp:app
+
 Systemd
 -------
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -37,11 +37,6 @@ in tools like ``ps`` and ``top``. This helps for distinguishing the master
 process as well as between masters when running more than one app on a single
 machine. See the proc_name_ setting for more information.
 
-Gunicorn fails to start with upstart
-------------------------------------
-
-Make sure you run gunicorn with ``--daemon`` option.
-
 Why is there no HTTP Keep-Alive?
 --------------------------------
 


### PR DESCRIPTION
Add an Upstart deployment example and remove the Upstart entry in the
FAQ.
