### PR TITLE
Make WorkerTmp accept a configurable tmp dir

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -708,6 +708,18 @@ class Pidfile(Setting):
         If not set, no PID file will be written.
         """
 
+class WorkerTmpDir(Setting):
+    name = "worker_tmp_dir"
+    section = "Server Mechanics"
+    cli = ["--worker-tmp-dir"]
+    meta = "DIR"
+    validator = validate_string
+    default = None
+    desc = """\
+        A directory to use for the worker heartbeat temporary file.
+
+        If not set, the default temporary directory will be used.
+        """
 
 class User(Setting):
     name = "user"

--- a/gunicorn/workers/workertmp.py
+++ b/gunicorn/workers/workertmp.py
@@ -19,7 +19,10 @@ class WorkerTmp(object):
 
     def __init__(self, cfg):
         old_umask = os.umask(cfg.umask)
-        fd, name = tempfile.mkstemp(prefix="wgunicorn-")
+        fdir = cfg.worker_tmp_dir
+        if fdir and not os.path.isdir(fdir):
+            raise RuntimeError("%s doesn't exist. Can't create workertmp." % fdir)
+        fd, name = tempfile.mkstemp(prefix="wgunicorn-", dir=fdir)
 
         # allows the process to write to the file
         util.chown(name, cfg.uid, cfg.gid)


### PR DESCRIPTION
This adds a --worker-tmp-dir option to use an optional temp dir when creating heartbeat for workers
