### PR TITLE
Only log '[num] workers' message when it changes.

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -51,12 +51,12 @@ class Arbiter(object):
         if name[:3] == "SIG" and name[3] != "_"
     )
 
-    last_logged_worker_count = None
-
     def __init__(self, app):
         os.environ["SERVER_SOFTWARE"] = SERVER_SOFTWARE
 
         self._num_workers = None
+        self._last_logged_active_worker_count = None
+
         self.setup(app)
 
         self.pidfile = None
@@ -485,8 +485,8 @@ class Arbiter(object):
             self.kill_worker(pid, signal.SIGTERM)
 
         active_worker_count = len(workers)
-        if self.last_logged_worker_count != active_worker_count:
-            self.last_logged_worker_count = active_worker_count
+        if self._last_logged_active_worker_count != active_worker_count:
+            self._last_logged_active_worker_count = active_worker_count
             self.log.debug("{0} workers".format(active_worker_count),
                            extra={"metric": "gunicorn.workers",
                                   "value": active_worker_count,

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -473,6 +473,8 @@ class Arbiter(object):
         Maintain the number of workers by spawning or killing
         as required.
         """
+        orig_num_workers = self.num_workers
+
         if len(self.WORKERS.keys()) < self.num_workers:
             self.spawn_workers()
 
@@ -482,10 +484,11 @@ class Arbiter(object):
             (pid, _) = workers.pop(0)
             self.kill_worker(pid, signal.SIGTERM)
 
-        self.log.debug("{0} workers".format(len(workers)),
-                       extra={"metric": "gunicorn.workers",
-                              "value": len(workers),
-                              "mtype": "gauge"})
+        if self.num_workers != orig_num_workers:
+            self.log.debug("{0} workers".format(len(workers)),
+                           extra={"metric": "gunicorn.workers",
+                                  "value": len(workers),
+                                  "mtype": "gauge"})
 
     def spawn_worker(self):
         self.worker_age += 1


### PR DESCRIPTION
Otherwise when debug logging is on, the message prints every second even with no system activity, drowning out more useful log messages:

```
[2015-07-12 17:39:25 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:26 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:27 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:28 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:29 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:30 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:31 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:32 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:33 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:34 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:35 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:36 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:37 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:38 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:39 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:40 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:41 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:42 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:43 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:45 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:46 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:47 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:48 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:49 +0000] [19970] [DEBUG] 3 workers
[2015-07-12 17:39:50 +0000] [19970] [DEBUG] 3 workers
```