### PR TITLE
Use `sent` instead of `response_length` in access log formatter

### DIFF
--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -240,7 +240,7 @@ class Logger(object):
             'r': "%s %s %s" % (environ['REQUEST_METHOD'],
                 environ['RAW_URI'], environ["SERVER_PROTOCOL"]),
             's': status,
-            'b': resp.response_length and str(resp.response_length) or '-',
+            'b': resp.sent and str(resp.sent) or '-',
             'f': environ.get('HTTP_REFERER', '-'),
             'a': environ.get('HTTP_USER_AGENT', '-'),
             'T': request_time.seconds,


### PR DESCRIPTION
Currently, `resp.response_length` is used for the b atom of the access log formatter. If the application does not set a content-length header, `resp.response_length` is `None`, resulting in the b atom being set to the fallback "-".

`resp.sent` is a more reliable way to determine the number of bytes actually included in the response body, which seems to more closely match the description of %b at http://httpd.apache.org/docs/2.0/logs.html#combined
