### PR TITLE
Remove obsolete function sorter

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -78,10 +78,6 @@ class Config(object):
                 help="show program's version number and exit")
         parser.add_argument("args", nargs="*", help=argparse.SUPPRESS)
 
-        keys = list(self.settings)
-        def sorter(k):
-            return (self.settings[k].section, self.settings[k].order)
-
         keys = sorted(self.settings, key=self.settings.__getitem__)
         for k in keys:
             self.settings[k].add_option(parser)

--- a/gunicorn/management/commands/run_gunicorn.py
+++ b/gunicorn/management/commands/run_gunicorn.py
@@ -45,18 +45,13 @@ except ImportError:
 
 
 def make_options():
-    g_settings = make_settings(ignore=("version"))
-
-    keys = g_settings.keys()
-
-    def sorter(k):
-        return (g_settings[k].section, g_settings[k].order)
-
     opts = [
         make_option('--adminmedia', dest='admin_media_path', default='',
         help='Specifies the directory from which to serve admin media.')
     ]
 
+    g_settings = make_settings(ignore=("version"))
+    keys = g_settings.keys()
     for k in keys:
         if k in ('pythonpath', 'django_settings',):
             continue


### PR DESCRIPTION
Function `sorter` is obsolete, as it isn't used anywhere anymore. I think we should remove it.
