### PR TITLE
Simplify sendfile logic

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 
 import email.utils
 import fcntl
-import io
 import os
 import pkg_resources
 import random
@@ -515,19 +514,6 @@ def to_latin1(value):
     if not isinstance(value, text_type):
         raise TypeError('%r is not a string' % value)
     return value.encode("latin-1")
-
-
-def is_fileobject(obj):
-    if not hasattr(obj, "tell") or not hasattr(obj, "fileno"):
-        return False
-
-    # check BytesIO case and maybe others
-    try:
-        obj.fileno()
-    except (IOError, io.UnsupportedOperation):
-        return False
-
-    return True
 
 
 def warn(msg):


### PR DESCRIPTION
A safe and reliable check for whether a file descriptor supports mmap
is to directly check if it is seekable. However, some seekable file
descriptors may also report a zero size when calling fstat. If there
is no content length specified for the response and it cannot be
determined from the file descriptor then it is not possible to know
what chunk size to send to the client. In this case, is it necessary
to fall back to unwinding the body by iteration.

The above conditions together reveal a straightforward and reliable
way to check for sendfile support. This patch modifies the Response
class to assert these conditions using a try/catch block as part of
a new, simplified sendfile method. This method returns False if it
is not possible to serve the response using sendfile. Otherwise, it
serves the response and returns True. By returning False when SSL is
in use, the code is made even simpler by removing the special support
for SSL, which is served well enough by the iteration protocol.

Fix #1038