### PR TITLE
Fix RuntimeError in gunicorn.reloader.

### DIFF
--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -26,7 +26,7 @@ class Reloader(threading.Thread):
     def get_files(self):
         fnames = [
             re.sub('py[co]$', 'py', module.__file__)
-            for module in sys.modules.values()
+            for module in list(sys.modules.values())
             if hasattr(module, '__file__')
         ]
 


### PR DESCRIPTION
Here's the reproducer in Python 3.3:

```
$ gunicorn --paste paste.ini --reload
```

Then I got the following exception:

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/local/lib/python3.3/threading.py", line 901, in _bootstrap_inner
    self.run()
  File "/home/berker/hacking/mediagoblin/venv3/lib/python3.3/site-packages/gunicorn/reloader.py", line 41, in run
    for filename in self.get_files():
  File "/home/berker/hacking/mediagoblin/venv3/lib/python3.3/site-packages/gunicorn/reloader.py", line 29, in get_files
    for module in sys.modules.values()
  File "/home/berker/hacking/mediagoblin/venv3/lib/python3.3/site-packages/gunicorn/reloader.py", line 28, in <listcomp>
    re.sub('py[co]$', 'py', module.__file__)
RuntimeError: dictionary changed size during iteration
```
