### PR TITLE
handle HaltServer in manage_workers

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -171,9 +171,9 @@ class Arbiter(object):
         self.start()
         util._setproctitle("master [%s]" % self.proc_name)
 
-        self.manage_workers()
-        while True:
-            try:
+        try:
+            self.manage_workers()
+            while True:
                 sig = self.SIG_QUEUE.pop(0) if len(self.SIG_QUEUE) else None
                 if sig is None:
                     self.sleep()
@@ -193,21 +193,21 @@ class Arbiter(object):
                 self.log.info("Handling signal: %s", signame)
                 handler()
                 self.wakeup()
-            except StopIteration:
-                self.halt()
-            except KeyboardInterrupt:
-                self.halt()
-            except HaltServer as inst:
-                self.halt(reason=inst.reason, exit_status=inst.exit_status)
-            except SystemExit:
-                raise
-            except Exception:
-                self.log.info("Unhandled exception in main loop:\n%s",
-                              traceback.format_exc())
-                self.stop(False)
-                if self.pidfile is not None:
-                    self.pidfile.unlink()
-                sys.exit(-1)
+        except StopIteration:
+            self.halt()
+        except KeyboardInterrupt:
+            self.halt()
+        except HaltServer as inst:
+            self.halt(reason=inst.reason, exit_status=inst.exit_status)
+        except SystemExit:
+            raise
+        except Exception:
+            self.log.info("Unhandled exception in main loop:\n%s",
+                          traceback.format_exc())
+            self.stop(False)
+            if self.pidfile is not None:
+                self.pidfile.unlink()
+            sys.exit(-1)
 
     def handle_chld(self, sig, frame):
         "SIGCHLD handling"


### PR DESCRIPTION
In Arbiter#run() the call to self.manage_workers() can also raise HaltServer, but it's outside the try block where it is handled.

For example (from [RHBZ#1200041](https://bugzilla.redhat.com/show_bug.cgi?id=1200041)):

```

Traceback (most recent call last):
  File "/usr/bin/gunicorn", line 9, in <module>
    load_entry_point('gunicorn==19.1.1', 'console_scripts', 'gunicorn')()
  File "/usr/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 74, in run
    WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]").run()
  File "/usr/lib/python2.7/site-packages/gunicorn/app/base.py", line 185, in run
    super(Application, self).run()
  File "/usr/lib/python2.7/site-packages/gunicorn/app/base.py", line 71, in run
    Arbiter(self).run()
  File "/usr/lib/python2.7/site-packages/gunicorn/arbiter.py", line 169, in run
    self.manage_workers()
  File "/usr/lib/python2.7/site-packages/gunicorn/arbiter.py", line 477, in manage_workers
    self.spawn_workers()
  File "/usr/lib/python2.7/site-packages/gunicorn/arbiter.py", line 542, in spawn_workers
    time.sleep(0.1 * random.random())
  File "/usr/lib/python2.7/site-packages/gunicorn/arbiter.py", line 209, in handle_chld
    self.reap_workers()
  File "/usr/lib/python2.7/site-packages/gunicorn/arbiter.py", line 459, in reap_workers
    raise HaltServer(reason, self.WORKER_BOOT_ERROR)
HaltServer: <HaltServer 'Worker failed to boot.' 3>
```