### PR TITLE
Ensure response to HEAD request won't have message body

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -230,6 +230,8 @@ class Response(object):
             return True
         if self.response_length is not None or self.chunked:
             return False
+        if self.req.method == 'HEAD':
+            return False
         if self.status_code < 200 or self.status_code in (204, 304):
             return False
         return True
@@ -286,6 +288,9 @@ class Response(object):
         if self.response_length is not None:
             return False
         elif self.req.version <= (1, 0):
+            return False
+        elif self.req.method == 'HEAD':
+            # Responses to a HEAD request MUST NOT contain a response body.
             return False
         elif self.status_code in (204, 304):
             # Do not use chunked responses when the response is guaranteed to


### PR DESCRIPTION
Ensure that Gunicorn won't try to use chunked transfer-encoding for responses
to a HEAD request, so that `Response.close` will not write a terminating
chunk. Responses to a HEAD request MUST NOT have a message-body.

The application is still responsible for ensuring no message body is actually
generated in response to a HEAD request.

Refs #990