### PR TITLE
HEAD requests must not have body

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -322,6 +322,11 @@ class Response(object):
 
     def write(self, arg):
         self.send_headers()
+
+        if self.req.method == "HEAD":
+            # HEAD request must not have body
+            return
+
         if not isinstance(arg, binary_type):
             raise TypeError('%r is not a byte' % arg)
         arglen = len(arg)


### PR DESCRIPTION
The HTTP/1.1 specification states that: 'The HEAD method is identical to GET except that the server MUST NOT return a message-body in the response.'
(http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html)

Gunicorn currently does not comply with that as it sends a "0" in the body as the terminating chunk. This can be easily shown by a curl command against the echo:app example:

```
curl -v -I http://127.0.0.1:8000
* Rebuilt URL to: http://127.0.0.1:8000/
* Hostname was NOT found in DNS cache
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
> HEAD / HTTP/1.1
> User-Agent: curl/7.37.1
> Host: 127.0.0.1:8000
> Accept: */*
>
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
* Server gunicorn/19.2.1 is not blacklisted
< Server: gunicorn/19.2.1
Server: gunicorn/19.2.1
< Date: Fri, 27 Feb 2015 11:22:17 GMT
Date: Fri, 27 Feb 2015 11:22:17 GMT
< Connection: close
Connection: close
< Content-type: text/plain
Content-type: text/plain
< Content-Length: 14
Content-Length: 14
< X-Gunicorn-Version: 19.2.1
X-Gunicorn-Version: 19.2.1
< Test: test тест
Test: test тест

<
* Excess found in a non pipelined read: excess = 14 url = / (zero-length body)
* Closing connection 0
```

Note the line: "* Excess found in a non pipelined read: excess = 14 url = / (zero-length body)"

With my proposed fix the same curl command does not show the above warning.

I've found this issue when the nodejs http parser failed on paring gunicorn's responses on HEAD requests.