### PR TITLE
731 umask

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -417,7 +417,7 @@ def daemonize(enable_stdio_inheritance=False):
         if os.fork():
             os._exit(0)
 
-        os.umask(0)
+        os.umask(2)
 
         # In both the following any file descriptors above stdin
         # stdout and stderr are left untouched. The inheritence


### PR DESCRIPTION
There is a case where running gunicorn in daemon mode can create world writable `__pycache__` directories the first time it runs.
