### PR TITLE
A fix for https://github.com/benoitc/gunicorn/issues/581

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -192,7 +192,12 @@ class Response(object):
     def should_close(self):
         if self.must_close or self.req.should_close():
             return True
-        return False
+        if self.status:
+            if self.status.startswith('204') or self.status.startswith('3'):
+                return False
+        if self.response_length is not None or self.chunked:
+            return False
+        return True
 
     def start_response(self, status, headers, exc_info=None):
         if exc_info:


### PR DESCRIPTION
Responses with status=204 or status=3*\* should not cause the socket to be closed, even thought their Content-Length is empty.
