### PR TITLE
stop to accept more requests when maximum accepted is achieved

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -194,6 +194,9 @@ class ThreadWorker(base.Worker):
                     callback = key.data
                     callback(key.fileobj)
 
+            if not self.is_parent_alive():
+                break
+
             # hanle keepalive timeouts
             self.murder_keepalived()
 


### PR DESCRIPTION
this change makes sure that a worker don't handle more requests than it can achieved.  The new workflow is quite more simple:

1. listeners are put in the poller. On read we try to accept on them.
2. When a connection is accepted it is put in the execution queue
3. When a request is done and the socket can be kept alived, we put it in the poller, on read event we will try to handle the new request. 
4. If it is not put out of the poller before the keepalive timeout the socket will be closed.
5. if all threads are busy we are waiting until one request complet. If it doesn't complete before the timeout we kill the worker.

fix #908