### PR TITLE
reloader should survive SyntaxError

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -541,6 +541,6 @@ def make_fail_app(msg):
             ("Content-Type", "text/plain"),
             ("Content-Length", str(len(msg)))
         ])
-        return iter([msg])
+        return [msg]
 
     return app

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -532,3 +532,15 @@ def warn(msg):
 
     print("!!!\n", file=sys.stderr)
     sys.stderr.flush()
+
+
+def make_fail_app(msg):
+
+    def app(environ, start_response):
+        start_response("500 Internal Server Error", [
+            ("Content-Type", "text/plain"),
+            ("Content-Length", str(len(msg)))
+        ])
+        return iter([msg])
+
+    return app

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -117,6 +117,15 @@ class Worker(object):
 
         self.init_signals()
 
+        self.cfg.post_worker_init(self)
+
+        self.load_wsgi()
+
+        # Enter main run loop
+        self.booted = True
+        self.run()
+
+    def load_wsgi(self):
         try:
             self.wsgi = self.app.wsgi()
         except SyntaxError as e:
@@ -130,12 +139,6 @@ class Worker(object):
 
             tb_string = traceback.format_exc(exc_tb)
             self.wsgi = util.make_fail_app(tb_string)
-
-        self.cfg.post_worker_init(self)
-
-        # Enter main run loop
-        self.booted = True
-        self.run()
 
     def init_signals(self):
         # reset signaling

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -120,7 +120,7 @@ class Worker(object):
         try:
             self.wsgi = self.app.wsgi()
         except SyntaxError as e:
-            if not self.reloader:
+            if not self.cfg.reload:
                 raise
 
             self.log.exception(e)


### PR DESCRIPTION
This implements the feature requested in issue #964.

When there is `SyntaxError` raised while importing the app, provides a fallback app to display those errors instead of completely exit gunicorn.