### PR TITLE
Add Note for async workers with Django

### DIFF
--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -42,6 +42,10 @@ Gevent_). Greenlets are an implementation of cooperative multi-threading for
 Python. In general, an application should be able to make use of these worker
 classes with no changes.
 
+Some application servers like Django_ load certain configurations lazily during
+the first request. Asynchronous workers might lead to issues like 527_ if applications
+are not carefully designed.
+
 Tornado Workers
 ---------------
 
@@ -128,3 +132,5 @@ the master process).
 .. _Gevent: http://gevent.org
 .. _Slowloris: http://ha.ckers.org/slowloris/
 .. _aiohttp: https://github.com/KeepSafe/aiohttp
+.. _527: https://github.com/benoitc/gunicorn/issues/527
+.. _Django: https://www.djangoproject.com/


### PR DESCRIPTION
Django lazy loads URLConf during the first request. As mentioned in issue https://github.com/benoitc/gunicorn/issues/527 this might lead to certain inconsistencies during the first request for a worker.
