### PR TITLE
fix HTTP-violating excess whitespace in write_error output

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -337,8 +337,7 @@ def write_error(sock, status_int, reason, mesg):
     Content-Type: text/html\r
     Content-Length: %d\r
     \r
-    %s
-    """) % (str(status_int), reason, len(html), html)
+    %s""") % (str(status_int), reason, len(html), html)
     write_nonblock(sock, http.encode('latin1'))
 
 


### PR DESCRIPTION
Excess whitespace in `write_error` output yields excess data that doesn't match `Content-Length`. I found this after finding _'upstream sent more data than specified in "Content-Length" header while reading upstream'_ messages in nginx error log (matching "internal server error" responses). It also can be obseved with curl:

```
#test.py
def app(environ, start_response):
  raise Exception('test')
```

```
gunicorn --preload --error-logfile - test:app
```

```
$ curl -v http://localhost:8000/ 2>&1 | grep -i excess
* Excess found in a non pipelined read: excess = 1, size = 141, maxdownload = 141, bytecount = 0
```

The fix is really trivial and straightforward, should i rearrange it as an issue-fix-branch?
Also if a unit test is needed, I need some guidance regarding usage of current testing system.
I ran `tox` and existing tests passed for py27.
