### PR TITLE
add support for gevent on python3

### DIFF
--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -70,8 +70,12 @@ class GeventWorker(AsyncWorker):
         # patch sockets
         sockets = []
         for s in self.sockets:
-            sockets.append(socket(s.FAMILY, _socket.SOCK_STREAM,
-                _sock=s))
+            if sys.version_info[0] == 3:
+                sockets.append(socket(s.FAMILY, _socket.SOCK_STREAM,
+                    fileno=s.sock.fileno()))
+            else:
+                sockets.append(socket(s.FAMILY, _socket.SOCK_STREAM,
+                    _sock=s))
         self.sockets = sockets
 
     def notify(self):


### PR DESCRIPTION
In python3 gevent (1.1a1) we have different socket interface, which does not have _sock method.

It's compatible with python standard library socket and have just fileno param.

Here's the socket for python3 code in gevent repo -  https://github.com/gevent/gevent/blob/dedb08cf210ebae1ac059150a05542a10d285926/gevent/_socket3.py#L35