### PR TITLE
Remove __future__.with_statement imports.

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -3,8 +3,6 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
-from __future__ import with_statement
-
 import errno
 import os
 import random

--- a/gunicorn/pidfile.py
+++ b/gunicorn/pidfile.py
@@ -3,8 +3,6 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
-from __future__ import with_statement
-
 import errno
 import os
 import tempfile

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -3,8 +3,6 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
-from __future__ import with_statement
-
 import errno
 import os
 import sys

--- a/tests/t.py
+++ b/tests/t.py
@@ -4,8 +4,6 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
-from __future__ import with_statement
-
 import array
 import os
 import tempfile

--- a/tests/test_003-config.py
+++ b/tests/test_003-config.py
@@ -3,8 +3,6 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
-from __future__ import with_statement
-
 import t
 
 import functools

--- a/tests/treq.py
+++ b/tests/treq.py
@@ -3,8 +3,6 @@
 # This file is part of the pywebmachine package released
 # under the MIT license.
 
-from __future__ import with_statement
-
 import t
 
 import inspect


### PR DESCRIPTION
Gunicorn requires Python 2.6 or newer now:

http://docs.gunicorn.org/en/latest/install.html#requirements
