### PR TITLE
Fix worker class link in FAQ

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -96,7 +96,7 @@ experience high load due to this problem when using many workers or threads.
 However `a work has been started <https://github.com/benoitc/gunicorn/issues/792>`_
 to remove this issue.
 
-.. _worker_class: configure.html#worker-class
+.. _worker_class: settings.html#worker-class
 .. _`number of workers`: design.html#how-many-workers
 
 Why I don't see any logs in the console?


### PR DESCRIPTION
Fix the _worker_class_ link at http://docs.gunicorn.org/en/19.3/faq.html#worker-processes
