### PR TITLE
Fix implicitly shared mutable instance properties.

### DIFF
--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -25,11 +25,8 @@ from gunicorn.six import MAXSIZE
 
 
 class Worker(object):
-
     SIGNALS = [getattr(signal, "SIG%s" % x)
-            for x in "ABRT HUP QUIT INT TERM USR1 USR2 WINCH CHLD".split()]
-
-    PIPE = []
+               for x in "ABRT HUP QUIT INT TERM USR1 USR2 WINCH CHLD".split()]
 
     def __init__(self, age, ppid, sockets, app, timeout, cfg, log):
         """\
@@ -46,6 +43,7 @@ class Worker(object):
         self.booted = False
         self.aborted = False
         self.reloader = None
+        self.pipe = None
 
         self.nr = 0
         jitter = randint(0, cfg.max_requests_jitter)
@@ -104,8 +102,8 @@ class Worker(object):
         util.seed()
 
         # For waking ourselves up
-        self.PIPE = os.pipe()
-        for p in self.PIPE:
+        self.pipe = os.pipe()
+        for p in self.pipe:
             util.set_non_blocking(p)
             util.close_on_exec(p)
 

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -32,7 +32,7 @@ class SyncWorker(base.Worker):
     def wait(self, timeout):
         try:
             self.notify()
-            ret = select.select(self.sockets, [], self.PIPE, timeout)
+            ret = select.select(self.sockets, [], self.pipe, timeout)
             if ret[0]:
                 return ret[0]
 


### PR DESCRIPTION
Several properties in `Arbiter` and other classes were actually mutable class properties masquerading as instance properties.

Note that because `Arbiter` is bound to a single PID, you would never expect to have multiple instances of it anyway. But that is not enforced so either way there is some weirdness here in that case, and it looked like the code was doing this unaware.

If it were desired (for example, to support unit testing),  there are a few other things preventing multiple Arbiter instances operating correctly in the same process:
1. The PID file.
2. The signal handlers.
3. The use of `sys.exit`.
