### PR TITLE
Updated gunicorn/pidfile.py

### DIFF
--- a/gunicorn/pidfile.py
+++ b/gunicorn/pidfile.py
@@ -67,11 +67,8 @@ class Pidfile(object):
         try:
             with open(self.fname, "r") as f:
                 try:
-                    wpid = int(f.read())
+                    wpid = int(f.read() or 0)
                 except ValueError:
-                    wpid = 0
-
-                if wpid <= 0:
                     return
 
                 try:

--- a/gunicorn/pidfile.py
+++ b/gunicorn/pidfile.py
@@ -66,7 +66,10 @@ class Pidfile(object):
             return
         try:
             with open(self.fname, "r") as f:
-                wpid = int(f.read() or 0)
+                try:
+                    wpid = int(f.read())
+                except ValueError:
+                    wpid = 0
 
                 if wpid <= 0:
                     return

--- a/gunicorn/pidfile.py
+++ b/gunicorn/pidfile.py
@@ -67,7 +67,7 @@ class Pidfile(object):
         try:
             with open(self.fname, "r") as f:
                 try:
-                    wpid = int(f.read() or 0)
+                    wpid = int(f.read())
                 except ValueError:
                     return
 


### PR DESCRIPTION
Added a try block to convert the contents of the `pidfile.py` if it can be converted to integer or not. If not, then `wpid` is assigned 0 and the `validate` function returns as usual. If the pidfile has a valid int, the function continues to kill the process as before.