### PR TITLE
Remove incompatible SSL option in Python 2.6

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -140,25 +140,12 @@ class Config(object):
     def is_ssl(self):
         return self.certfile or self.keyfile
 
-    def _load_attrs(self, attrs, version=sys.version_info):
-        for attr in attrs:
-            # suppress_ragged_eofs/do_handshake_on_connect are booleans that can
-            # be False hence we use hasattr instead of getattr(self, attr, None).
-            if hasattr(self, attr) and version >= sys.version_info:
-                yield (attr, getattr(self, attr))
-
     @property
     def ssl_options(self):
-
         opts = {}
-
-        opts.update(self._load_attrs(('certfile', 'keyfile', 'cert_reqs', 'ssl_version',
-                'ca_certs', 'suppress_ragged_eofs', 'do_handshake_on_connect')))
-
-        # The `ciphers` kwarg was only available in Python 2.7, so don't make
-        # it available for us in older versions on Python.
-        opts.update(self._load_attrs(('ciphers'), version=(2, 7)))
-
+        for name, value in self.settings.items():
+            if value.section == 'Ssl':
+                opts[name] = value.get()
         return opts
 
     @property
@@ -1557,14 +1544,13 @@ class DoHandshakeOnConnect(Setting):
     Whether to perform SSL handshake on socket connect (see stdlib ssl module's)
     """
 
-class Ciphers(Setting):
-    name = "ciphers"
-    section = "Ssl"
-    cli = ["--ciphers"]
-    validator = validate_string
-    default = 'TLSv1'
-    desc = """\
-    Ciphers to use (see stdlib ssl module's)
-
-    Note, this value is only available in Python 2.7+ and is ignored in older versions of Python.
-    """
+if sys.version_info >= (2, 7):
+    class Ciphers(Setting):
+        name = "ciphers"
+        section = "Ssl"
+        cli = ["--ciphers"]
+        validator = validate_string
+        default = 'TLSv1'
+        desc = """\
+        Ciphers to use (see stdlib ssl module's)
+        """

--- a/tests/test_007-ssl.py
+++ b/tests/test_007-ssl.py
@@ -8,12 +8,16 @@
 # stdlib
 import inspect
 import ssl
+import sys
 from unittest import TestCase
 
 # gunicorn
 from gunicorn.config import KeyFile, CertFile, SSLVersion, CACerts, \
-     SuppressRaggedEOFs, DoHandshakeOnConnect, Ciphers, Setting, validate_bool, validate_string, \
+     SuppressRaggedEOFs, DoHandshakeOnConnect, Setting, validate_bool, validate_string, \
      validate_pos_int
+
+if sys.version_info >= (2, 7):
+    from gunicorn.config import Ciphers
 
 class SSLTestCase(TestCase):
     def test_settings_classes(self):
@@ -59,8 +63,10 @@ class SSLTestCase(TestCase):
         self.assertEquals(DoHandshakeOnConnect.action, 'store_true')
         self.assertEquals(DoHandshakeOnConnect.default, False)
 
-        self.assertTrue(issubclass(Ciphers, Setting))        
-        self.assertEquals(Ciphers.name, 'ciphers')
-        self.assertEquals(Ciphers.section, 'Ssl')
-        self.assertEquals(Ciphers.cli, ['--ciphers'])
-        self.assertEquals(Ciphers.default, 'TLSv1')
+
+        if sys.version_info >= (2, 7):
+            self.assertTrue(issubclass(Ciphers, Setting))        
+            self.assertEquals(Ciphers.name, 'ciphers')
+            self.assertEquals(Ciphers.section, 'Ssl')
+            self.assertEquals(Ciphers.cli, ['--ciphers'])
+            self.assertEquals(Ciphers.default, 'TLSv1')


### PR DESCRIPTION
An exposed SSL option, `ciphers`, was added in Python 2.7 and breaks older
versions of Python with an unexpected kwargs error on `ssl.wrap_socket`.

I'm not sure if this is the best way to fix this, and I'm happy to consider
other approachs. Some things I'm a bit up in the air about are:

  i) This is only broken for Python 2.6 using sync worker and older whose ssl module doesn't
  expose this. Do the other types of workers not use ssl module, and thus might
  be able to make use of the `cipher` kwarg?

  ii) Should we silently or explicity fail? I couldn't find a nice way to do
  this because the configuration setting has a default value and resulted in
  stringy code to special case the one setting`.

What I would really like to do would add a "python_version" validator that
could intelligently handle this, but I went off into the weeds figuring out
how the SettingsMeta class works. :)
