### PR TITLE
Fix mixed up worker signal handling

### DIFF
--- a/docs/source/signals.rst
+++ b/docs/source/signals.rst
@@ -35,8 +35,8 @@ Sending signals directly to the worker processes should not normally be
 needed.  If the master process is running, any exited worker will be
 automatically respawned.
 
-- **QUIT**, **INT**: Graceful shutdown
-- **TERM**: Quick shutdown
+- **QUIT**, **INT**: Quick shutdown
+- **TERM**: Graceful shutdown
 - **USR1**: Reopen the log files
 
 Reload the configuration

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -336,9 +336,9 @@ class Arbiter(object):
         killed gracefully  (ie. trying to wait for the current connection)
         """
         self.LISTENERS = []
-        sig = signal.SIGQUIT
+        sig = signal.SIGTERM
         if not graceful:
-            sig = signal.SIGTERM
+            sig = signal.SIGQUIT
         limit = time.time() + self.cfg.graceful_timeout
         while self.WORKERS and time.time() < limit:
             self.kill_workers(sig)


### PR DESCRIPTION
Commit 81241907ffcf94517ffa14b8427205906b61b540 changed the signal
handling by switching the roles of `TERM` and `QUIT` for the arbiter
so that `TERM` is graceful and `QUIT` is not.

At the time, workers performed graceful shutdown on `QUIT` and quick
shutdown on `TERM` and `INT`. This behavior was also changed so that
`QUIT` (and `INT`) cause a quick shutdown and `TERM` is graceful.

However, the documentation incorrectly reversed the roles of the worker
signals and the arbiter was not updated to use the correct signals.

This commit fixes the documentation and the arbiter signals.
