### PR TITLE
Change the rest of QUIT and TERM signals.

### DIFF
--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -262,7 +262,7 @@ systemd:
     WorkingDirectory=/home/urban/gunicorn/bin
     ExecStart=/home/someuser/gunicorn/bin/gunicorn -p /home/urban/gunicorn/gunicorn.pid- test:app
     ExecReload=/bin/kill -s HUP $MAINPID
-    ExecStop=/bin/kill -s QUIT $MAINPID
+    ExecStop=/bin/kill -s TERM $MAINPID
     PrivateTmp=true
 
 **gunicorn.socket**::

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -727,7 +727,7 @@ worker_int
         def worker_int(worker):
             pass
 
-Called just after a worker exited on SIGINT or SIGTERM.
+Called just after a worker exited on SIGINT or SIGQUIT.
 
 The callable needs to accept one instance variable for the initialized
 Worker.

--- a/docs/source/signals.rst
+++ b/docs/source/signals.rst
@@ -22,7 +22,7 @@ Master process
 - **TTIN**: Increment the number of processes by one
 - **TTOU**: Decrement the nunber of processes by one
 - **USR1**: Reopen the log files
-- **USR2**: Upgrade the Gunicorn on the fly. A separate **QUIT** signal should
+- **USR2**: Upgrade the Gunicorn on the fly. A separate **TERM** signal should
   be used to kill the old process. This signal can also be used to use the new
   versions of pre-loaded applications.
 - **WINCH**: Gracefully shutdown the worker processes when gunicorn is
@@ -91,7 +91,7 @@ incoming requests together. To phase the old instance out, you have to
 send **WINCH** signal to the old master process, and its worker
 processes will start to gracefully shut down.
 
-t this point you can still revert to the old server because it hasn't closed its listen sockets yet, by following these steps:
+At this point you can still revert to the old server because it hasn't closed its listen sockets yet, by following these steps:
 
 - Send HUP signal to the old master process - it will start the worker processes without reloading a configuration file
 - Send TERM signal to the new master process to gracefully shut down its worker processes

--- a/examples/example_config.py
+++ b/examples/example_config.py
@@ -202,7 +202,7 @@ def when_ready(server):
     server.log.info("Server is ready. Spwawning workers")
 
 def worker_int(worker):
-    worker.log.info("worker received INT or TERM signal")
+    worker.log.info("worker received INT or QUIT signal")
 
     ## get traceback info
     import threading, sys, traceback

--- a/examples/when_ready.conf.py
+++ b/examples/when_ready.conf.py
@@ -29,7 +29,7 @@ class MemoryWatch(threading.Thread):
                 if self.memory_usage(pid) > self.max_mem:
                     self.server.log.info("Pid %s killed (memory usage > %s)", 
                         pid, self.max_mem)
-                    self.server.kill_worker(pid, signal.SIGQUIT)
+                    self.server.kill_worker(pid, signal.SIGTERM)
             time.sleep(self.timeout)
             
 

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -229,7 +229,7 @@ class Arbiter(object):
         raise StopIteration
 
     def handle_quit(self):
-        "SIGTERM handling"
+        "SIGQUIT handling"
         self.stop(False)
         raise StopIteration
 
@@ -273,7 +273,7 @@ class Arbiter(object):
         if self.cfg.daemon:
             self.log.info("graceful stop of workers")
             self.num_workers = 0
-            self.kill_workers(signal.SIGQUIT)
+            self.kill_workers(signal.SIGTERM)
         else:
             self.log.debug("SIGWINCH ignored. Not daemonized")
 
@@ -480,7 +480,7 @@ class Arbiter(object):
         workers = sorted(workers, key=lambda w: w[1].age)
         while len(workers) > self.num_workers:
             (pid, _) = workers.pop(0)
-            self.kill_worker(pid, signal.SIGQUIT)
+            self.kill_worker(pid, signal.SIGTERM)
 
     def spawn_worker(self):
         self.worker_age += 1

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1369,7 +1369,7 @@ class WorkerInt(Setting):
 
     default = staticmethod(worker_int)
     desc = """\
-        Called just after a worker exited on SIGINT or SIGTERM.
+        Called just after a worker exited on SIGINT or SIGQUIT.
 
         The callable needs to accept one instance variable for the initialized
         Worker.


### PR DESCRIPTION
This will restore graceful shutdown of workers by master.
Also worker_int callback is moved from handle_exit (INT and TERM before switching) to handle_quit(INT and QUIT).
