### PR TITLE
Don't fail if SCRIPT_NAME isn't part of PATH

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -193,7 +193,7 @@ def create(req, sock, client, server, cfg):
     # set the path and script name
     path_info = req.path
     if script_name:
-        path_info = path_info.split(script_name, 1)[1]
+        path_info = path_info.split(script_name, 1)[-1]
     environ['PATH_INFO'] = unquote_to_wsgi_str(path_info)
     environ['SCRIPT_NAME'] = script_name
 


### PR DESCRIPTION
If SCRIPT_NAME isn't part of PATH assume that it already was removed from path PATH and use PATH value as PATH_INFO.