### PR TITLE
Add graceful_signals configuration value.

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -149,6 +149,16 @@ Generally set to thirty seconds. How max time worker can handle
 request after got restart signal. If the time is up worker will
 be force killed.
 
+graceful_signals
+~~~~~~~~~~~~~~~~
+
+* ``--graceful-signals INT``
+* ``2``
+
+A list of signals which should perform a graceful shutdown.  The
+default value is SIGQUIT.  Supported signals are SIGQUIT (3),
+SIGINT (2) and SIGTERM (15).
+
 keepalive
 ~~~~~~~~~
 

--- a/docs/source/signals.rst
+++ b/docs/source/signals.rst
@@ -12,9 +12,10 @@ exception of TTIN/TTOU the signals handling match the behaviour of `nginx
 Master process
 ==============
 
-- **TERM**, **INT**: Quick shutdown
-- **QUIT**: Graceful shutdwn. I waits for workers to finish their
-  current request before finishing until the *graceful timeout*.
+- **TERM**, **INT**, **QUIT**: Shut down.  Signals listed in **graceful_signals**
+  will wait up to *graceful timeout* for workers to finish their current request.
+  Other signals will shut down immediately.  By default, **QUIT** is a graceful
+  shutdown signal.
 - **HUP**: Reload the configuration, start the new worker processes with a new
   configuration and gracefully shutdown older workers. If the application is
   not preloaded (using the ``--preload`` option), Gunicorn will also load the

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -227,16 +227,20 @@ class Arbiter(object):
 
     def handle_quit(self):
         "SIGQUIT handling"
+        if signal.SIGQUIT not in self.cfg.graceful_signals:
+            self.stop(False)
         raise StopIteration
 
     def handle_int(self):
         "SIGINT handling"
-        self.stop(False)
+        if signal.SIGINT not in self.cfg.graceful_signals:
+            self.stop(False)
         raise StopIteration
 
     def handle_term(self):
         "SIGTERM handling"
-        self.stop(False)
+        if signal.SIGTERM not in self.cfg.graceful_signals:
+            self.stop(False)
         raise StopIteration
 
     def handle_ttin(self):

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -12,6 +12,7 @@ except ImportError: # python 2.6
     from . import argparse_compat as argparse
 import os
 import pwd
+import signal
 import sys
 import textwrap
 import types
@@ -302,6 +303,13 @@ def validate_list_string(val):
         val = [val]
 
     return [validate_string(v) for v in val]
+
+
+def validate_list_pos_int(val):
+    if not val:
+        return []
+
+    return [validate_pos_int(v) for v in val]
 
 
 def validate_string_to_list(val):
@@ -606,7 +614,19 @@ class GracefulTimeout(Setting):
         be force killed.
         """
 
+class GracefulSignals(Setting):
+    name = "graceful_signals"
+    section = "Worker Processes"
+    cli = ["--graceful-signals"]
+    validator = validate_list_pos_int
+    action = "append"
+    meta = "INT"
+    default = [signal.SIGQUIT]
 
+    desc = """\
+        A signal number that should perform a graceful shutdown.
+       """
+ 
 class Keepalive(Setting):
     name = "keepalive"
     section = "Worker Processes"

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -115,7 +115,7 @@ class Worker(object):
         # reset signaling
         [signal.signal(s, signal.SIG_DFL) for s in self.SIGNALS]
         # init new signaling
-        signal.signal(signal.SIGQUIT, self.handle_quit)
+        signal.signal(signal.SIGQUIT, self.handle_exit)
         signal.signal(signal.SIGTERM, self.handle_exit)
         signal.signal(signal.SIGINT, self.handle_exit)
         signal.signal(signal.SIGWINCH, self.handle_winch)
@@ -129,12 +129,10 @@ class Worker(object):
     def handle_usr1(self, sig, frame):
         self.log.reopen_files()
 
-    def handle_quit(self, sig, frame):
-        self.alive = False
-
     def handle_exit(self, sig, frame):
         self.alive = False
-        sys.exit(0)
+        if sig not in self.cfg.graceful_signals:
+            sys.exit(0)
 
     def handle_error(self, req, client, addr, exc):
         request_start = datetime.now()


### PR DESCRIPTION
Gunicorn performs a clean shutdown on SIGQUIT, and a hard shutdown on
SIGTERM.  However, Heroku uses SIGTERM to request a clean shutdown, not
SIGQUIT.  (Hard shutdown is SIGKILL.)  This allows specifying which
signals should perform a clean shutdown:

import signal
graceful_signals = [signal.SIGTERM]

The default value is [signal.SIGQUIT], which is the existing behavior.
