### PR TITLE
propagate proxy_protocol_info to keep-alive requests correctly, fix #923

### DIFF
--- a/gunicorn/workers/async.py
+++ b/gunicorn/workers/async.py
@@ -38,14 +38,17 @@ class AsyncWorker(base.Worker):
                     self.handle_request(listener_name, req, client, addr)
                 else:
                     # keepalive loop
-                    proxy_protocol_info = req.proxy_protocol_info
+                    proxy_protocol_info = {}
                     while True:
                         req = None
                         with self.timeout_ctx():
                             req = six.next(parser)
                         if not req:
                             break
-                        req.proxy_protocol_info = proxy_protocol_info
+                        if req.proxy_protocol_info:
+                            proxy_protocol_info = req.proxy_protocol_info
+                        else:
+                            req.proxy_protocol_info = proxy_protocol_info
                         self.handle_request(listener_name, req, client, addr)
             except http.errors.NoMoreData as e:
                 self.log.debug("Ignored premature client disconnection. %s", e)


### PR DESCRIPTION
Fix #923 introduced by pull request https://github.com/benoitc/gunicorn/pull/900 when fixing #899.

I don't have a proxy-protocol enabled proxy currently, so I can't test this now..
