### PR TITLE
Update Debian/Ubuntu installation instructions.

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -66,7 +66,7 @@
       <div class="tab-box active" data-tab="quickstart">
         <h1>Installation</h1>
         <p>
-          Here's a quick rundown on how to get started with gunicorn. For more detail read the documentation.
+          Here's a quick rundown on how to get started with Gunicorn. For more detail read the documentation.
         </p>
 <pre>
   $ sudo pip install virtualenv
@@ -118,7 +118,7 @@
     }
   }
 </pre>
-        <p>Nginx is set up as reverse proxy server to gunicorn server which is running at localhost port 8000.</p>
+        <p>Nginx is set up as reverse proxy server to Gunicorn server which is running at localhost port 8000.</p>
         <p>Read the full documentation at <a
           href="http://docs.gunicorn.org/en/latest/deploy.html">docs.gunicorn.org</a></p>
       </div>

--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -176,7 +176,7 @@ Using Gafferd and gaffer
 ++++++++++++++++++++++++
 
 `Gaffer <http://gaffer.readthedocs.org/en/latest/index.html>`_ can be
-used to monitor gunicorn. A simple configuration is::
+used to monitor Gunicorn. A simple configuration is::
 
     [process:gunicorn]
     cmd = gunicorn -w 3 test:app
@@ -194,7 +194,7 @@ Create a ``Procfile`` in your project::
 
 You can launch any other applications that should be launched at the same time.
 
-Then you can start your gunicorn application using `gaffer <http://gaffer.readthedocs.org/en/latest/gaffer.html>`_.::
+Then you can start your Gunicorn application using `gaffer <http://gaffer.readthedocs.org/en/latest/gaffer.html>`_.::
 
     gaffer start
 
@@ -226,7 +226,7 @@ Here is an `example service`_ definition::
 Save this as ``/etc/sv/[app_name]/run``, and make it executable
 (``chmod u+x /etc/sv/[app_name]/run``).
 Then run ``ln -s /etc/sv/[app_name] /etc/service/[app_name]``.
-If runit is installed, gunicorn should start running automatically as soon
+If runit is installed, Gunicorn should start running automatically as soon
 as you create the symlink.
 
 If it doesn't start automatically, run the script directly to troubleshoot.
@@ -247,7 +247,7 @@ Another useful tool to monitor and control Gunicorn is Supervisor_. A
 
 Upstart
 -------
-Using gunicorn with upstart is simple. In this example we will run the app "myapp"
+Using Gunicorn with upstart is simple. In this example we will run the app "myapp"
 from a virtualenv. All errors will go to /var/log/upstart/myapp.log.
 
 **/etc/init/myapp.conf**::
@@ -268,8 +268,8 @@ Systemd
 -------
 
 A tool that is starting to be common on linux systems is Systemd_. Here
-are configurations files to set the gunicorn launch in systemd and
-the interfaces on which gunicorn will listen. The sockets will be managed by
+are configurations files to set the Gunicorn launch in systemd and
+the interfaces on which Gunicorn will listen. The sockets will be managed by
 systemd:
 
 **gunicorn.service**::
@@ -309,7 +309,7 @@ systemd:
 
     d /run/gunicorn 0755 someuser someuser -
 
-After running curl http://localhost:9000/ gunicorn should start and you
+After running ``curl http://localhost:9000/``, Gunicorn should start and you
 should see something like that in logs::
 
     2013-02-19 23:48:19 [31436] [DEBUG] Socket activation sockets: unix:/run/gunicorn/socket,http://0.0.0.0:9000,http://[::]:8000

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -54,7 +54,7 @@ Debian GNU/Linux
 
 If you are using Debian GNU/Linux and it is recommended that you use
 system packages to install Gunicorn except maybe when you want to use
-different versions of gunicorn with virtualenv. This has a number of
+different versions of Gunicorn with virtualenv. This has a number of
 advantages:
 
 * Zero-effort installation: Automatically starts multiple Gunicorn instances
@@ -71,11 +71,32 @@ advantages:
   rolled back in case of incompatibility. The package can also be purged
   entirely from the system in seconds.
 
-Stable ("wheezy")
+stable ("jessie")
 -----------------
 
-The version of Gunicorn in the Debian_ "stable" distribution is 0.14.5 (June
-2012). You can install it using::
+The version of Gunicorn in the Debian_ "stable" distribution is 19.0 (June
+2014). You can install it using::
+
+    $ sudo apt-get install gunicorn
+
+You can also use the most recent version by using `Debian Backports`_.
+First, copy the following line to your ``/etc/apt/sources.list``::
+
+    deb http://backports.debian.org/debian-backports jessie-backports main
+
+Then, update your local package lists::
+
+    $ sudo apt-get update
+
+You can then install the latest version using::
+
+    $ sudo apt-get -t jessie-backports install gunicorn
+
+oldstable ("wheezy")
+--------------------
+
+The version of Gunicorn in the Debian_ "oldstable" distribution is 0.14.5 (June
+2012). you can install it using::
 
     $ sudo apt-get install gunicorn
 
@@ -92,29 +113,10 @@ You can then install the latest version using::
 
     $ sudo apt-get -t wheezy-backports install gunicorn
 
-Oldstable ("squeeze")
----------------------
+Testing ("stretch") / Unstable ("sid")
+--------------------------------------
 
