### PR TITLE
Set logconfig default to paster more trivially

### DIFF
--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -199,8 +199,11 @@ class Logger(object):
 
         if cfg.logconfig:
             if os.path.exists(cfg.logconfig):
-                fileConfig(cfg.logconfig, defaults=CONFIG_DEFAULTS,
-                        disable_existing_loggers=False)
+                defaults = CONFIG_DEFAULTS.copy()
+                defaults['__file__'] = cfg.logconfig
+                defaults['here'] = os.path.dirname(cfg.logconfig)
+                fileConfig(cfg.logconfig, defaults=defaults,
+                           disable_existing_loggers=False)
             else:
                 msg = "Error: log config '%s' not found"
                 raise RuntimeError(msg % cfg.logconfig)


### PR DESCRIPTION
Rather than using fileConfig twice and risking different defaults
and behavior around disable_existing_loggers (ref #902), simply
set the default logging config file to be the paster config file
if it has a logger section and let glogging set up the rest.
