### PR TITLE
Clarify pythonpath setting description

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -670,10 +670,10 @@ pythonpath
 * ``--pythonpath STRING``
 * ``None``
 
-A directory to add to the Python path.
+A comma-separated list of directories to add to the Python path.
 
 e.g.
-'/home/djangoprojects/myproject'.
+'/home/djangoprojects/myproject,/home/python/mylibrary'.
 
 paste
 ~~~~~

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1308,10 +1308,10 @@ class PythonPath(Setting):
     validator = validate_string
     default = None
     desc = """\
-        A directory to add to the Python path.
+        A comma-separated list of directories to add to the Python path.
 
         e.g.
-        '/home/djangoprojects/myproject'.
+        '/home/djangoprojects/myproject,/home/python/mylibrary'.
         """
 
 


### PR DESCRIPTION
Show that setting multiple paths requires using a comma-separated list.