### PR TITLE
Add universal Wheel support.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ group = System Environment/Daemons
 
 [pytest]
 norecursedirs = examples lib local src
+
+[wheel]
+universal = 1


### PR DESCRIPTION
Gunicorn works on both Python 2 and Python 3, so we can create a
universal Wheel distribution.

See https://github.com/pypa/sampleproject/blob/master/setup.cfg for
more information.
