### PR TITLE
Add scripting API to gunicorn

### DIFF
--- a/gunicorn/app/flask_wsgi.py
+++ b/gunicorn/app/flask_wsgi.py
@@ -1,0 +1,14 @@
+from gunicorn.app.base import Application, Config
+
+
+class FlaskApplication(Application):
+
+    def __init__(self, app):
+        self.usage, self.callable, self.prog, self.app = None, None, None, app
+
+    def run(self, **options):
+        self.cfg = Config()
+        [self.cfg.set(key, value) for key, value in options.items()]
+        return Application.run(self)
+
+    load = lambda self: self.app


### PR DESCRIPTION
This is a stub for discussing a possible scripting API for gunicorn.

It is useful to have it if you want to integrate gunicorn inside you app (probably similar to #625).

Right now I'm using it in the following way:

``` python
from flask import Flask
from gunicorn.app.flask_wsgi import FlaskApplication as Gunicorn


app = Flask(__name__)
gunicorn = Gunicorn(app)

...

if __name__ == '__main__':
    args = docopt(__doc__)

    if args['development']:
        app.run(debug=True, host=host, port=port)
    elif args['production']:
        gunicorn.run(workers=workers, bind='%s:%s' % (host, port))
```

I named the class `FlaskApplication` because I assumed that this is most useful in Flask setting, but this is probably a bad assumption.
