### PR TITLE
Raise new exception to avoid race condition on socket.error

### DIFF
--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -50,7 +50,7 @@ class SyncWorker(base.Worker):
                 except socket.error as e:
                     if e.args[0] not in (errno.EAGAIN, errno.ECONNABORTED,
                             errno.EWOULDBLOCK):
-                        raise
+                        raise Exception("errno {0}: {1}".format(e.args[0], e.args[1]))
 
             # If our parent changed then we shut down.
             if self.ppid != os.getppid():


### PR DESCRIPTION
We have been seeing issue 514 occasionally. https://github.com/benoitc/gunicorn/issues/514

Best guess is that we are getting real socket errors but the message gets overwritten by the next call to connect before it is read by the web app. This fix creates a new Exception with the socket error before the loop continues and the error can be over written.
