### PR TITLE
empty ACCEPT header support

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -88,7 +88,8 @@ def default_environ(req, sock, cfg):
         "REQUEST_METHOD": req.method,
         "QUERY_STRING": req.query,
         "RAW_URI": req.uri,
-        "SERVER_PROTOCOL": "HTTP/%s" % ".".join([str(v) for v in req.version])
+        "SERVER_PROTOCOL": "HTTP/%s" % ".".join([str(v) for v in req.version]),
+        "HTTP_ACCEPT": "*/*"
     })
     return env
 
@@ -144,6 +145,9 @@ def create(req, sock, client, server, cfg):
             continue
         elif hdr_name == "CONTENT-LENGTH":
             environ['CONTENT_LENGTH'] = hdr_value
+            continue
+        elif hdr_name == "ACCEPT":
+            environ['ACCEPT'] = hdr_value
             continue
 
         key = 'HTTP_' + hdr_name.replace('-', '_')


### PR DESCRIPTION
Some of our legacy clients stopped working ffter we upgraded from _18.0_ to _19.3_.
As we find out, the reason was they were sending an empty `Accept` header. 
Some authors recommend replacing treating empty `Accept:` as `Accept: */*`([link](http://stackoverflow.com/questions/12130910/how-to-interpret-empty-http-accept-header)).
This fix is treating `Accept:` as `Accept: */*`.

**Before**:

    curl -i 'https://host.example.com/' -H 'Accept:'

>HTTP/1.1 500 Internal Server Error UNKNOWN STATUS CODE
>Server: nginx/1.8.0
>Date: Thu, 28 May 2015 14:56:20 GMT
>Content-Type: text/html; charset=utf-8
>Transfer-Encoding: chunked
>Connection: keep-alive

log:
>2015-05-28 07:56:20 +0000] [19480] [ERROR] Error handling request
>Traceback (most recent call last):
>  File ".../env/local/lib/python2.7/site-packages/gunicorn/workers/sync.py", line 177, in handle_request
>    resp.write(item)
>  File ".../env/local/lib/python2.7/site-packages/gunicorn/http/wsgi.py", line 326, in write
>    raise TypeError('%r is not a byte' % arg)
>TypeError: u'The server has either erred or is incapable of performing\r\nthe requested operation.\r\n<br><br>\nNone\nNone' is not a byte

**After**:

    curl -i 'http://127.0.0.1:8000' -H 'Accept:' 

>HTTP/1.1 302 FOUND
>Server: gunicorn/19.3.0
>Date: Fri, 29 May 2015 04:22:28 GMT
>Connection: close
>Transfer-Encoding: chunked
>Vary: Cookie
>Content-Type: text/html; charset=utf-8
>Location: http://127.0.0.1:8000/user/login/?next=/

    curl -i 'http://127.0.0.1:8000' -H 'Accept: */*' 

>HTTP/1.1 302 FOUND
>Server: gunicorn/19.3.0
>Date: Fri, 29 May 2015 04:22:32 GMT
>Connection: close
>Transfer-Encoding: chunked
>Vary: Cookie
>Content-Type: text/html; charset=utf-8
>Location: http://127.0.0.1:8000/user/login/?next=/