### PR TITLE
Fixed broken link to gafferctl in docs

### DIFF
--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -159,7 +159,7 @@ used to monitor gunicorn. A simple configuration is::
     cmd = gunicorn -w 3 test:app
     cwd = /path/to/project
 
-Then you can easily manage Gunicorn using `gafferctl <http://gaffer.readthedocs.org/en/latest/gafferctl.html>`_.
+Then you can easily manage Gunicorn using `gafferctl <http://gaffer.readthedocs.org/en/latest/getting-started.html#control-gafferd-with-gafferctl>`_.
 
 
 Using a Procfile


### PR DESCRIPTION
The gafferctl page was removed from the docs in benoitc/gaffer@00a4f629b0. This is the best replacement url I could find.