### PR TITLE
Close existing sockets in master process when stopping.

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -389,7 +389,8 @@ class Arbiter(object):
         # do we need to change listener ?
         if old_address != self.cfg.address:
             # close all listeners
-            [l.close() for l in self.LISTENERS]
+            for l in self.LISTENERS:
+                l.close()
             # init new listeners
             self.LISTENERS = create_sockets(self.cfg, self.log)
             self.log.info("Listening at: %s", ",".join(str(self.LISTENERS)))

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -326,6 +326,8 @@ class Arbiter(object):
         :attr graceful: boolean, If True (the default) workers will be
         killed gracefully  (ie. trying to wait for the current connection)
         """
+        for l in self.LISTENERS:
+            l.close()
         self.LISTENERS = []
         sig = signal.SIGTERM
         if not graceful:


### PR DESCRIPTION
Previously, when `gunicorn` is told to restart, it'll signal
workers to stop listening for new connections. But listening
ports are still open in master process. This lets load balancer,
such as haproxy, think that this server is still up and dispatch
requests to this server. But because all workers have stopped
accepting new connections. New requests will block until timeout.
This is especially severe when conducting a restart in a setup with
long graceful-timeout setting, causing many requests to timeout.

This patch fix that by closing all `LISTENERS` in `stop` method of
`Arbitor`.