### PR TITLE
fix race condition error

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -309,8 +309,9 @@ class Arbiter(object):
             oldest = time.time()
             for w in worker_values:
                 try:
-                    if w.tmp.last_update() < oldest:
-                        oldest = w.tmp.last_update()
+                    last_update = w.tmp.last_update()
+                    if last_update < oldest:
+                        oldest = last_update
                 except ValueError:
                     pass
 


### PR DESCRIPTION
When the worker exited the tempfile is not available anymore so we can't get the last update and calculate the dynamic timeout introduced in d76bab4d716fed3f965fbde4ba1a1bba975f03d1 .

This changes fix it by catching the IO error. fix #863 .
