### PR TITLE
Updated nginx.conf: removed if statment: if is evil

### DIFF
--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -111,10 +111,7 @@ http {
 
       # Try to serve static files from nginx, no point in making an
       # *application* server like Unicorn/Rainbows! serve static files.
-      if (!-f $request_filename) {
-        proxy_pass http://app_server;
-        break;
-      }
+      proxy_pass http://app_server;
     }
 
     # Error pages


### PR DESCRIPTION
## Fixed problem detailed in issue #404 

In nginx, if is evil, for further reference, please see here(http://www.kaminoo.com/post/31052183924/nginx-gunicorn)

The problematic config example is fixed in docs but not in this example
