### PR TITLE
731 - Avoid creating world writable files

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -416,7 +416,7 @@ def daemonize(enable_stdio_inheritance=False):
         if os.fork():
             os._exit(0)
 
-        os.umask(0)
+        os.umask(0o22)
 
         # In both the following any file descriptors above stdin
         # stdout and stderr are left untouched. The inheritence


### PR DESCRIPTION
Using the agreed umask of 022 to avoid creating world writable files, particularly **pycache**
