### PR TITLE
set wsgi.multithread to True for async workers

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -42,22 +42,29 @@ class FileWrapper(object):
         raise IndexError
 
 
-def default_environ(req, sock, cfg):
+def base_environ(cfg):
     return {
-        "wsgi.input": req.body,
         "wsgi.errors": sys.stderr,
         "wsgi.version": (1, 0),
         "wsgi.multithread": False,
         "wsgi.multiprocess": (cfg.workers > 1),
         "wsgi.run_once": False,
         "wsgi.file_wrapper": FileWrapper,
-        "gunicorn.socket": sock,
         "SERVER_SOFTWARE": SERVER_SOFTWARE,
+    }
+
+
+def default_environ(req, sock, cfg):
+    env = base_environ(cfg)
+    env.update({
+        "wsgi.input": req.body,
+        "gunicorn.socket": sock,
         "REQUEST_METHOD": req.method,
         "QUERY_STRING": req.query,
         "RAW_URI": req.uri,
         "SERVER_PROTOCOL": "HTTP/%s" % ".".join([str(v) for v in req.version])
-    }
+    })
+    return env
 
 
 def proxy_environ(req):

--- a/gunicorn/workers/async.py
+++ b/gunicorn/workers/async.py
@@ -81,6 +81,7 @@ class AsyncWorker(base.Worker):
             self.cfg.pre_request(self, req)
             resp, environ = wsgi.create(req, sock, addr,
                     listener.getsockname(), self.cfg)
+            environ["wsgi.multithread"] = True
             self.nr += 1
             if self.alive and self.nr >= self.max_requests:
                 self.log.info("Autorestarting worker after current request.")

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -28,6 +28,7 @@ from gevent.socket import wait_write, socket
 from gevent import pywsgi
 
 import gunicorn
+from gunicorn.http.wsgi import base_environ
 from gunicorn.workers.async import AsyncWorker
 from gunicorn.http.wsgi import sendfile as o_sendfile
 
@@ -48,16 +49,6 @@ def patch_sendfile():
 
     if o_sendfile is not None:
         setattr(wsgi, "sendfile", _gevent_sendfile)
-
-BASE_WSGI_ENV = {
-    'GATEWAY_INTERFACE': 'CGI/1.1',
-    'SERVER_SOFTWARE': VERSION,
-    'SCRIPT_NAME': '',
-    'wsgi.version': (1, 0),
-    'wsgi.multithread': False,
-    'wsgi.multiprocess': False,
-    'wsgi.run_once': False
-}
 
 
 class GeventWorker(AsyncWorker):
@@ -107,9 +98,15 @@ class GeventWorker(AsyncWorker):
             s.setblocking(1)
             pool = Pool(self.worker_connections)
             if self.server_class is not None:
+                environ = base_environ(self.cfg)
+                environ.update({
+                    "wsgi.multithread": True,
+                    "SERVER_SOFTWARE": VERSION,
+                })
                 server = self.server_class(
                     s, application=self.wsgi, spawn=pool, log=self.log,
-                    handler_class=self.wsgi_handler, **ssl_args)
+                    handler_class=self.wsgi_handler, environ=environ,
+                    **ssl_args)
             else:
                 hfun = partial(self.handle, s)
                 server = StreamServer(s, handle=hfun, spawn=pool, **ssl_args)
@@ -229,7 +226,7 @@ class PyWSGIHandler(pywsgi.WSGIHandler):
 
 
 class PyWSGIServer(pywsgi.WSGIServer):
-    base_env = BASE_WSGI_ENV
+    pass
 
 
 class GeventPyWSGIWorker(GeventWorker):


### PR DESCRIPTION
Also simplifies the environment handling in the gevent_pywsgi
server so that it also has this key. An added side effect is
that the gunicorn FileWrapper gets set for the gevent_pywsgi
worker, too.

Fixes #486
