### PR TITLE
Remove an unmatched leading quote from the beginning of the default access log format string

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -856,7 +856,7 @@ class AccessLogFormat(Setting):
     cli = ["--access-logformat"]
     meta = "STRING"
     validator = validate_string
-    default = '"%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
+    default = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
     desc = """\
         The Access log format .
 


### PR DESCRIPTION
This patch removes what appears to be a misplaced quote at the beginning of the default access log format string. This quote makes it to the eventual log file, causing every access log entry to begin with a quote.  The documentation for the setting contains the same format string, without the quote, on line 865 of config.py.
