### PR TITLE
Retry socket binding up to five times upon EADDRNOTAVAIL.

### DIFF
--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -214,7 +214,6 @@ def create_sockets(conf, log):
                     log.error("Connection in use: %s", str(addr))
                 if e.args[0] == errno.EADDRNOTAVAIL:
                     log.error("Invalid address: %s", str(addr))
-                    sys.exit(1)
                 if i < 5:
                     log.error("Retrying in 1 second.")
                     time.sleep(1)


### PR DESCRIPTION
I'm using gunicorn in an embedded virtual networking application, and it's not uncommon for the bind address to take a few moments to actually be added to the interface.  Given that other socket binding failures in this method lead to a retry loop, it seems reasonable that this one would as well?