### PR TITLE
Send SIGQUIT once when stopping ungracefully.

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -344,13 +344,15 @@ class Arbiter(object):
         killed gracefully  (ie. trying to wait for the current connection)
         """
         self.LISTENERS = []
-        sig = signal.SIGTERM
-        if not graceful:
-            sig = signal.SIGQUIT
-        limit = time.time() + self.cfg.graceful_timeout
-        while self.WORKERS and time.time() < limit:
-            self.kill_workers(sig)
+        if graceful:
+          limit = time.time() + self.cfg.graceful_timeout
+          while self.WORKERS and time.time() < limit:
+            self.kill_workers(signal.SIGTERM)
             time.sleep(0.1)
+        else:
+          self.kill_workers(signal.SIGQUIT)
+          time.sleep(0.1)
+
         self.kill_workers(signal.SIGKILL)
 
     def reexec(self):


### PR DESCRIPTION
Sending SIGQUIT multiple times to child processes can trigger issue #14173
when running in python < 2.7.5.

Fixes #655
