### PR TITLE
Fix check for file-like objects

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -515,7 +515,7 @@ def is_fileobject(obj):
     # check BytesIO case and maybe others
     try:
         obj.fileno()
-    except io.UnsupportedOperation:
+    except (IOError, io.UnsupportedOperation):
         return False
 
     return True


### PR DESCRIPTION
The `is_fileobject()` function in utils.py would break when the respones
was a wrapped `HTTPResponse`'s `raw` attribute. This just adds the
`IOError` exception type to the `is_fileobject()` function so that the
response can be streamed normally.

Fixes #805
