### PR TITLE
increase hard limit for headers

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -19,7 +19,7 @@ from gunicorn.six.moves.urllib.parse import urlsplit
 
 MAX_REQUEST_LINE = 8190
 MAX_HEADERS = 32768
-MAX_HEADERFIELD_SIZE = 8190
+MAX_HEADERFIELD_SIZE = 16384
 
 HEADER_RE = re.compile("[\x00-\x1F\x7F()<>@,;:\[\]={} \t\\\\\"]")
 METH_RE = re.compile(r"[A-Z0-9$-_.]{3,20}")


### PR DESCRIPTION
Kerberos tickets can be greater than 8190 bytes. This can occur when the ticket comes from Active Directory for a user who is a member of many groups. If the ticket is used as the value for the Authorization header, it will be rejected by gunicorn.
Authorization: Negotiate YIIYkAYGKwYBBQUCoIIYhDCCGICgMDAuBgkqhkiC9xIBAgIGCSqGSIb3EgECAg.....<another ~8500 bytes>
causes a 400 Bad Request, with Error parsing headers: 'limit request headers fields size'.
Workaround is to set --limit-request-field_size=0, but this disables that header checking functionality completely. 

I note that my solution also increases the default value. You may want to alter your code to retain 8190 as the default but allow the setting to set a value higher.

Also note that Microsoft have an IIS setting for similar reasons, and it can go to 64k max. see http://support.microsoft.com/kb/2020943
