### PR TITLE
arbiter: Consolidate configuration logging

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -72,3 +72,4 @@ Xie Shi <xieshi@douban.com>
 Steven Cummings <estebistec@gmail.com>
 Malthe Borch <mborch@gmail.com>
 Berker Peksag <berker.peksag@gmail.com>
+W. Trevor King <wking@tremily.us>

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -99,10 +99,12 @@ class Arbiter(object):
         self.timeout = self.cfg.timeout
         self.proc_name = self.cfg.proc_name
 
-        self.log.debug("Current configuration:")
-        for config, value in sorted(self.cfg.settings.items(),
-                key=lambda setting: setting[1]):
-            self.log.debug("  %s: %s", config, value.value)
+        self.log.debug('Current configuration:\n{0}'.format(
+            '\n'.join(
+                '  {0}: {1}'.format(config, value.value)
+                for config, value
+                in sorted(self.cfg.settings.items(),
+                          key=lambda setting: setting[1]))))
 
         if self.cfg.preload_app:
             self.app.wsgi()


### PR DESCRIPTION
Benoit prefers the log prefix for the first line ("Current configuration:")
but not subsequent lines (" {config}: {value}") [1](https://github.com/benoitc/gunicorn/pull/701/files#r9767234), so consolidate to a
single log.debug call.  The newer '{0}'.format() syntax requires Python 2.6
[2](http://docs.python.org/2/whatsnew/2.6.html#pep-3101-advanced-string-formatting), but our setup.py only claims compatibility with 2.6, 2.7, 3.2, and 3.3,
so that should be fine.
