### PR TITLE
Fixed typos/copyediting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,8 @@ Or from PyPI::
 
 You may also want to install Eventlet_ or Gevent_ if you expect that your
 application code may need to pause for extended periods of time during
-request processing. If you're on Python 3 you may also consider one othe Asyncio_ workers. Check out the FAQ_ for more information on when you'll
+request processing. If you're on Python 3 you may also consider one of
+the Asyncio_ workers. Check out the FAQ_ for more information on when you'll
 want to consider one of the alternate worker types.
 
 To install eventlet::

--- a/docs/source/2014-news.rst
+++ b/docs/source/2014-news.rst
@@ -32,10 +32,9 @@ Core
 Logging
 +++++++
 
-- fix  `#838 <https://github.com/benoitc/gunicorn/issues/838>`_: statsd logegr, send statsd timing metrics in milliseconds
+- fix  `#838 <https://github.com/benoitc/gunicorn/issues/838>`_: statsd logger, send statsd timing metrics in milliseconds
 - fix `#839 <https://github.com/benoitc/gunicorn/issues/839>`_: statsd logger,  allows for empty log message while pushing metrics and restore worker number in DEBUG logs
-- fix  `#850 <https://github.com/benoitc/gunicorn/issues/850>`_: add
-  timezonw to logging
+- fix  `#850 <https://github.com/benoitc/gunicorn/issues/850>`_: add timezone to logging
 - fix `#853 <https://github.com/benoitc/gunicorn/issues/853>`_: Respect logger_class setting unless statsd is on
 
 AioHttp worker
@@ -186,7 +185,7 @@ core
 - fix logging: don't try to redirect stdout/stderr to the logfile.
 - fix logging: don't propagate log
 - improve logging: file option can be overriden by the gunicorn options `--error-logfile` and `--access-logfile` if they are given.
-- fix: dont' override SERVER_* by the Host header
+- fix: don't override SERVER_* by the Host header
 - fix: handle_error
 - add more option to configure SSL
 - fix: sendfile with SSL
@@ -214,7 +213,7 @@ gevent worker
 - fix: "global name 'hub' is not defined"
 - fix: reinit `hub` on old versions of gevent
 - support gevent 1.0
-- fix: add subprocess in monket patching
+- fix: add subprocess in monkey patching
 - fix: add support for multiple listener
 
 eventlet worker
@@ -227,4 +226,4 @@ eventlet worker
 tornado worker
 ++++++++++++++
 
-- add gracefull stop support
+- add graceful stop support

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -88,7 +88,7 @@ Does Gunicorn suffer from the thundering herd problem?
 The thundering herd problem occurs when many sleeping request handlers, which
 may be either threads or processes, wake up at the same time to handle a new
 request. Since only one handler will receive the request, the others will have
-been awakened for no reaon, wasting CPU cycles. At this time, Gunicorn does not
+been awakened for no reason, wasting CPU cycles. At this time, Gunicorn does not
 implement any IPC solution for coordinating between worker processes. You may
 experience high load due to this problem when using many workers or threads.
 However `a work has been started <https://github.com/benoitc/gunicorn/issues/792>`_

--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -192,7 +192,7 @@ core
 - fix logging: don't propagate log
 - improve logging: file option can be overriden by the gunicorn options
   `--error-logfile` and `--access-logfile` if they are given.
-- fix: dont' override SERVER_* by the Host header
+- fix: don't override SERVER_* by the Host header
 - fix: handle_error
 - add more option to configure SSL
 - fix: sendfile with SSL
@@ -220,7 +220,7 @@ gevent worker
 - fix: "global name 'hub' is not defined"
 - fix: reinit `hub` on old versions of gevent
 - support gevent 1.0
-- fix: add subprocess in monket patching
+- fix: add subprocess in monkey patching
 - fix: add support for multiple listener
 
 eventlet worker
@@ -233,7 +233,7 @@ eventlet worker
 tornado worker
 ++++++++++++++
 
-- add gracefull stop support
+- add graceful stop support
 
 18.0 / 2013-08-26
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -275,7 +275,7 @@ check_config
 * ``--check-config``
 * ``False``
 
-Check the configuration..
+Check the configuration.
 
 Server Mechanics
 ----------------
@@ -564,7 +564,7 @@ syslog_prefix
 * ``--log-syslog-prefix SYSLOG_PREFIX``
 * ``None``
 
-makes gunicorn use the parameter as program-name in the syslog entries.
+Makes gunicorn use the parameter as program-name in the syslog entries.
 
 All entries will be prefixed by gunicorn.<prefix>. By default the program
 name is the name of the process.
@@ -759,7 +759,7 @@ worker_abort
 
 Called when a worker received the SIGABRT signal.
 
-This call generally happen on timeout.
+This call generally happens on timeout.
 
 The callable needs to accept one instance variable for the initialized
 Worker.
@@ -854,8 +854,8 @@ proxy_protocol
 
 Enable detect PROXY protocol (PROXY mode).
 
-Allow using Http and Proxy together. It's may be useful for work with
-stunnel as https frondend and gunicorn as http server.
+Allow using Http and Proxy together. It may be useful for work with
+stunnel as https frontend and gunicorn as http server.
 
 PROXY protocol: http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt
 
@@ -964,5 +964,5 @@ statsd_prefix
 * ``--statsd-prefix STATSD_PREFIX``
 * ````
 
-prefix to use when emitting statsd metrics (a trailing . is added, if not provided)
+Prefix to use when emitting statsd metrics (a trailing . is added, if not provided)
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -796,7 +796,7 @@ class ConfigCheck(Setting):
     action = "store_true"
     default = False
     desc = """\
-        Check the configuration..
+        Check the configuration.
         """
 
 
@@ -1179,7 +1179,7 @@ class SyslogPrefix(Setting):
     validator = validate_string
     default = None
     desc = """\
-    makes gunicorn use the parameter as program-name in the syslog entries.
+    Makes gunicorn use the parameter as program-name in the syslog entries.
 
     All entries will be prefixed by gunicorn.<prefix>. By default the program
     name is the name of the process.
@@ -1423,7 +1423,7 @@ class WorkerAbort(Setting):
     desc = """\
         Called when a worker received the SIGABRT signal.
 
-        This call generally happen on timeout.
+        This call generally happens on timeout.
 
         The callable needs to accept one instance variable for the initialized
         Worker.
@@ -1542,8 +1542,8 @@ class ProxyProtocol(Setting):
     desc = """\
         Enable detect PROXY protocol (PROXY mode).
 
-        Allow using Http and Proxy together. It's may be useful for work with
-        stunnel as https frondend and gunicorn as http server.
+        Allow using Http and Proxy together. It may be useful for work with
+        stunnel as https frontend and gunicorn as http server.
 
         PROXY protocol: http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt
 
@@ -1680,5 +1680,5 @@ class StatsdPrefix(Setting):
     default = ""
     validator = validate_string
     desc = """\
-    prefix to use when emitting statsd metrics (a trailing . is added, if not provided)
+    Prefix to use when emitting statsd metrics (a trailing . is added, if not provided)
     """


### PR DESCRIPTION
Fixed minor typos and copyediting errors in documentation and docstrings.

Affected files:
- README.rst
- docs/source/news.rst
- docs/source/2014-news.rst
- docs/source/faq.rst
- docs/source/settings.rst
- gunicorn/config.py

Possible errors left uncorrected in gunicorn/config.py (and docs/source/settings.rst):
- an incomplete sentence in the description of LimitRequestFieldSize 
- ambiguous phrasing in the description of ForwardedAllowIPS
- ambiguous phrasing in the description of ProxyAllowFrom
