### PR TITLE
Deprecate the --debug setting

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -215,10 +215,8 @@ debug
 * ``--debug``
 * ``False``
 
-Turn on debugging in the server.
-
-This limits the number of worker processes to 1 and changes some error
-handling that's sent to clients.
+**DEPRECATED**: This no functionality was removed after v18.0.  This
+option is now a no-op.
 
 reload
 ~~~~~~

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -96,21 +96,16 @@ class Arbiter(object):
         self.worker_class = self.cfg.worker_class
         self.address = self.cfg.address
         self.num_workers = self.cfg.workers
-        self.debug = self.cfg.debug
         self.timeout = self.cfg.timeout
         self.proc_name = self.cfg.proc_name
 
-        if self.cfg.debug:
-            self.log.debug("Current configuration:")
-            for config, value in sorted(self.cfg.settings.items(),
-                    key=lambda setting: setting[1]):
-                self.log.debug("  %s: %s", config, value.value)
+        self.log.debug("Current configuration:")
+        for config, value in sorted(self.cfg.settings.items(),
+                key=lambda setting: setting[1]):
+            self.log.debug("  %s: %s", config, value.value)
 
         if self.cfg.preload_app:
-            if not self.cfg.debug:
-                self.app.wsgi()
-            else:
-                self.log.warning("debug mode: app isn't preloaded.")
+            self.app.wsgi()
 
     def start(self):
         """\

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -701,8 +701,8 @@ class Debug(Setting):
     desc = """\
         Turn on debugging in the server.
 
-        This limits the number of worker processes to 1 and changes some error
-        handling that's sent to clients.
+        **DEPRECATED**: This no functionality was removed after v18.0.
+        This option is now a no-op.
         """
 
 

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -46,7 +46,6 @@ class Worker(object):
         self.max_requests = cfg.max_requests or MAXSIZE
         self.alive = True
         self.log = log
-        self.debug = cfg.debug
         self.tmp = WorkerTmp(cfg)
 
     def __str__(self):

--- a/tests/test_003-config.py
+++ b/tests/test_003-config.py
@@ -57,7 +57,7 @@ def test_property_access():
     # Class was loaded
     t.eq(c.worker_class, SyncWorker)
 
-    # Debug affects workers
+    # Workers defaults to 1
     t.eq(c.workers, 1)
     c.set("workers", 3)
     t.eq(c.workers, 3)
@@ -89,15 +89,15 @@ def test_property_access():
 
 def test_bool_validation():
     c = config.Config()
-    t.eq(c.debug, False)
-    c.set("debug", True)
-    t.eq(c.debug, True)
-    c.set("debug", "true")
-    t.eq(c.debug, True)
-    c.set("debug", "false")
-    t.eq(c.debug, False)
-    t.raises(ValueError, c.set, "debug", "zilch")
-    t.raises(TypeError, c.set, "debug", 4)
+    t.eq(c.preload_app, False)
+    c.set("preload_app", True)
+    t.eq(c.preload_app, True)
+    c.set("preload_app", "true")
+    t.eq(c.preload_app, True)
+    c.set("preload_app", "false")
+    t.eq(c.preload_app, False)
+    t.raises(ValueError, c.set, "preload_app", "zilch")
+    t.raises(TypeError, c.set, "preload_app", 4)
 
 def test_pos_int_validation():
     c = config.Config()
@@ -169,9 +169,9 @@ def test_cmd_line():
     with AltArgs(["prog_name", "-w", "3"]):
         app = NoConfigApp()
         t.eq(app.cfg.workers, 3)
-    with AltArgs(["prog_name", "--debug"]):
+    with AltArgs(["prog_name", "--preload"]):
         app = NoConfigApp()
-        t.eq(app.cfg.debug, True)
+        t.eq(app.cfg.preload_app, True)
 
 def test_app_config():
     with AltArgs():


### PR DESCRIPTION
Remove "limits the number of worker processes to 1", which hasn't been true
since 06a4dc6 (fix one error in gunicorn_paster, global conf was ignored,
2010-06-22), although it was true when the line was added in 3c7d532 (Large
refactor of the documentation and website, 2010-05-22).

I also add caveats to the preload section mentioning that it's not compatible
with --debug (since 06a4dc6) or --reload (as already mentioned in the --reload
docs).

I don't understand _why_ --debug and --preload are incompatible though.  It
would be nice if you could have both at the same time.

Fixes #700.
