### PR TITLE
Remove time.sleep for gevent

### DIFF
--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -7,7 +7,6 @@ from datetime import datetime
 import os
 import signal
 import sys
-import time
 import traceback
 from random import randint
 
@@ -167,7 +166,6 @@ class Worker(object):
         self.alive = False
         # worker_int callback
         self.cfg.worker_int(self)
-        time.sleep(0.1)
         sys.exit(0)
 
     def handle_abort(self, sig, frame):


### PR DESCRIPTION
When using gevent worker, time.sleep will block under gevent.
Please review, thanks.

Sample output:

```
[2015-10-15 11:02:45 +0800] [2526] [INFO] Starting gunicorn 19.3.0
[2015-10-15 11:02:45 +0800] [2526] [INFO] Listening at: http://0.0.0.0:8080 (2526)
[2015-10-15 11:02:45 +0800] [2526] [INFO] Using worker: dae.gworkers.ggevent.GeventWorker
[2015-10-15 11:02:45 +0800] [2529] [INFO] Booting worker with pid: 2529
[2015-10-15 11:02:45 +0800] [2530] [INFO] Booting worker with pid: 2530
^CTraceback (most recent call last):
  File "/Users/xtao/Work/douban/dae/venv/src/gunicorn/gunicorn/workers/base.py", line 158, in handle_quit
Traceback (most recent call last):
    time.sleep(0.1)
  File "/Users/xtao/Work/douban/dae/venv/lib/python2.7/site-packages/gevent/hub.py", line 75, in sleep
  File "/Users/xtao/Work/douban/dae/venv/src/gunicorn/gunicorn/workers/base.py", line 158, in handle_quit
    time.sleep(0.1)
  File "/Users/xtao/Work/douban/dae/venv/lib/python2.7/site-packages/gevent/hub.py", line 75, in sleep
    hub.wait(loop.timer(seconds, ref=ref))
  File "/Users/xtao/Work/douban/dae/venv/lib/python2.7/site-packages/gevent/hub.py", line 341, in wait
    result = waiter.get()
  File "/Users/xtao/Work/douban/dae/venv/lib/python2.7/site-packages/gevent/hub.py", line 568, in get
    return self.hub.switch()
  File "/Users/xtao/Work/douban/dae/venv/lib/python2.7/site-packages/gevent/hub.py", line 330, in switch
    switch_out()
  File "/Users/xtao/Work/douban/dae/venv/lib/python2.7/site-packages/gevent/hub.py", line 334, in switch_out
    raise AssertionError('Impossible to call blocking function in the event loop callback')
AssertionError: Impossible to call blocking function in the event loop callback
    hub.wait(loop.timer(seconds, ref=ref))
  File "/Users/xtao/Work/douban/dae/venv/lib/python2.7/site-packages/gevent/hub.py", line 341, in wait
    result = waiter.get()
  File "/Users/xtao/Work/douban/dae/venv/lib/python2.7/site-packages/gevent/hub.py", line 568, in get
    return self.hub.switch()
  File "/Users/xtao/Work/douban/dae/venv/lib/python2.7/site-packages/gevent/hub.py", line 330, in switch
    switch_out()
  File "/Users/xtao/Work/douban/dae/venv/lib/python2.7/site-packages/gevent/hub.py", line 334, in switch_out
    raise AssertionError('Impossible to call blocking function in the event loop callback')
AssertionError: Impossible to call blocking function in the event loop callback
[2015-10-15 11:02:45 +0800] [2526] [INFO] Handling signal: int
[2015-10-15 11:02:45 +0800] [2530] [INFO] Worker exiting (pid: 2530)
[2015-10-15 11:02:45 +0800] [2529] [INFO] Worker exiting (pid: 2529)
[2015-10-15 11:02:46 +0800] [2526] [INFO] Shutting down: Master
```