### PR TITLE
Feature/ipc

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -478,7 +478,6 @@ class Arbiter(object):
                     worker = self.WORKERS.pop(wpid, None)
                     if not worker:
                         continue
-                    worker.tmp.close()
         except OSError as e:
             if e.errno == errno.ECHILD:
                 pass
@@ -534,7 +533,6 @@ class Arbiter(object):
         finally:
             self.log.info("Worker exiting (pid: %s)", worker_pid)
             try:
-                worker.tmp.close()
                 self.cfg.worker_exit(self, worker)
             except:
                 pass
@@ -572,7 +570,6 @@ class Arbiter(object):
             if e.errno == errno.ESRCH:
                 try:
                     worker = self.WORKERS.pop(pid)
-                    worker.tmp.close()
                     self.cfg.worker_exit(self, worker)
                     return
                 except (KeyError, OSError):

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -112,6 +112,10 @@ class Worker(object):
             util.close_on_exec(p)
 
 
+        # make sure that the signal socket isn't blocking
+        self.worker_signal_pipe[1].setblocking(False)
+        util.close_on_exec(self.worker_signal_pipe[1])
+
         # Prevent fd inherientence
         [util.close_on_exec(s) for s in self.sockets]
         util.close_on_exec(self.tmp.fileno())

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -72,7 +72,7 @@ class Worker(object):
         this task, the master process will murder your workers.
         """
         try:
-            self.worker_signal_pipe[1].send("1")
+            self.worker_signal_pipe[1].send(b"1")
         except socket.error as e:
             print(e)
             if e.args[0] not in (errno.EAGAIN, errno.ECONNABORTED,

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -51,7 +51,8 @@ class Worker(object):
         self.tmp = WorkerTmp(cfg)
 
         # set woerker signal
-        self.worker_signal_pipe = socket.socketpair()
+        self.worker_signal_pipe = socket.socketpair(socket.AF_UNIX,
+                socket.SOCK_DGRAM)
         for p in self.worker_signal_pipe:
             util.set_non_blocking(p.fileno())
             util.close_on_exec(p.fileno())
@@ -74,7 +75,6 @@ class Worker(object):
         try:
             self.worker_signal_pipe[1].send(b"1")
         except socket.error as e:
-            print(e)
             if e.args[0] not in (errno.EAGAIN, errno.ECONNABORTED,
                             errno.EWOULDBLOCK):
                 self.alive = False

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -13,7 +13,6 @@ import traceback
 
 
 from gunicorn import util
-from gunicorn.workers.workertmp import WorkerTmp
 from gunicorn.http.errors import InvalidHeader, InvalidHeaderName, \
 InvalidRequestLine, InvalidRequestMethod, InvalidHTTPVersion, \
 LimitRequestLine, LimitRequestHeaders
@@ -48,7 +47,6 @@ class Worker(object):
         self.alive = True
         self.log = log
         self.debug = cfg.debug
-        self.tmp = WorkerTmp(cfg)
 
         # set woerker signal
         self.worker_signal_pipe = socket.socketpair(socket.AF_UNIX,
@@ -118,7 +116,6 @@ class Worker(object):
 
         # Prevent fd inherientence
         [util.close_on_exec(s) for s in self.sockets]
-        util.close_on_exec(self.tmp.fileno())
 
         self.log.close_on_exec()
 

--- a/gunicorn/workers/geventlet.py
+++ b/gunicorn/workers/geventlet.py
@@ -45,6 +45,10 @@ class EventletWorker(AsyncWorker):
         eventlet.monkey_patch(os=False)
         patch_sendfile()
 
+        # patch the socket handling the signaling
+        self.worker_signal_pipe = (self.worker_signal_pipe[0],
+                GreenSocket(self.worker_signal_pipe[1]))
+
     def init_process(self):
         hubs.use_hub()
         super(EventletWorker, self).init_process()

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -85,6 +85,10 @@ class GeventWorker(AsyncWorker):
                 _sock=s))
         self.sockets = sockets
 
+        # patch the socket hamdling the signaling
+        self.worker_signal_pipe = (self.worker_signal_pipe[0],
+                socket(_socket.AF_UNIX, _socket.SOCK_DGRAM,
+                _sock=self.worker_signal_pipe[1]))
 
     def notify(self):
         super(GeventWorker, self).notify()


### PR DESCRIPTION
use a unix socket instead of a temportay file to signal activity

This change replace the use of a temportary file by a socket pair to
notify the master that the worker is still alive.

before we were doing the following:
- create a tmp file / worker
- write to it
- check the last update bey using os.stat

now:

- open a socket pair
- write to it
- on socket read we update the worker state

The advantage of this change is to remove any possible file leaking on some platform also it can possibly be faster since we don't have to read the file size each time.