### PR TITLE
Honor $WEB_CONCURRENCY environment variable.

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -514,6 +514,9 @@ class Workers(Setting):
         A positive integer generally in the 2-4 x $(NUM_CORES) range. You'll
         want to vary this a bit to find the best for your particular
         application's work load.
+
+        By default, the value of the WEB_CONCURRENCY environment variable. If
+        it is not defined, the default is 1.
         """
 
 


### PR DESCRIPTION
Similar to #436. 

Allows for changing concurrency configuration without changing
application code. This is an environment variable that other
communities (e.g. Rails) are starting to follow, and have enjoyed 
for a little while now.

Have discussed with /cc @benoitc in the past and he was very +1
