### PR TITLE
Fix statsd Logging in Python 3

### DIFF
--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -224,8 +224,8 @@ class Logger(object):
     def debug(self, msg, *args, **kwargs):
         self.error_log.debug(msg, *args, **kwargs)
 
-    def exception(self, msg, *args):
-        self.error_log.exception(msg, *args)
+    def exception(self, msg, *args, **kwargs):
+        self.error_log.exception(msg, *args, **kwargs)
 
     def log(self, lvl, msg, *args, **kwargs):
         if isinstance(lvl, string_types):


### PR DESCRIPTION
`statsd` logging appears to be (silently) broken in Python 3, because it passes it passes `unicode` (i.e. not `bytes`) to the `sock.send` method.

This PR:

  + Ensures `bytes` are used
  + Adds tests that actually go through an actual (UNIX) socket to ensure those errors can be caught in uni testing in the future.
  + Logs `statsd` errors as warnings (the exceptions being silently swallowed made them difficult to troubleshoot)