### PR TITLE
Let the reloader kill the worker by signal only

### DIFF
--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -87,7 +87,6 @@ class Worker(object):
             def changed(fname):
                 self.log.info("Worker reloading: %s modified", fname)
                 os.kill(self.pid, signal.SIGQUIT)
-                raise SystemExit()
             Reloader(callback=changed).start()
 
         # set environment' variables


### PR DESCRIPTION
There is no reason to raise a `SystemExit` because the reloader thread
will die when the worker exits anyway. Having this exception can cause
tracebacks during interpreter shutdown (#910).

Close #910
