### PR TITLE
Clarify concurrent.futures requirement error message

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -31,8 +31,8 @@ try:
     import concurrent.futures as futures
 except ImportError:
     raise RuntimeError("""
-    You need 'concurrent.futures' (PyPI: futures) installed to use this worker
-    with this python version.
+    You need to install the 'futures' package to use this worker with this
+    Python version.
     """)
 
 try:


### PR DESCRIPTION
Specify which PyPI package needs to be installed in order for the gthread worker implementation to work on Python < 3.2.
