### PR TITLE
Add support for setting number of workers directly using SIGTSTP

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -636,6 +636,24 @@ class Keepalive(Setting):
         """
 
 
+class NumWorkersPath(Setting):
+    name = "num_workers_path"
+    section = "Worker Processes"
+    cli = ["--num_workers_path"]
+    meta = "STRING"
+    validator = validate_string
+    default = None
+    desc = """\
+        A file that store the new number of workers.
+
+        When the master process get a SIGTSTP signal, a number will be read from
+        this file and set as its new number of workers.
+
+        e.g.
+        '/etc/myapp/num_workers'.
+        """
+
+
 class LimitRequestLine(Setting):
     name = "limit_request_line"
     section = "Security"


### PR DESCRIPTION
Gunicorn allow us to increment/decrement the number of workers by one with signal `TTIN/TTOU`.
This is great when we need to change the number of workers without reloading the whole application.

But there are cases when this is not the most efficient way to accomplish our goal.

For example, out of 20 workers spawned for an application, we notice that only 4 of them are busy, and we decide that 10 workers would be enough for it.
We'll have to send `TTOU` 10 times to kill unnecessary workers (possibly with 10 calls to `num_workers_changed`).

Now if we have a signal that allow can set the number of workers directly, things would be a lot easier, one signal is enough.

How do we tell gunicorn the new number of workers? Since we can't pass any data to the signal handler, we'll use a file which stores the number of workers.
