### PR TITLE
Use tox in .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "pypy"
-install:
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install aiohttp; fi
-script: python setup.py test
-branches:
-  only:
-    - master
+env:
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=py32
+  - TOXENV=py33
+  - TOXENV=py34
+  - TOXENV=pypy
+  - TOXENV=pypy3
+install: pip install tox
+script: tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include NOTICE
 include README.rst
 include THANKS
 include requirements_dev.txt
+include requirements_test.txt
 recursive-include tests *
 recursive-include examples *
 recursive-include docs *

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ coverage:
 	venv/bin/python setup.py test --cov
 
 clean:
-	@rm -rf .Python MANIFEST build dist venv* *.egg-info
+	@rm -rf .Python MANIFEST build dist venv* *.egg-info *.egg
 	@find . -type f -name "*.py[co]" -delete
 	@find . -type d -name "__pycache__" -delete
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pytest==2.6.3
-pytest-cov==1.7.0
+-r requirements_test.txt
+
 sphinx
 sphinx_rtd_theme

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,2 @@
+pytest==2.6.3
+pytest-cov==1.7.0

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
     long_description = f.read()
 
 # read dev requirements
-fname = os.path.join(os.path.dirname(__file__), 'requirements_dev.txt')
+fname = os.path.join(os.path.dirname(__file__), 'requirements_test.txt')
 with open(fname) as f:
-    tests_require = list(map(lambda l: l.strip(), f.readlines()))
+    tests_require = [l.strip() for l in f.readlines()]
 
 if sys.version_info[:2] < (3, 3):
     tests_require.append('mock')

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
-
 [tox]
-envlist = py26, py27, py33, pypy
+envlist = py26, py27, py32, py33, py34, pypy, pypy3
+skipsdist = True
 
 [testenv]
+usedevelop = True
 commands = py.test tests/
-deps = pytest
+deps =
+  -rrequirements_test.txt
+  py26: unittest2
+  py2{6,7},pypy,py32,pypy3: mock
+  py3{3,4}: aiohttp


### PR DESCRIPTION
This way we can avoid code duplication.

Also, this change makes tests faster due to ignoring the sdist step
and adds Python 3.2, 3.4 and PyPy 3 to build matrix.
