### PR TITLE
Respect defaults when running a paster application

### DIFF
--- a/gunicorn/app/pasterapp.py
+++ b/gunicorn/app/pasterapp.py
@@ -44,8 +44,6 @@ def paste_config(gconfig, config_url, relative_to, global_conf=None):
     elif host:
         cfg['bind'] = host.split(',')
 
-    cfg['workers'] = int(lc.get('workers', 1))
-    cfg['umask'] = int(lc.get('umask', 0))
     cfg['default_proc_name'] = gc.get('__file__')
 
     # init logging configuration


### PR DESCRIPTION
The values of both the 'workers' and 'umask' settings have global defaults. In the case of 'workers', this global default can be overridden by the WEB_CONCURRENCY environment variable, which is currently ignored when running an application with `gunicorn --paste`.

Removing this duplication of defaults allows `gunicorn --paste` to respect settings from:

- the environment (WEB_CONCURRENCY)
- the paste configuration file
- CLI flags