### PR TITLE
Fix microseconds logging, add decimal seconds.

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -438,7 +438,8 @@ By default:
 | f: referer
 | a: user agent
 | T: request time in seconds
-| D: request time in microseconds,
+| D: request time in microseconds
+| L: request time in decimal seconds
 | p: process ID
 | {Header}i: request header
 | {Header}o: response header

--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -244,7 +244,8 @@ class Logger(object):
             'f': environ.get('HTTP_REFERER', '-'),
             'a': environ.get('HTTP_USER_AGENT', '-'),
             'T': request_time.seconds,
-            'D': request_time.microseconds,
+            'D': (request_time.seconds*1000000) + request_time.microseconds,
+            'L': "%d.%06d" % (request_time.seconds, request_time.microseconds),
             'p': "<%s>" % os.getpid()
         }
 


### PR DESCRIPTION
Apache will log %D microseconds over 1 million for requests that take over a second, this change sync's that access log behavior since the formatting seems to be based on that. So a request that takes 1 second and 30 milliseconds will have 1000030 for this atom.

This pull request  also adds a %L atom for decimal seconds for a quick human-readable latency number. In the above example it would output 1.000030 to the log.
