### PR TITLE
ISO-8859-1 encoded http headers

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -317,7 +317,7 @@ class Response(object):
         tosend.extend(["%s: %s\r\n" % (k, v) for k, v in self.headers])
 
         header_str = "%s\r\n" % "".join(tosend)
-        util.write(self.sock, util.to_bytestring(header_str))
+        util.write(self.sock, util.to_latin1(header_str))
         self.headers_sent = True
 
     def write(self, arg):

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -508,6 +508,15 @@ def to_bytestring(value):
     return value.encode("utf-8")
 
 
+def to_latin1(value):
+    """Converts a string argument to a byte string"""
+    if isinstance(value, bytes):
+        return value
+    if not isinstance(value, text_type):
+        raise TypeError('%r is not a string' % value)
+    return value.encode("latin-1")
+
+
 def is_fileobject(obj):
     if not hasattr(obj, "tell") or not hasattr(obj, "fileno"):
         return False


### PR DESCRIPTION
Hi,

gunicorn uses utf8 encoding for http response headers. I don't know
much about http standards, but this is probably not correct:

http://stackoverflow.com/questions/4400678/http-header-should-use-what-character-encoding

best regards,
Jochen