### PR TITLE
remove checking timeouts while graceful stopping tornado worker

### DIFF
--- a/gunicorn/workers/gtornado.py
+++ b/gunicorn/workers/gtornado.py
@@ -58,7 +58,7 @@ class TornadoWorker(Worker):
                         pass
                 self.server_alive = False
             else:
-                if not self.ioloop._callbacks and len(self.ioloop._timeouts) <= 1:
+                if not self.ioloop._callbacks:
                     self.ioloop.stop()
 
     def run(self):


### PR DESCRIPTION
Tornado add many timeouts internally which can be ignored while graceful stopping.