### PR TITLE
set ForwardedAllowIPS via cli

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -906,6 +906,7 @@ class XForwardedFor(Setting):
 class ForwardedAllowIPS(Setting):
     name = "forwarded_allow_ips"
     section = "Server Mechanics"
+    cli = ["--forwarded-allow-ips"]
     meta = "STRING"
     validator = validate_string_to_list
     default = "127.0.0.1"


### PR DESCRIPTION
set `ForwardedAllowIPS` option via cli `--forwarded-allow-ips`
example:

``` bash
exec gunicorn \
--bind=192.168.11.1:8080 \
--forwarded-allow-ips='*'
```
