### PR TITLE
New CLI argument --paste-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ examples/frameworks/pylonstest/PasteScript*
 examples/frameworks/pylonstest/pylonstest.egg-info/
 examples/frameworks/django/testing/testdb.sql
 .tox
+.idea

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -419,7 +419,7 @@ temporary directory.
 secure_scheme_headers
 ~~~~~~~~~~~~~~~~~~~~~
 
-* ``{'X-FORWARDED-PROTO': 'https', 'X-FORWARDED-SSL': 'on', 'X-FORWARDED-PROTOCOL': 'ssl'}``
+* ``{'X-FORWARDED-PROTOCOL': 'ssl', 'X-FORWARDED-PROTO': 'https', 'X-FORWARDED-SSL': 'on'}``
 
 A dictionary containing headers and values that the front-end proxy
 uses to indicate HTTPS requests. These tell gunicorn to set
@@ -692,7 +692,7 @@ paste_server
 * ``--paste-server STRING, --paster-server STRING``
 * ``None``
 
-Name of an server section from the config file, if it is different from
+Name of a server section from the config file, if it is different from
 the app name.
 
 Server Hooks

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -316,7 +316,7 @@ chdir
 ~~~~~
 
 * ``--chdir``
-* ``/Users/benoitc/work/gunicorn/py27/gunicorn/docs``
+* ``/home/dm/myprojects/gunicorn/docs``
 
 Chdir to specified directory before apps loading.
 
@@ -369,7 +369,7 @@ user
 ~~~~
 
 * ``-u USER, --user USER``
-* ``501``
+* ``1000``
 
 Switch worker processes to run as this user.
 
@@ -381,7 +381,7 @@ group
 ~~~~~
 
 * ``-g GROUP, --group GROUP``
-* ``20``
+* ``1000``
 
 Switch worker process to run as this group.
 
@@ -419,7 +419,7 @@ temporary directory.
 secure_scheme_headers
 ~~~~~~~~~~~~~~~~~~~~~
 
-* ``{'X-FORWARDED-PROTOCOL': 'ssl', 'X-FORWARDED-PROTO': 'https', 'X-FORWARDED-SSL': 'on'}``
+* ``{'X-FORWARDED-PROTO': 'https', 'X-FORWARDED-SSL': 'on', 'X-FORWARDED-PROTOCOL': 'ssl'}``
 
 A dictionary containing headers and values that the front-end proxy
 uses to indicate HTTPS requests. These tell gunicorn to set
@@ -547,7 +547,7 @@ syslog_addr
 ~~~~~~~~~~~
 
 * ``--log-syslog-to SYSLOG_ADDR``
-* ``unix:///var/run/syslog``
+* ``udp://localhost:514``
 
 Address to send syslog messages.
 
@@ -683,10 +683,17 @@ paste
 
 Load a paste.deploy config file. The argument may contain a "#" symbol
 followed by the name of an app section from the config file, e.g.
-"production.ini#admin".
+"production.ini#admin". Uses this name also for the server section,
+unless you additionally use --paste-server.
 
-At this time, using alternate server blocks is not supported. Use the
-command line arguments to control server configuration instead.
+paste_server
+~~~~~~~~~~~~
+
+* ``--paste-server STRING, --paster-server STRING``
+* ``None``
+
+Name of an server section from the config file, if it is different from
+the app name.
 
 Server Hooks
 ------------

--- a/examples/frameworks/pylonstest/development.ini
+++ b/examples/frameworks/pylonstest/development.ini
@@ -37,6 +37,23 @@ beaker.session.secret = somesecret
 # execute malicious code after an exception is raised.
 #set debug = false
 
+[server:smeagol]
+use = egg:gunicorn#main
+host = 127.0.0.1
+port = 5111
+# Uncomment and replace with a file containing advanced gunicorn configuration
+#config = %(here)/gunicorn.conf.py
+
+[app:smeagol]
+use = egg:smeagolapp
+full_stack = true
+static_files = true
+
+cache_dir = %(here)s/data
+beaker.session.key = pylonstest
+beaker.session.secret = somesecret
+
+
 
 # Logging configuration
 [loggers]

--- a/gunicorn/app/pasterapp.py
+++ b/gunicorn/app/pasterapp.py
@@ -32,7 +32,6 @@ def paste_config(gconfig, config_url, relative_to, global_conf=None):
     sys.path.insert(0, relative_to)
     pkg_resources.working_set.add_entry(relative_to)
 
-    config_url = config_url.split('#')[0]
     cx = loadwsgi.loadcontext(SERVER, config_url, relative_to=relative_to,
                               global_conf=global_conf)
     gc, lc = cx.global_conf.copy(), cx.local_conf.copy()

--- a/gunicorn/app/wsgiapp.py
+++ b/gunicorn/app/wsgiapp.py
@@ -24,12 +24,16 @@ class WSGIApplication(Application):
             if not os.path.exists(path):
                 raise ConfigError("%r not found" % path)
 
-            # paste application, load the config
-            self.cfgurl = 'config:%s#%s' % (path, app_name)
+            srv_name = opts.paste_server \
+                if opts.paste_server and opts.paste_server is not None \
+                else app_name
+            self.cfgurl = 'config:%s#%s' % (path, srv_name)
             self.relpath = os.path.dirname(path)
 
             from .pasterapp import paste_config
-            return paste_config(self.cfg, self.cfgurl, self.relpath)
+            pc = paste_config(self.cfg, self.cfgurl, self.relpath)
+            self.cfgurl = 'config:%s#%s' % (path, app_name)
+            return pc
 
         if len(args) < 1:
             parser.error("No application module specified.")

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1325,10 +1325,21 @@ class Paste(Setting):
     desc = """\
         Load a paste.deploy config file. The argument may contain a "#" symbol
         followed by the name of an app section from the config file, e.g.
-        "production.ini#admin".
+        "production.ini#admin". Uses this name also for the server section,
+        unless you additionally use --paste-server.
+        """
 
-        At this time, using alternate server blocks is not supported. Use the
-        command line arguments to control server configuration instead.
+
+class PasteServer(Setting):
+    name = "paste_server"
+    section = "Server Mechanics"
+    cli = ["--paste-server", "--paster-server"]
+    meta = "STRING"
+    validator = validate_string
+    default = None
+    desc = """\
+        Name of a server section from the config file, if it is different from
+        the app name.
         """
 
 


### PR DESCRIPTION
Added app and server section "smeagol" to `examples/frameworks/pylonstest/development.ini`. Without really installing pylonstest and smeagolapp, we can determine by the log and error messages which server and app is loaded:
- app "main" is "pylonstest", "smeagol" is "smeagolapp"
- server "main" is on port 5000, "smeagol" on port 5111
  (Don't know how to write test cases for this config.)

Try combinations of:

```
--paste development.ini
--paste development.ini#main
--paste development.ini#main --paste-server smeagol
--paste development.ini#smeagol --paste-server main
--paste development.ini#smeagol
```
