### PR TITLE
Fix config description of accesslog user-name params

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -472,7 +472,7 @@ Identifier  Description
 ==========  ===========
 h           remote address
 l           ``'-'``
-u           currently ``'-'``, may be user name in future releases
+u           user name
 t           date of the request
 r           status line (e.g. ``GET / HTTP/1.1``)
 s           status

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1049,7 +1049,7 @@ class AccessLogFormat(Setting):
         ==========  ===========
         h           remote address
         l           ``'-'``
-        u           currently ``'-'``, may be user name in future releases
+        u           user name
         t           date of the request
         r           status line (e.g. ``GET / HTTP/1.1``)
         s           status


### PR DESCRIPTION
Username parameter has been implemented in https://github.com/benoitc/gunicorn/pull/1069 .