-The version of Gunicorn in the Debian_ "oldstable" distribution is 0.10.0 (July
-2010). It is not recommended that you use this version.
-
-However, you can use the most recent version by using `Debian Backports`_.
-First, copy the following line to your ``/etc/apt/sources.list``::
-
-    deb http://backports.debian.org/debian-backports squeeze-backports main
-
-Then, update your local package lists::
-
-    $ sudo apt-get update
-
-You can then install the latest version using::
-
-    $ sudo apt-get -t squeeze-backports install gunicorn
-
-Testing ("jessie") / Unstable ("sid")
--------------------------------------
-
-"jessie" and "sid" contain the latest released version of Gunicorn. You can
+"stretch" and "sid" contain the latest released version of Gunicorn. You can
 install it in the usual way::
 
     $ sudo apt-get install gunicorn
@@ -123,9 +125,21 @@ install it in the usual way::
 Ubuntu
 ======
 
-If you use Ubuntu_, you can update your system with packages from
-our PPA_ by adding ``ppa:gunicorn/ppa`` to your system's Software
-Sources::
+12.04 or later
+--------------
+
+Ubuntu_ 12.04 (trusty) or later contains Gunicorn package by default so that
+you can install it in the usual way::
+
+    $ sudo apt-get update
+    $ sudo apt-get install gunicorn
+
+10.04 through 11.10
+-------------------
+
+If you use Ubuntu_ 10.04 (lucid) or any version up to 11.10 (oneiric), you can
+update your system with packages from our PPA_ by adding ``ppa:gunicorn/ppa``
+to your system's Software Sources::
 
     $ sudo apt-get install python-software-properties
     $ sudo apt-add-repository ppa:gunicorn/ppa

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -125,43 +125,11 @@ install it in the usual way::
 Ubuntu
 ======
 
-12.04 or later
---------------
-
 Ubuntu_ 12.04 (trusty) or later contains Gunicorn package by default so that
 you can install it in the usual way::
 
     $ sudo apt-get update
     $ sudo apt-get install gunicorn
-
-10.04 through 11.10
--------------------
-
-If you use Ubuntu_ 10.04 (lucid) or any version up to 11.10 (oneiric), you can
-update your system with packages from our PPA_ by adding ``ppa:gunicorn/ppa``
-to your system's Software Sources::
-
-    $ sudo apt-get install python-software-properties
-    $ sudo apt-add-repository ppa:gunicorn/ppa
-    $ sudo apt-get update
-    $ sudo apt-get install gunicorn
-
-Or this PPA can be added to your system manually by copying the lines below
-and adding them to your system's software sources in ``/etc/apt/sources.list``::
-
-  deb http://ppa.launchpad.net/gunicorn/ppa/ubuntu lucid main
-  deb-src http://ppa.launchpad.net/gunicorn/ppa/ubuntu lucid main
-
-Replace *lucid* with your Ubuntu distribution series.
-
-Then run::
-
-  $ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5370FF2A
-  $ sudo apt-get update
-  $ sudo apt-get install gunicorn
-
-:Signing key: ``1024R/5370FF2A``
-:Fingerprint: ``FC7B41B54C9B8476D9EC22A2C6773E575370FF2A``
 
 
 .. _`design docs`: design.html
@@ -171,4 +139,3 @@ Then run::
 .. _Debian: http://www.debian.org/
 .. _`Debian Backports`: http://backports.debian.org/
 .. _Ubuntu: http://www.ubuntu.com/
-.. _PPA: https://launchpad.net/~gunicorn/+archive/ppa

--- a/docs/source/instrumentation.rst
+++ b/docs/source/instrumentation.rst
@@ -13,7 +13,7 @@ The use of UDP cleanly isolates Gunicorn from the receiving end of the statsD
 metrics so that instrumentation does not cause Gunicorn to be held up by a slow
 statsD consumer.
 
-To use statsD, just tell gunicorn where the statsD server is:
+To use statsD, just tell Gunicorn where the statsD server is:
 
 .. code-block:: bash
 

--- a/docs/source/signals.rst
+++ b/docs/source/signals.rst
@@ -23,7 +23,7 @@ Master process
 - **USR2**: Upgrade the Gunicorn on the fly. A separate **TERM** signal should
   be used to kill the old process. This signal can also be used to use the new
   versions of pre-loaded applications.
-- **WINCH**: Gracefully shutdown the worker processes when gunicorn is
+- **WINCH**: Gracefully shutdown the worker processes when Gunicorn is
   daemonized.
 
 Worker process
@@ -63,7 +63,7 @@ option), Gunicorn will also load the new version.
 Upgrading to a new binary on the fly
 ====================================
 
-If you need to replace the gunicorn binary with a new one (when
+If you need to replace the Gunicorn binary with a new one (when
 upgrading to a new version or adding/removing server modules), you can
 do it without any service downtime - no incoming requests will be
 lost. Preloaded applications will also be reloaded.
@@ -84,7 +84,7 @@ which in turn starts a new master process and the new worker processes::
     20860 benoitc   20   0 55748  11m 1500 S   0.0  0.1   0:00.00 gunicorn: worker [test:app]
     20861 benoitc   20   0 55748  11m 1500 S   0.0  0.1   0:00.01 gunicorn: worker [test:app]
 
-At this point, two instances of gunicorn are running, handling the
+At this point, two instances of Gunicorn are running, handling the
 incoming requests together. To phase the old instance out, you have to
 send the **WINCH** signal to the old master process, and its worker
 processes will start to gracefully shut down.


### PR DESCRIPTION
Updated Debian/Ubuntu installation docs as installation documents for Debian and Ubuntu got obsolete.

For Ubuntu, the guide for lucid may now be deleted as [it reached EOL in Apr 2015](http://fridge.ubuntu.com/2015/03/18/ubuntu-10-04-lucid-lynx-reaches-end-of-life-on-april-30-2015/).