### PR TITLE
subclass Exception replace BaseException

### DIFF
--- a/gunicorn/errors.py
+++ b/gunicorn/errors.py
@@ -4,7 +4,7 @@
 # See the NOTICE for more information.
 
 
-class HaltServer(BaseException):
+class HaltServer(Exception):
     def __init__(self, reason, exit_status=1):
         self.reason = reason
         self.exit_status = exit_status
@@ -13,7 +13,7 @@ class HaltServer(BaseException):
         return "<HaltServer %r %d>" % (self.reason, self.exit_status)
 
 
-class ConfigError(BaseException):
+class ConfigError(Exception):
     """ Exception raised on config error """
 
 


### PR DESCRIPTION
All user-defined exceptions should also be derived from Exception
https://docs.python.org/3/library/exceptions.html?highlight=baseexception#base-classes