### PR TITLE
allow set command line arguments programmically

### DIFF
--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -19,11 +19,12 @@ class Application(object):
     the various necessities for any given web framework.
     """
 
-    def __init__(self, usage=None, prog=None):
+    def __init__(self, usage=None, prog=None, args=None):
         self.usage = usage
         self.cfg = None
         self.callable = None
         self.prog = prog
+        self.args = args
         self.logger = None
         self.do_load_config()
 
@@ -72,7 +73,7 @@ class Application(object):
 
         # parse console args
         parser = self.cfg.parser()
-        args = parser.parse_args()
+        args = parser.parse_args(self.args)
 
         # optional settings from apps
         cfg = self.init(parser, args, args.args)


### PR DESCRIPTION
We need to use gunicorn in our own program, which has a different set of command line options.  It is error-prone to modify `sys.argv` in place before call `Application.run`, e.g. it breaks the USR2 signal.

This pull request adds support to pass args (a list of str) to `Application`, so that we can build it in our program and pass it to gunicorn, and the USR2 signal still works.
