### PR TITLE
Consistent usage of `@proxy_to_app` named location

### DIFF
--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -77,7 +77,7 @@ To turn off buffering, you only need to add ``proxy_buffering off;`` to your
 ``location`` block::
 
   ...
-  location / {
+  location @proxy_to_app {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;


### PR DESCRIPTION
This can be confusing since `location / {}` and `location @proxy_to_app {}` were both being used.
