### PR TITLE
Remove dead workers immediately after killing.

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -561,4 +561,5 @@ class Arbiter(object):
                 raise
 
         worker = self.WORKERS.pop(pid, None)
-        self.DYING_WORKERS.setdefault(pid, worker)
+        if worker is not None:
+            self.DYING_WORKERS.setdefault(pid, worker)

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -528,10 +528,6 @@ class Arbiter(object):
             sys.exit(-1)
         finally:
             self.log.info("Worker exiting (pid: %s)", worker_pid)
-            try:
-                self.cleanup_worker(worker)
-            except:
-                pass
 
     def spawn_workers(self):
         """\

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -339,7 +339,7 @@ class Arbiter(object):
         # instruct the workers to exit
         self.kill_workers(sig)
         # wait until the graceful timeout
-        while self.WORKERS and time.time() < limit:
+        while (self.WORKERS or self.DYING_WORKERS) and time.time() < limit:
             time.sleep(0.1)
 
         self.kill_workers(signal.SIGKILL)
@@ -425,7 +425,7 @@ class Arbiter(object):
         """
         if not self.timeout:
             return
-        workers = list(self.WORKERS.items())
+        workers = list(self.WORKERS.items() + self.DYING_WORKERS.items())
         for (pid, worker) in workers:
             try:
                 if time.time() - worker.tmp.last_update() <= self.timeout:

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -425,7 +425,7 @@ class Arbiter(object):
         """
         if not self.timeout:
             return
-        workers = list(self.WORKERS.items() + self.DYING_WORKERS.items())
+        workers = list(self.WORKERS.items()) + list(self.DYING_WORKERS.items())
         for (pid, worker) in workers:
             try:
                 if time.time() - worker.tmp.last_update() <= self.timeout:

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -164,7 +164,7 @@ class Arbiter(object):
         [signal.signal(s, self.signal) for s in self.HANDLED_SIGNALS]
 
     def signal(self, sig, frame):
-        if len(self.SIG_QUEUE) < 5:
+        if len(self.SIG_QUEUE) < 256:
             self.SIG_QUEUE.append(sig)
             self.wakeup()
 


### PR DESCRIPTION
This also organizes the shared "worker cleanup" operations like closing `worker.tmp` and calling `self.cfg.worker_exit`.

This means that `self.WORKERS` will always be updated after spawning/killing, and may only be out of sync due to unknown dead processes (handled in `reap_workers`).

This was done based on conversation in #1078. The original suggestion was to maintain a dead worker list ~~but I believe that this is a little simpler and accomplishes the same thing.~~ and I eventually came to the same conclusion.
