### PR TITLE
Make the gevent workers handle the quit signal by deferring to a new greenlet

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -159,3 +159,4 @@ Marc Abramowitz <msabramo@gmail.com>
 Hebert J <hebert@mail.ru>
 Kevin Littlejohn <kevin@littlejohn.id.au>
 Wolfgang Schnerring <wosc@wosc.de>
+Jason Madden <jason@nextthought.com>

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -166,6 +166,11 @@ class GeventWorker(AsyncWorker):
         except SystemExit:
             pass
 
+    def handle_quit(self, sig, frame):
+        # Move this out of the signal handler so we can use
+        # blocking calls. See #1126
+        gevent.spawn(super(GeventWorker, self).handle_quit, sig, frame)
+
     if gevent.version_info[0] == 0:
 
         def init_process(self):


### PR DESCRIPTION
As discussed in #1126. This fixes the problem interactively. However, I have no idea how to add a unit test; there doesn't seem to be anything similar in place already. Suggestions welcome!