### PR TITLE
Docs: Fix the link to the proc_name setting on the FAQ page

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -49,7 +49,7 @@ you should use one of the async workers.
 
 .. _slowloris: http://ha.ckers.org/slowloris/
 .. _setproctitle: http://pypi.python.org/pypi/setproctitle
-.. _proc_name: configure.html#proc-name
+.. _proc_name: settings.html#proc-name
 
 
 Worker Processes


### PR DESCRIPTION
Fixes the link to the `proc_name` setting on the FAQ [here](http://docs.gunicorn.org/en/19.3/faq.html#how-can-i-name-processes), since it no longer exists on the configure page.