### PR TITLE
use shared memory

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -424,7 +424,7 @@ class Arbiter(object):
             return
         for (pid, worker) in self.WORKERS.items():
             try:
-                if time.time() - worker.tmp.last_update() <= self.timeout:
+                if time.time() - worker.last_update.value <= self.timeout:
                     continue
             except ValueError:
                 continue

--- a/gunicorn/shared.py
+++ b/gunicorn/shared.py
@@ -1,0 +1,37 @@
+
+try:
+    from .sharedctypes import Value
+    ctypes = True
+except ImportError:
+    ctypes = False
+import threading
+
+if not ctypes:
+
+    import mmap
+    import struct
+
+    class Value(object):
+
+        def __init__(self, fmt, val):
+            self.struct = struct.Struct(fmt)
+            self._buffer = mmap.mmap(-1, mmap.PAGESIZE)
+            self._val = val
+            self._commit()
+
+        def _commit(self):
+            s = self.struct.pack(self._val)
+            self._buffer.seek(0)
+            self._buffer.write(s)
+
+        @property
+        def value(self):
+            self._buffer.seek(0)
+            print self._buffer.size
+            v, = self.struct.unpack(self._buffer[:self._buffer.size()])
+            return v
+
+        @value.setter
+        def value(self, new):
+            self._val = new
+            self._commit()

--- a/gunicorn/shared.py
+++ b/gunicorn/shared.py
@@ -27,7 +27,6 @@ if not ctypes:
         @property
         def value(self):
             self._buffer.seek(0)
-            print self._buffer.size
             v, = self.struct.unpack(self._buffer[:self._buffer.size()])
             return v
 

--- a/gunicorn/sharedctypes.py
+++ b/gunicorn/sharedctypes.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+try:
+    import ctypes
+    import ctypes.util
+except MemoryError:
+    # selinux execmem denial
+    # https://bugzilla.redhat.com/show_bug.cgi?id=488396
+    raise ImportError
+import mmap
+import sys
+import _multiprocessing
+
+from .six import PY3
+
+fmt_to_ctype = {
+    'c': ctypes.c_char,  'u': ctypes.c_wchar,
+    'b': ctypes.c_byte,  'B': ctypes.c_ubyte,
+    'h': ctypes.c_short, 'H': ctypes.c_ushort,
+    'i': ctypes.c_int,   'I': ctypes.c_uint,
+    'l': ctypes.c_long,  'L': ctypes.c_ulong,
+    'f': ctypes.c_float, 'd': ctypes.c_double
+    }
+
+class Value(object):
+
+    def __init__(self, code_or_ctype, val):
+        type_ = fmt_to_ctype.get(code_or_ctype, code_or_ctype)
+        print(type_)
+        size = ctypes.sizeof(type_)
+        self._mmap = mmap.mmap(-1, size)
+        if '__pypy__' not in sys.builtin_module_names:
+            self._val = type_.from_buffer(self._mmap)
+        else:
+            address, length = _multiprocessing.address_of_buffer(self._mmap)
+            assert size <= length
+            self._val = type_.from_address(address)
+
+        ctypes.memset(ctypes.addressof(self._val), 0, ctypes.sizeof(self._val))
+
+        # initialize the vallue
+        self._val.value = val
+
+    @property
+    def value(self):
+        return self._val.value
+
+    @value.setter
+    def value(self, new):
+        self._val.value = new

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import os
 import signal
 import sys
+import time
 import traceback
 
 
@@ -18,6 +19,7 @@ LimitRequestLine, LimitRequestHeaders
 from gunicorn.http.errors import InvalidProxyLine, ForbiddenProxyRequest
 from gunicorn.http.wsgi import default_environ, Response
 from gunicorn.six import MAXSIZE
+from gunicorn.shared import Value
 
 
 class Worker(object):
@@ -47,6 +49,7 @@ class Worker(object):
         self.log = log
         self.debug = cfg.debug
         self.tmp = WorkerTmp(cfg)
+        self.last_update = Value('i', int(time.time()))
 
     def __str__(self):
         return "<Worker %s>" % self.pid
@@ -61,7 +64,9 @@ class Worker(object):
         once every ``self.timeout`` seconds. If you fail in accomplishing
         this task, the master process will murder your workers.
         """
-        self.tmp.notify()
+        # store the last updated value
+        t = int(time.time())
+        self.last_update.value = t
 
     def run(self):
         """\


### PR DESCRIPTION
Instead of opening a fd (file or IPC) to notify the master that the worker is still
alive we could just share the memory between the process and the master
and read when it has been updated by reading a value. It will improve
the performances and use less fds.