### PR TITLE
Respect logger_class setting unless statsd is on

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,7 +161,7 @@ The `Statsd` logger overrides `gunicorn.glogging.Logger` to track
 all requests. The following metrics are generated:
 
   * ``gunicorn.requests``: request rate per second
-  * ``gunicorn.request.duration``: histogram of request duration
+  * ``gunicorn.request.duration``: histogram of request duration (in millisecond)
   * ``gunicorn.workers``: number of workers managed by the arbiter (gauge)
   * ``gunicorn.log.critical``: rate of critical log messages
   * ``gunicorn.log.error``: rate of error log messages

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -142,9 +142,9 @@ class Config(object):
         if uri == "simple":
             # support the default
             uri = "gunicorn.glogging.Logger"
-        
+
         # if statsd is on, automagically switch to the statsd logger
-        if 'statsd_host' in self.settings:
+        if 'statsd_host' in self.settings and self.settings['statsd_host'].value is not None:
             logger_class = util.load_class("gunicorn.instrument.statsd.Statsd",
                 section="gunicorn.loggers")
         else:
@@ -1646,7 +1646,7 @@ class StatsdHost(Setting):
     section = "Logging"
     cli = ["--statsd-host"]
     meta = "STATSD_ADDR"
-    default = "localhost:8125"
+    default = None
     validator = validate_hostport
     desc ="""\
     host:port of the statsd server to log to


### PR DESCRIPTION
This should fix #848.

If `--statsd-host` is set to some value, it will set `logger_class` to the StatsD logger. If the option is not present it respects any `logger_class` that is passed as an option.
