### PR TITLE
Cleanup Makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.sw*
 *.pyc
 *#*
+venv*
+__pycache__
+MANIFEST
 build
 dist
 setuptools-*
@@ -14,12 +17,6 @@ distribute-0.6.8.tar.gz
 gunicorn.egg-info
 nohup.out
 .coverage
-doc/.sass-cache
-bin/
-lib/
-man/
-include/
-html/
 examples/frameworks/pylonstest/PasteScript*
 examples/frameworks/pylonstest/pylonstest.egg-info/
 examples/frameworks/django/testing/testdb.sql

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
 build:
-	virtualenv --no-site-packages .
-	bin/python setup.py develop
-	bin/pip install -r requirements_dev.txt
+	virtualenv venv
+	venv/bin/pip install -e .
+	venv/bin/pip install -r requirements_dev.txt
 
 test:
-	bin/python setup.py test
+	venv/bin/python setup.py test
 
 coverage:
-	bin/python setup.py test --cov
+	venv/bin/python setup.py test --cov
 
 clean:
-	@rm -rf .Python bin lib include man build html
+	@rm -rf .Python MANIFEST build dist venv* *.egg-info
+	@find . -type f -name "*.py[co]" -delete
+	@find . -type d -name "__pycache__" -delete
+
+.PHONY: build clean coverage test


### PR DESCRIPTION
- The "--no-site-packages" option is default now
- "pip install -e" is basically equivalent to "python setup.py develop"
- Delete also dist/ and MANIFEST
- Delete all *.py[co] files (and **pycache** directories on Python 3)
