### PR TITLE
upstart: removed unneeded console log

### DIFF
--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -235,7 +235,6 @@ from a virtualenv. All errors will go to /var/log/upstart/myapp.log.
     stop on runlevel [016]
 
     respawn
-    console log
     setuid nobody
     setgid nogroup
     chdir /path/to/app/directory


### PR DESCRIPTION
It's there by default since Ubuntu 12.04
