### PR TITLE
Fix import error for django 1.7

### DIFF
--- a/gunicorn/app/django_wsgi.py
+++ b/gunicorn/app/django_wsgi.py
@@ -18,7 +18,6 @@ except:
 
 
 from django.conf import settings
-from django.core.management.validation import get_validation_errors
 from django.utils import translation
 
 try:
@@ -34,13 +33,13 @@ from gunicorn import util
 def make_wsgi_application():
     # validate models
     s = StringIO()
-    if get_validation_errors(s):
-        s.seek(0)
-        error = s.read()
-        msg = "One or more models did not validate:\n%s" % error
-        print(msg, file=sys.stderr)
-        sys.stderr.flush()
-        sys.exit(1)
+    import django
+    from django.core.management.base import BaseCommand
+    django.setup()
+    cmd = BaseCommand()
+    import sys
+    cmd.stdout, cmd.stderr = sys.stdout, sys.stderr
+    cmd.check()
 
     translation.activate(settings.LANGUAGE_CODE)
     if django14:


### PR DESCRIPTION
This is the fix for import error 'No module named django.core.management.validation'

Original post: http://www.snip2code.com/Snippet/81958/Possible-fix-to-gunicorn-s-Django-1-7-bu