### PR TITLE
proxy_allow_ips: Allow proxy protocol if "*" specified.

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1403,6 +1403,10 @@ class ProxyAllowFrom(Setting):
     default = "127.0.0.1"
     desc = """\
         Front-end's IPs from which allowed accept proxy requests (comma separate).
+
+        Set to "*" to disable checking of Front-end IPs (useful for setups
+        where you don't know in advance the IP address of Front-end, but
+        you still trust the environment)
         """
 
 

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -252,7 +252,8 @@ class Request(Message):
                 if e.args[0] == ENOTCONN:
                     raise ForbiddenProxyRequest("UNKNOW")
                 raise
-            if remote_host not in self.cfg.proxy_allow_ips:
+            if ("*" not in self.cfg.proxy_allow_ips and
+                    remote_host not in self.cfg.proxy_allow_ips):
                 raise ForbiddenProxyRequest(remote_host)
 
     def parse_proxy_protocol(self, line):


### PR DESCRIPTION
This makes proxy_allow_ips symmetrical with forwarded_allow_ips and is
useful in the same situations.
