### PR TITLE
Do not override REMOTE_ADDR with X-Fowarded-For

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -903,6 +903,21 @@ class XForwardedFor(Setting):
         """
 
 
+class OverrideRemoteAddr(Setting):
+    name = "override_remote_addr"
+    section = "Server Mechanics"
+    cli = ["--override-remote-addr"]
+    validator = validate_bool
+    action = "store_true"
+    default = False
+    desc = """\
+        Override the REMOTE_ADDR using the X-Forwarded-For header
+
+        The settings XForwardedFor is also available to override
+        the name of the used header.
+        """
+
+
 class ForwardedAllowIPS(Setting):
     name = "forwarded_allow_ips"
     section = "Server Mechanics"


### PR DESCRIPTION
From rfc 3875
The REMOTE_ADDR variable MUST be set to the network address of the
client sending the request to the server.
## For exemple
# WSGI app

def application(environ, start_response):
    start_response('200 OK', [('Content-Type','text/html')])
    ret = []
    for k, v in environ.items():
       if k not in ('REMOTE_ADDR', 'HTTP_X_FORWARDED_FOR'):
           continue
       ret.append('{0}={1}\n'.format(k, v))
##     return ret
# Client

import requests
response  = requests.get('http://localhost:5000',
                         headers={'X-Forwarded-For': '1.2.3.4'})

print response.text

---

Running server and client:

python client.py
REMOTE_ADDR=127.0.0.1
HTTP_X_FORWARDED_FOR=1.2.3.4

---

Before that patch, using gunicorn, it is impossible to get the proxy address inside the WSGi application.
Every other tested WSGI Server (mod_wsgi and uwsgi), it works.
Gunicorn should works too.
