### PR TITLE
Make frontpage banner text easier to read

### DIFF
--- a/docs/site/css/style.css
+++ b/docs/site/css/style.css
@@ -109,7 +109,6 @@ a:hover {
 
 .banner h1 {
     font-size: 20px;
-    font-weight: lighter;
     color: #FFF;
     margin: 15px 10px 0;
     padding: 5px 40px;


### PR DESCRIPTION
At first glance of the homepage, the banner h1 text which describes gunicorn seems very difficult to read: bright green with crosshatch background, with thin white text.

Removing the font-weight: lighter css tag will revert the h1 font-weight to the 400 default, increasing the readability, of some very critical text.

New style:
![2013121215017zhxp](https://f.cloud.github.com/assets/130111/1738298/d39bd30c-6381-11e3-97b4-0eda39e327bc.png)
