### PR TITLE
notify systemd about main pid

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -9,6 +9,7 @@ import os
 import random
 import select
 import signal
+import socket
 import sys
 import time
 import traceback
@@ -123,6 +124,14 @@ class Arbiter(object):
         if self.cfg.pidfile is not None:
             self.pidfile = Pidfile(self.cfg.pidfile)
             self.pidfile.create(self.pid)
+
+        notify_socket = os.environ.get("NOTIFY_SOCKET", None)
+        if notify_socket and notify_socket[0] in ("@", "/"):
+            if notify_socket[0] == "@":
+                notify_socket = "\0" + notify_socket[1:]
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+            sock.sendto("MAINPID=%s\n" % self.pid, notify_socket)
+
         self.cfg.on_starting(self)
 
         self.init_signals()

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -129,8 +129,13 @@ class Arbiter(object):
         if notify_socket and notify_socket[0] in ("@", "/"):
             if notify_socket[0] == "@":
                 notify_socket = "\0" + notify_socket[1:]
-            sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-            sock.sendto("MAINPID=%s\n" % self.pid, notify_socket)
+            try:
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+                sock.sendto("MAINPID=%s\n" % self.pid, notify_socket)
+            except:
+                pass
+            finally:
+                sock.close()
 
         self.cfg.on_starting(self)
 


### PR DESCRIPTION
Send notification to systemd about the new master pid.

It's required when re-execing gunicorn (using `ExecReload=/bin/kill -SIGUSR2 $MAINPID`). systemd gets confused about the main pid when the previous master is still alive finishing requests and scheduling next reload.