### PR TITLE
propagate proxy_protocol_info to keep-alive requests, fixes #899

### DIFF
--- a/gunicorn/workers/async.py
+++ b/gunicorn/workers/async.py
@@ -38,12 +38,14 @@ class AsyncWorker(base.Worker):
                     self.handle_request(listener_name, req, client, addr)
                 else:
                     # keepalive loop
+                    proxy_protocol_info = req.proxy_protocol_info
                     while True:
                         req = None
                         with self.timeout_ctx():
                             req = six.next(parser)
                         if not req:
                             break
+                        req.proxy_protocol_info = proxy_protocol_info
                         self.handle_request(listener_name, req, client, addr)
             except http.errors.NoMoreData as e:
                 self.log.debug("Ignored premature client disconnection. %s", e)


### PR DESCRIPTION
save off proxy_protocol_info and set it on subsequent keep-alive requests

closes #899
