### PR TITLE
Fix: logger_class can be undefined.

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -123,10 +123,10 @@ class Config(object):
         if uri == "simple":
             # support the default
             uri = "gunicorn.glogging.Logger"
-        else:
-            logger_class = util.load_class(uri,
-                    default="gunicorn.glogging.Logger",
-                    section="gunicorn.loggers")
+
+        logger_class = util.load_class(uri,
+                default="gunicorn.glogging.Logger",
+                section="gunicorn.loggers")
 
         if hasattr(logger_class, "install"):
             logger_class.install()


### PR DESCRIPTION
If `uri` is `simple`, then `logger_class` is undefined. 
Returning `logger_class` under this circumstance leads to exception.
