### PR TITLE
don't close the unix socket when the worker exit

### DIFF
--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -57,7 +57,6 @@ class BaseSocket(object):
             self.sock.close()
         except socket.error as e:
             self.log.info("Error while closing socket %s", str(e))
-        time.sleep(0.3)
         del self.sock
 
 
@@ -104,6 +103,7 @@ class UnixSocket(BaseSocket):
                     os.remove(addr)
                 else:
                     raise ValueError("%r is not a socket" % addr)
+        self.parent = os.getpid()
         super(UnixSocket, self).__init__(addr, conf, log, fd=fd)
 
     def __str__(self):
@@ -118,7 +118,8 @@ class UnixSocket(BaseSocket):
 
     def close(self):
         super(UnixSocket, self).close()
-        os.unlink(self.cfg_addr)
+        if self.parent == os.getpid():
+            os.unlink(self.cfg_addr)
 
 
 def _sock_type(addr):


### PR DESCRIPTION
When the worker was exiting, eventlet is closing the listening socket in th
worker. Since the socket instances are shared, this was also removing the unix
socket on close. This change make sure that the socket can only be closed by
its parent (where the socket have been bound).

While I'm here, also make sure we don't use any blocking function in eventlet
while switching).

fix #965