### PR TITLE
Fix argument to disable sendfile

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -828,6 +828,8 @@ class Sendfile(Setting):
         Disables the use of ``sendfile()``.
 
         .. versionadded:: 19.2
+        .. versionchanged:: 19.4
+            Swapped --sendfile with --no-sendfile to actually allow disabling
         """
 
 class Chdir(Setting):

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -820,12 +820,12 @@ class PreloadApp(Setting):
 class Sendfile(Setting):
     name = "sendfile"
     section = "Server Mechanics"
-    cli = ["--sendfile"]
+    cli = ["--no-sendfile"]
     validator = validate_bool
-    action = "store_true"
+    action = "store_false"
     default = True
     desc = """\
-        Enables or disables the use of ``sendfile()``.
+        Disables the use of ``sendfile()``.
 
         .. versionadded:: 19.2
         """


### PR DESCRIPTION
The --sendfile parameter which is supposed to allow disabling use of sendfile doesn't actually accomplish that. Here we replace with --no-sendfile which works as expected.

Fix #856 for realz.