### PR TITLE
resp maybe None when pre_request raises exceptions

### DIFF
--- a/gunicorn/workers/async.py
+++ b/gunicorn/workers/async.py
@@ -105,7 +105,7 @@ class AsyncWorker(base.Worker):
             if resp.should_close():
                 raise StopIteration()
         except Exception:
-            if resp.headers_sent:
+            if resp and resp.headers_sent:
                 # If the requests have already been sent, we should close the
                 # connection to indicate the error.
                 try:

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -144,7 +144,7 @@ class SyncWorker(base.Worker):
         except socket.error:
             raise
         except Exception as e:
-            if resp.headers_sent:
+            if resp and resp.headers_sent:
                 # If the requests have already been sent, we should close the
                 # connection to indicate the error.
                 try:


### PR DESCRIPTION
then the response shows something like this:

```
Internal Server Error

Traceback:

Traceback (most recent call last):
  File "/home/vagrant/projects/dae/venv/local/lib/python2.7/site-packages/gunicorn/workers/sync.py", line 88, in     handle
    self.handle_request(listener, req, client, addr)
  File "/home/vagrant/projects/dae/dae/gworkers/sync.py", line 19, in handle_request
    super(SyncWorker, self).handle_request(*args)
  File "/home/vagrant/projects/dae/venv/local/lib/python2.7/site-packages/gunicorn/workers/sync.py", line 142, in handle_request
    if resp.headers_sent:
AttributeError: 'NoneType' object has no attribute 'headers_sent'
```

this hides the real exception, which can only be seen in command line logs, and makes beginners hard to find their own bugs.
