### PR TITLE
design.rst: grammar

### DIFF
--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -5,7 +5,7 @@
 Design
 ======
 
-A brief description of an architecture of Gunicorn.
+A brief description of the architecture of Gunicorn.
 
 Server Model
 ============


### PR DESCRIPTION
Currently, we introduce this document as a description
of "an" architecture of Gunicorn, which makes it sound
like this document describes one of many Gunicorn
architectures, which doesn't make a lot of sense.

Clarify the grammar by introducing the document as a
description of "the" Gunicorn architecture.