### PR TITLE
Meaningful warnings for HTTP requests arriving to HTTPS services

### DIFF
--- a/gunicorn/workers/async.py
+++ b/gunicorn/workers/async.py
@@ -58,9 +58,7 @@ class AsyncWorker(base.Worker):
                 self.log.debug("ssl connection closed")
                 client.close()
             elif e.args[0] == ssl.SSL_ERROR_SSL:
-                self.log.warning("*************************************************************************************")
-                self.log.warning("* Failed to make an SSL connection. Maybe someone is trying to connect to an HTTPS service using HTTP?")
-                self.log.warning("*************************************************************************************")                
+                self.log.info("Failed to make an SSL connection. Maybe someone is trying to connect to an HTTPS service using HTTP?")
                 client.close()
             else:
                 self.log.debug("Error processing SSL request.")


### PR DESCRIPTION
This kicks in when somebody tries to connect to HTTPS worker via HTTP.
Helps to realize what's wrong.

In some very rare cases, it might kick in on other SSL errors, too,
and in those cases, the message _might_ be _slightly_ misleading.

That's why it says **maybe**.
