### PR TITLE
Shutdown socket writes before close

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -271,6 +271,7 @@ def set_non_blocking(fd):
 
 def close(sock):
     try:
+        sock.shutdown(socket.SHUT_WR)
         sock.close()
     except socket.error:
         pass


### PR DESCRIPTION
Calling shutdown(2) with SHUT_WR before close(2) ensures that a FIN
packet is sent before any RST packet. Doing so ensures that clients
and proxies get a clean shutdown signal when the server terminates the
connection while an upload is pending.

Fix #872