### PR TITLE
Add SSL support to gaiohttp worker

### DIFF
--- a/docs/source/run.rst
+++ b/docs/source/run.rst
@@ -57,7 +57,7 @@ Commonly Used Arguments
   Check the :ref:`faq` for ideas on tuning this parameter.
 * ``-k WORKERCLASS, --worker-class=WORKERCLASS`` - The type of worker process
   to run. You'll definitely want to read the production page for the
-  implications of this parameter. You can set this to ``egg:gunicorn#$(NAME)``
+  implications of this parameter. You can set this to ``$(NAME)``
   where ``$(NAME)`` is one of ``sync``, ``eventlet``, ``gevent``, or
   ``tornado``, ``gthread``, ``gaiohttp``. ``sync`` is the default.
 * ``-n APP_NAME, --name=APP_NAME`` - If setproctitle_ is installed you can

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -51,12 +51,12 @@ class Arbiter(object):
         if name[:3] == "SIG" and name[3] != "_"
     )
 
-    last_logged_worker_count = None
-
     def __init__(self, app):
         os.environ["SERVER_SOFTWARE"] = SERVER_SOFTWARE
 
         self._num_workers = None
+        self._last_logged_active_worker_count = None
+
         self.setup(app)
 
         self.pidfile = None
@@ -485,8 +485,8 @@ class Arbiter(object):
             self.kill_worker(pid, signal.SIGTERM)
 
         active_worker_count = len(workers)
-        if self.last_logged_worker_count != active_worker_count:
-            self.last_logged_worker_count = active_worker_count
+        if self._last_logged_active_worker_count != active_worker_count:
+            self._last_logged_active_worker_count = active_worker_count
             self.log.debug("{0} workers".format(active_worker_count),
                            extra={"metric": "gunicorn.workers",
                                   "value": active_worker_count,

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -473,6 +473,8 @@ class Arbiter(object):
         Maintain the number of workers by spawning or killing
         as required.
         """
+        orig_num_workers = self.num_workers
+
         if len(self.WORKERS.keys()) < self.num_workers:
             self.spawn_workers()
 
@@ -482,10 +484,11 @@ class Arbiter(object):
             (pid, _) = workers.pop(0)
             self.kill_worker(pid, signal.SIGTERM)
 
-        self.log.debug("{0} workers".format(len(workers)),
-                       extra={"metric": "gunicorn.workers",
-                              "value": len(workers),
-                              "mtype": "gauge"})
+        if self.num_workers != orig_num_workers:
+            self.log.debug("{0} workers".format(len(workers)),
+                           extra={"metric": "gunicorn.workers",
+                                  "value": len(workers),
+                                  "mtype": "gauge"})
 
     def spawn_worker(self):
         self.worker_age += 1

--- a/gunicorn/workers/_gaiohttp.py
+++ b/gunicorn/workers/_gaiohttp.py
@@ -23,7 +23,7 @@ class AiohttpWorker(base.Worker):
     def __init__(self, *args, **kw):  # pragma: no cover
         super().__init__(*args, **kw)
         cfg = self.cfg
-        if cfg.ssl_version:
+        if cfg.is_ssl:
             self.ssl_context = ssl.SSLContext(cfg.ssl_version)
             self.ssl_context.load_cert_chain(cfg.certfile, cfg.keyfile)
         else:


### PR DESCRIPTION
This pr just passes required ssl options from [Gunicorn config](http://gunicorn-docs.readthedocs.org/en/latest/settings.html#ssl) to `SSLContext` instance used in `create_server`
This is just minimal working example, but it is tested with self-signed certificate:
```sh
gunicorn -k gaiohttp --bind=127.0.0.1:443  --keyfile=ssl.key --certfile=ssl.crt app
```
Without patch gunicorn runs HTTP server over 443 port with ssl arguments present.