### PR TITLE
Issue 1087: support dictConfig logging configuration

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1138,6 +1138,19 @@ class LogConfig(Setting):
     """
 
 
+class LogConfigDict(Setting):
+    name = "logconfig_dict"
+    section = "Logging"
+    validator = validate_dict
+    default = {}
+    desc = """\
+    The log config dictionary to use, using the standard Python logging
+    module's dictConfig format.
+    If specified, this takes precedence over logconfig, which uses the older
+    fileConfig format.
+    """
+
+
 class SyslogTo(Setting):
     name = "syslog_addr"
     section = "Logging"

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1145,8 +1145,8 @@ class LogConfigDict(Setting):
     default = {}
     desc = """\
     The log config dictionary to use, using the standard Python logging
-    module's dictConfig format.
-    If specified, this takes precedence over logconfig, which uses the older
+    module's dictConfig format added in python 2.7.
+    If available, this takes precedence over logconfig, which uses the older
     fileConfig format.
     """
 

--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -7,7 +7,7 @@ import base64
 import time
 import logging
 logging.Logger.manager.emittedNoHandlerWarning = 1
-from logging.config import fileConfig
+from logging.config import fileConfig, dictConfig
 import os
 import socket
 import sys
@@ -199,7 +199,11 @@ class Logger(object):
                 self.access_log, cfg, self.syslog_fmt, "access"
             )
 
-        if cfg.logconfig:
+        if cfg.logconfig_dict:
+            config = CONFIG_DEFAULTS.copy()
+            config.update(cfg.logconfig_dict)
+            dictConfig(config)
+        elif cfg.logconfig:
             if os.path.exists(cfg.logconfig):
                 defaults = CONFIG_DEFAULTS.copy()
                 defaults['__file__'] = cfg.logconfig

--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -7,7 +7,12 @@ import base64
 import time
 import logging
 logging.Logger.manager.emittedNoHandlerWarning = 1
-from logging.config import fileConfig, dictConfig
+from logging.config import fileConfig
+try:
+    from logging.config import dictConfig
+except ImportError:
+    # python 2.6
+    dictConfig = None
 import os
 import socket
 import sys
@@ -199,7 +204,7 @@ class Logger(object):
                 self.access_log, cfg, self.syslog_fmt, "access"
             )
 
-        if cfg.logconfig_dict:
+        if dictConfig and cfg.logconfig_dict:
             config = CONFIG_DEFAULTS.copy()
             config.update(cfg.logconfig_dict)
             dictConfig(config)


### PR DESCRIPTION
Hi,

This PR is a proof of concept for issue #1087.

So far I have only done a brief test, and I am not too familiar with the existing config implementation, but I will happily look into this in more detail and clean it up if I can get some feedback on the approach taken.

As pointed out in the linked issue, dictConfig enables certain functionality that is not available through the older fileConfig interface.

I've kept the new option separate from --config for backwards compatibility, but dictConfig takes precedence. I don't know whether --config should be entirely deprecated though.

@RoboSloNE @berkerpeksag what are your thoughts?
