### PR TITLE
Run worker's setup earlier than set num_workers

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -93,12 +93,12 @@ class Arbiter(object):
         if 'GUNICORN_FD' in os.environ:
             self.log.reopen_files()
 
+        self.worker_class = self.cfg.worker_class
         self.address = self.cfg.address
         self.num_workers = self.cfg.workers
         self.debug = self.cfg.debug
         self.timeout = self.cfg.timeout
         self.proc_name = self.cfg.proc_name
-        self.worker_class = self.cfg.worker_class
 
         if self.cfg.debug:
             self.log.debug("Current configuration:")


### PR DESCRIPTION
`cfg.worker_class` is a property, which calls the classmethod `setup` of
the worker class when accessed.  Gevent worker relies on this mechanism
to call `gevent.monkey.patch_all()`.

However, `num_workers` is a hooked property, when it is set, gunicorn
will call hook defined by user.  If the hooked code relies on
gevent's monkey patch, it will fail because the monkey patch has not
been applied yet.

This commit makes sure that `worker_class` property getter invokes
before `num_workers` setter to resolve this problem.
