### PR TITLE
Update installation docs to mention about pip.

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -2,65 +2,34 @@
 Installation
 ============
 
-Follow the following steps to install Gunicorn.
+.. highlight:: bash
 
-Requirements
-============
+:Requirements: **Python 2.x >= 2.6** or **Python 3.x >= 3.1**
 
-- **Python 2.x >= 2.6** or **Python 3.x >= 3.1** 
-- setuptools >= 0.6c6
-- nosetests (for the test suite only)
+To install the latest released version of Gunicorn::
 
-With easy_install
-=================
-
-If you don't already have ``easy_install`` available you'll want to download
-and run the ``ez_setup.py`` script::
-
-  $ curl -O http://peak.telecommunity.com/dist/ez_setup.py
-  $ sudo python ez_setup.py -U setuptools
-
-To install or upgrade to the latest released version of Gunicorn::
-
-  $ sudo easy_install -U gunicorn
+  $ pip install gunicorn
 
 .. note::
     There is a limited support version of Gunicorn that is compatible
     with Python 2.4. This fork is managed by Randall Leeds and can be
-    found `here on github`_. To install this version you must specify
-    the full url to something like ``pip``. This hasn't been tested
-    wtih ``easy_install`` just yet::
+    found `here on GitHub`_. To install this version via ``pip``, you
+    must specify the *py24* branch::
 
-        $ pip install -f http://github.com/tilgovi/gunicorn/tarball/py24 gunicorn
+      $ pip install git+https://github.com/tilgovi/gunicorn.git@py24
 
 From Source
 ===========
 
 You can install Gunicorn from source just as you would install any other
-Python package. Gunicorn uses setuptools which will automatically fetch all
-dependencies (including setuptools itself).
+Python package::
 
-You can download a tarball of the latest sources from `GitHub Downloads`_ or
-fetch them with git_::
+    $ pip install git+https://github.com/benoitc/gunicorn.git
 
-    # Using git:
-    $ git clone git://github.com/benoitc/gunicorn.git
-    $ cd gunicorn
+This will allow you To keep up to date with development on GitHub::
 
-    # Or using a tarball:
-    $ wget http://github.com/benoitc/gunicorn/tarball/master -o gunicorn.tar.gz
-    $ tar -xvzf gunicorn.tar.gz
-    $ cd gunicorn-$HASH/
+    $ pip install -U git+https://github.com/benoitc/gunicorn.git
 
-    # Install
-    $ sudo python setup.py install
-
-If you've cloned the git repository, its highly recommended that you use the
-``develop`` command which will allow you to use Gunicorn from the source
-directory. This will allow you to keep up to date with development on GitHub as
-well as make changes to the source::
-
-    $ python setup.py develop
 
 Async Workers
 =============
@@ -72,9 +41,9 @@ want to consider one of the alternate worker types.
 
 ::
 
-    $ easy_install -U greenlet  # Required for both
-    $ easy_install -U eventlet  # For eventlet workers
-    $ easy_install -U gevent    # For gevent workers
+    $ pip install greenlet  # Required for both
+    $ pip install eventlet  # For eventlet workers
+    $ pip install gevent    # For gevent workers
 
 .. note::
     If installing ``greenlet`` fails you probably need to install
@@ -87,6 +56,7 @@ want to consider one of the alternate worker types.
     package manager. If Gevent_ fails to build even with libevent_
     installed, this is the most likely reason.
 
+
 Debian GNU/Linux
 ================
 
@@ -95,22 +65,22 @@ system packages to install Gunicorn except maybe when you want to use
 different versions of gunicorn with virtualenv. This has a number of
 advantages:
 
- * Zero-effort installation: Automatically starts multiple Gunicorn instances
-   based on configurations defined in ``/etc/gunicorn.d``.
+* Zero-effort installation: Automatically starts multiple Gunicorn instances
+  based on configurations defined in ``/etc/gunicorn.d``.
 
- * Sensible default locations for logs (``/var/log/gunicorn``). Logs
-   can be automatically rotated and compressed using ``logrotate``.
+* Sensible default locations for logs (``/var/log/gunicorn``). Logs
+  can be automatically rotated and compressed using ``logrotate``.
 
- * Improved security: Can easily run each Gunicorn instance with a dedicated
-   UNIX user/group.
+* Improved security: Can easily run each Gunicorn instance with a dedicated
+  UNIX user/group.
 
- * Sensible upgrade path: Upgrades to newer versions result in less downtime,
-   handle conflicting changes in configuration options, and can be quickly
-   rolled back in case of incompatibility. The package can also be purged
-   entirely from the system in seconds.
+* Sensible upgrade path: Upgrades to newer versions result in less downtime,
+  handle conflicting changes in configuration options, and can be quickly
+  rolled back in case of incompatibility. The package can also be purged
+  entirely from the system in seconds.
 
 Stable ("wheezy")
-------------------
+-----------------
 
 The version of Gunicorn in the Debian_ "stable" distribution is 0.14.5 (June
 2012). You can install it using::
@@ -166,6 +136,8 @@ our PPA_ by adding ``ppa:gunicorn/ppa`` to your system's Software
 Sources. Use the ``apt-add-repository`` command from the
 ``python-software-properties`` package to add the Gunicorn software source.
 
+::
+
     $ sudo apt-add-repository ppa:gunicorn/ppa
 
 Or this PPA can be added to your system manually by copying the lines below
@@ -174,27 +146,15 @@ and adding them to your system's software sources::
   deb http://ppa.launchpad.net/gunicorn/ppa/ubuntu lucid main
   deb-src http://ppa.launchpad.net/gunicorn/ppa/ubuntu lucid main
 
-Replace 'lucid' with your Ubuntu distribution series.
+Replace *lucid* with your Ubuntu distribution series.
 
-Signing key
------------
+:Signing key: ``1024R/5370FF2A``
+:Fingerprint: ``FC7B41B54C9B8476D9EC22A2C6773E575370FF2A``
 
-::
 
-  1024R/5370FF2A
-
-Fingerprint
------------
-
-::
-
-  FC7B41B54C9B8476D9EC22A2C6773E575370FF2A
-
-.. _`GitHub Downloads`: http://github.com/benoitc/gunicorn/downloads
 .. _`design docs`: design.html
-.. _git: http://git-scm.com/
 .. _Eventlet: http://eventlet.net
-.. _`here on github`: http://github.com/tilgovi/gunicorn
+.. _`here on GitHub`: http://github.com/tilgovi/gunicorn
 .. _Gevent: http://gevent.org
 .. _libevent: http://monkey.org/~provos/libevent
 .. _Debian: http://www.debian.org/


### PR DESCRIPTION
Other changes:
- Minor markup and style changes
- Use https in URLs
- Remove the "python setup.py develop" part from the
  documentation. It's useful for development.
