### PR TITLE
Update nginx config to reflect best practice

### DIFF
--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -86,6 +86,11 @@ http {
     root /path/to/app/current/public;
 
     location / {
+      # checks for static file, if not found proxy to app
+      try_files $uri @proxy_to_app;
+    }
+
+    location @proxy_to_app {
       # an HTTP header important enough to have its own Wikipedia entry:
       #   http://en.wikipedia.org/wiki/X-Forwarded-For
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Should use `try_files` then fall back to a named location block. This is also what's recommended inside the docs already: http://gunicorn-docs.readthedocs.org/en/latest/deploy.html#nginx-configuration
