### PR TITLE
unix socket for syslog is a dgram not a stream

### DIFF
--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -107,7 +107,7 @@ class SafeAtoms(dict):
 def parse_syslog_address(addr):
 
     if addr.startswith("unix://"):
-        return (socket.SOCK_STREAM, addr.split("unix://")[1])
+        return (socket.SOCK_DGRAM, addr.split("unix://")[1])
 
     if addr.startswith("udp://"):
         addr = addr.split("udp://")[1]


### PR DESCRIPTION
Hi,

 With apologies for not knowing much about gunicorn or syslog,  I was trying to use gunicorn with syslog over a socket, but i kept getting "socket.error: [Errno 91] Protocol wrong type for socket"  errors.
this change fixed it for me and makes it work on my system.

details of my system:
gunicorn is invoked as: gunicorn -b 0.0.0.0:5000 <app> --log-syslog --log-syslog-prefix=gateway --log-syslog-facility local1 --log-syslog-to unix:///hostdev/log --debug --access-logfile syslog --error-logfile syslog

gunicorn is running on a docker container running ubuntu 13.04,
but the syslog daemon is running on the host (outside the container), which is an EC2 instance running ubuntu 12.04.
/hostdev/log is a docker mount for the host's /dev/log socket.

It's not clear to me whether this fix is universal,  or if it only applies in some situations.
  sorry if this pullreq is a waste of anybody's time, but it fixes my problem so maybe it's legit!?
