### PR TITLE
Feature/921 ignore async handle request socket error

### DIFF
--- a/gunicorn/workers/async.py
+++ b/gunicorn/workers/async.py
@@ -120,8 +120,8 @@ class AsyncWorker(base.Worker):
             raise
         except socket.error:
             # If the original exception was a socket.error we delegate
-            # handling it to the caller (where handle() might ignore it).
-            raise
+            # handling it to the caller (where handle() might ignore it 
+            six.reraise(*sys.exc_info())
         except Exception:
             if resp and resp.headers_sent:
                 # If the requests have already been sent, we should close the


### PR DESCRIPTION
after testing and discussion on our side [see release/19.1.1+laterpay2](https://github.com/laterpay/gunicorn/pull/2), this seems to be the right fix for benoitc/gunicorn#921.

I first tried to implement @tilgovi's suggestion in laterpay/gunicorn@301c3fdfadf402935c8ca599b17bf1802ebe6a8e but that lead to the stacktrace detailed in [this comment](https://github.com/laterpay/gunicorn/pull/2#issuecomment-61808305). The patch in this PR leads to no more logged errors on our servers, but somebody more familiar with gunicorn internals should definitely see whether there are unhandled edge cases.

(CC @doismellburning fyi)
