### PR TITLE
on reload don't raise SystemExit

### DIFF
--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -86,8 +86,8 @@ class Worker(object):
         if self.cfg.reload:
             def changed(fname):
                 self.log.info("Worker reloading: %s modified", fname)
-                os.kill(self.pid, signal.SIGQUIT)
-                raise SystemExit()
+                self.alive = False
+                os._exit(0)
             Reloader(callback=changed).start()
 
         # set environment' variables


### PR DESCRIPTION
With this change on reload we now tell the worker to exit from the run loop
and just exit without calling cleanup handlers using os._exit

fix #910
