### PR TITLE
Don't send blank messages with 500 errors.

### DIFF
--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -188,7 +188,7 @@ class Worker(object):
 
             status_int = 500
             reason = "Internal Server Error"
-            mesg = ""
+            mesg = "%s" % str(exc)
 
         if req is not None:
             request_time = datetime.now() - request_start


### PR DESCRIPTION
Recently, one of our proxy configurations had an invalid hostname, and Django was triggering the gunicorn error handler from this line: https://github.com/django/django/blob/stable/1.4.x/django/http/__init__.py#L821. However, the resultant 500 page did not have any message other than "Internal Server Error", which made things hard to debug. I noticed that the 'mesg' for 500s in gunicorn is an empty string, and here's a pull-request that sets it to something that's more verbose.
