### PR TITLE
add xheaders config to tornado worker and fix the bug orphaned tornado worker will never s...

### DIFF
--- a/gunicorn/workers/gtornado.py
+++ b/gunicorn/workers/gtornado.py
@@ -103,8 +103,7 @@ class TornadoWorker(Worker):
             elif hasattr(server, "_sockets"):  # tornado 2.0
                 server._sockets[s.fileno()] = s
 
-        if hasattr(app, 'xheaders'):
-            server.xheaders = app.xheaders
+        server.xheaders = app.settings.get('xheaders', False)
         server.no_keep_alive = self.cfg.keepalive <= 0
         server.start(num_processes=1)
 

--- a/gunicorn/workers/gtornado.py
+++ b/gunicorn/workers/gtornado.py
@@ -90,7 +90,7 @@ class TornadoWorker(Worker):
 
         if self.cfg.is_ssl:
             server = server_class(app, io_loop=self.ioloop,
-                    ssl_options=self.cfg.ssl_options)
+                                  ssl_options=self.cfg.ssl_options)
         else:
             server = server_class(app, io_loop=self.ioloop)
 
@@ -103,6 +103,8 @@ class TornadoWorker(Worker):
             elif hasattr(server, "_sockets"):  # tornado 2.0
                 server._sockets[s.fileno()] = s
 
+        if hasattr(app, 'xheaders'):
+            server.xheaders = app.xheaders
         server.no_keep_alive = self.cfg.keepalive <= 0
         server.start(num_processes=1)
 
@@ -117,5 +119,5 @@ class TornadoWorker(Worker):
         PeriodicCallback(self.stop_ioloop, 1000, io_loop=self.ioloop).start()
 
     def stop_ioloop(self):
-        if not self.ioloop._callbacks and len(self.ioloop._timeouts) <= 1:
+        if not self.ioloop._callbacks:
             self.ioloop.stop()


### PR DESCRIPTION
In the gunicorn 19.1,  xheaders config is removed, since there is no way to config xheaders any more, I think it can be left  to the tornado application.

Start a tornado app with gunicorn under supervisor, then force kill the master, worker will run forever.

I added a log to the stop_ioloop method like this:

  def stop_ioloop(self):
        self.log.info("callbacks:  %d, timeouts: %d", len(self.ioloop._callbacks), len(self.ioloop._timeouts))
        if not self.ioloop._callbacks and len(self.ioloop._timeouts) <= 1:
            self.ioloop.stop()

Then I found the log in the gunicorn log will like:

2014-08-14 10:54:18 [17430] [INFO] Parent changed, shutting down: <Worker 17430>
2014-08-14 10:54:18 [17372] [INFO] Parent changed, shutting down: <Worker 17372>
2014-08-14 10:54:18 [17373] [INFO] Parent changed, shutting down: <Worker 17373>
2014-08-14 10:54:18 [17430] [INFO] callbacks:  0, timeouts: 2
2014-08-14 10:54:18 [17372] [INFO] callbacks:  0, timeouts: 2
2014-08-14 10:54:18 [17408] [INFO] Parent changed, shutting down: <Worker 17408>
2014-08-14 10:54:18 [17373] [INFO] callbacks:  0, timeouts: 3
2014-08-14 10:54:18 [17408] [INFO] callbacks:  0, timeouts: 2
2014-08-14 10:54:19 [17430] [INFO] Parent changed, shutting down: <Worker 17430>
2014-08-14 10:54:19 [17430] [INFO] callbacks:  0, timeouts: 3
2014-08-14 10:54:19 [17372] [INFO] Parent changed, shutting down: <Worker 17372>
2014-08-14 10:54:19 [17372] [INFO] callbacks:  0, timeouts: 3
2014-08-14 10:54:19 [17373] [INFO] Parent changed, shutting down: <Worker 17373>
2014-08-14 10:54:19 [17373] [INFO] callbacks:  0, timeouts: 4
2014-08-14 10:54:19 [17430] [INFO] callbacks:  0, timeouts: 3
2014-08-14 10:54:19 [17372] [INFO] callbacks:  0, timeouts: 3
2014-08-14 10:54:19 [17408] [INFO] Parent changed, shutting down: <Worker 17408>
2014-08-14 10:54:19 [17408] [INFO] callbacks:  0, timeouts: 3
2014-08-14 10:54:19 [17373] [INFO] callbacks:  0, timeouts: 4
2014-08-14 10:54:19 [17408] [INFO] callbacks:  0, timeouts: 3
2014-08-14 10:54:20 [17430] [INFO] Parent changed, shutting down: <Worker 17430>
2014-08-14 10:54:20 [17430] [INFO] callbacks:  0, timeouts: 4
2014-08-14 10:54:20 [17430] [INFO] callbacks:  0, timeouts: 4
2014-08-14 10:54:20 [17372] [INFO] Parent changed, shutting down: <Worker 17372>
...

The callbacks is always 0 and timeouts will increase forever, since PeriodicCallback will add an timeout to the ioloop, the timeouts will never be zero, so the worker can nerver stop.
