### PR TITLE
Added missing import for `platform` in tests/support.py for os x.

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -1,6 +1,7 @@
 import functools
 import sys
 import unittest
+import platform
 
 HOST = "127.0.0.1"
 


### PR DESCRIPTION
`platform` was not included in `test/support.py`, leading to the following errors in OS X:

```
args = (<test_selectors.PollSelectorTestCase testMethod=test_above_fd_setsize>,), kw = {}

    @functools.wraps(func)
    def wrapper(*args, **kw):
        if sys.platform == 'darwin':
>           version_txt = platform.mac_ver()[0]
E           NameError: name 'platform' is not defined

tests/support.py:19: NameError
```
