### PR TITLE
Add graceful_term_signal configuration value.

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -149,6 +149,15 @@ Generally set to thirty seconds. How max time worker can handle
 request after got restart signal. If the time is up worker will
 be force killed.
 
+graceful_term_signals
+~~~~~~~~~~~~~~~~
+
+* ``--graceful-term-signal``
+
+By default, SIGQUIT performs a graceful shutdown and SIGTERM performs
+an immediate shutdown.  If *--graceful-term-signal* is specified, these
+signals are reversed.
+
 keepalive
 ~~~~~~~~~
 

--- a/docs/source/signals.rst
+++ b/docs/source/signals.rst
@@ -13,8 +13,14 @@ Master process
 ==============
 
 - **TERM**, **INT**: Quick shutdown
-- **QUIT**: Graceful shutdwn. I waits for workers to finish their
+- **QUIT**: Graceful shutdwn. Waits for workers to finish their
   current request before finishing until the *graceful timeout*.
+  If *graceful_term_signal* is enabled, the meaning of SIGTERM and
+  SIGQUIT is reversed.
+- **TERM**, **INT**, **QUIT**: Shut down.  Signals listed in **graceful_signals**
+  will wait up to *graceful timeout* for workers to finish their current request.
+  Other signals will shut down immediately.  By default, **QUIT** is a graceful
+  shutdown signal.
 - **HUP**: Reload the configuration, start the new worker processes with a new
   configuration and gracefully shutdown older workers. If the application is
   not preloaded (using the ``--preload`` option), Gunicorn will also load the

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -12,6 +12,7 @@ except ImportError: # python 2.6
     from . import argparse_compat as argparse
 import os
 import pwd
+import signal
 import sys
 import textwrap
 import types
@@ -163,6 +164,14 @@ class Config(object):
             env[k] = v
 
         return env
+
+    @property
+    def graceful_termination_signal(self):
+        return signal.SIGTERM if self.settings['graceful_term_signal'].get() else signal.SIGQUIT
+
+    @property
+    def immediate_termination_signal(self):
+        return signal.SIGQUIT if self.settings['graceful_term_signal'].get() else signal.SIGTERM
 
 
 class SettingMeta(type):
@@ -606,7 +615,20 @@ class GracefulTimeout(Setting):
         be force killed.
         """
 
+class GracefulTermSignal(Setting):
+    name = "graceful_term_signal"
+    section = "Worker Processes"
+    cli = ["--graceful-term-signal"]
+    validator = validate_bool
+    action = "store_true"
+    default = False
 
+    desc = """\
+       If true, SIGTERM performs a graceful shutdown and SIGQUIT performs an
+       immediate shutdown.  if false, SIGQUIT performs a graceful shutdown and
+       SIGTERM performs an immediate shutdown.
+       """
+ 
 class Keepalive(Setting):
     name = "keepalive"
     section = "Worker Processes"

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -115,24 +115,24 @@ class Worker(object):
         # reset signaling
         [signal.signal(s, signal.SIG_DFL) for s in self.SIGNALS]
         # init new signaling
-        signal.signal(signal.SIGQUIT, self.handle_quit)
-        signal.signal(signal.SIGTERM, self.handle_exit)
-        signal.signal(signal.SIGINT, self.handle_exit)
+        signal.signal(self.cfg.graceful_termination_signal, self.handle_graceful_shutdown_signal)
+        signal.signal(self.cfg.immediate_termination_signal, self.handle_immediate_shutdown_signal)
+        signal.signal(signal.SIGINT, self.handle_immediate_shutdown_signal)
         signal.signal(signal.SIGWINCH, self.handle_winch)
         signal.signal(signal.SIGUSR1, self.handle_usr1)
-        # Don't let SIGQUIT and SIGUSR1 disturb active requests
+        # Don't let SIGUSR1 or the graceful termination signal disturb active requests
         # by interrupting system calls
         if hasattr(signal, 'siginterrupt'):  # python >= 2.6
-            signal.siginterrupt(signal.SIGQUIT, False)
+            signal.siginterrupt(self.cfg.graceful_termination_signal, False)
             signal.siginterrupt(signal.SIGUSR1, False)
 
     def handle_usr1(self, sig, frame):
         self.log.reopen_files()
 
-    def handle_quit(self, sig, frame):
+    def handle_graceful_shutdown_signal(self, sig, frame):
         self.alive = False
 
-    def handle_exit(self, sig, frame):
+    def handle_immediate_shutdown_signal(self, sig, frame):
         self.alive = False
         sys.exit(0)
 


### PR DESCRIPTION
Gunicorn performs a clean shutdown on SIGQUIT, and a hard shutdown on
SIGTERM.  However, Heroku uses SIGTERM to request a clean shutdown, not
SIGQUIT.  (Hard shutdown is SIGKILL.)  This setting allows using those
semantics, when running in a Heroku instance.
