### PR TITLE
Fix code.djangoproject.com/ticket/20185

### DIFF
--- a/gunicorn/app/django_wsgi.py
+++ b/gunicorn/app/django_wsgi.py
@@ -10,10 +10,10 @@ import re
 import sys
 import time
 try:
+    from StringIO import StringIO
+except:
     from io import StringIO
     from imp import reload
-except ImportError:
-    from StringIO import StringIO
 
 
 from django.conf import settings


### PR DESCRIPTION
This change favors `python2` over `python3` by reversing the try/except order. 

Untested in `python3`, as most Django packages are not yet `python3`-compatible.
Works in `python2`, `Django 1.5.4`, `gunicorn 18.0`.

When running `gunicorn` in python 2, if a django model doesn't validate, the `gunicorn` will fail to display informative error messages about your model and instead complain about `str`/`unicode`:

Django was falsely accused of [this bug](https://code.djangoproject.com/ticket/20185)
