### PR TITLE
Rename post_init for greater clarity

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -561,12 +561,12 @@ Called just after a worker has been forked.
 The callable needs to accept two instance variables for the Arbiter and
 new Worker.
 
-post_init
+post_worker_init
 ~~~~~~~~~
 
 *  ::
 
-        def post_init(worker):
+        def post_worker_init(worker):
             pass
 
 Called just after a worker has initialized the application.

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1162,16 +1162,16 @@ class Postfork(Setting):
         """
 
 
-class PostInit(Setting):
-    name = "post_init"
+class PostWorkerInit(Setting):
+    name = "post_worker_init"
     section = "Server Hooks"
     validator = validate_callable(1)
     type = six.callable
 
-    def post_init(worker):
+    def post_worker_init(worker):
         pass
 
-    default = staticmethod(post_init)
+    default = staticmethod(post_worker_init)
     desc = """\
         Called just after a worker has initialized the application.
 

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -99,7 +99,7 @@ class Worker(object):
 
         self.wsgi = self.app.wsgi()
 
-        self.cfg.post_init(self)
+        self.cfg.post_worker_init(self)
 
         # Enter main run loop
         self.booted = True


### PR DESCRIPTION
Makes sense if you saw what it does, less if you just read the config option.

As suggested in #555
