### PR TITLE
Fix major issue with threaded worker keepalive

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -134,18 +134,17 @@ class ThreadWorker(base.Worker):
         now = time.time()
         while True:
             try:
+                # remove the connection from the queue
                 conn = self._keep.popleft()
             except IndexError:
                 break
 
             delta = conn.timeout - now
             if delta > 0:
+                # add the connection back to the queue
                 self._keep.appendleft(conn)
                 break
             else:
-                # remove the connection from the queue
-                conn = self._keep.popleft()
-
                 # remove the socket from the poller
                 self.poller.unregister(conn.sock)
 


### PR DESCRIPTION
The keepalive queue management is fixed to not pop extra connections
incorrectly.
