### PR TITLE
Let reloader survive NameError in wsgi app

### DIFF
--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -128,14 +128,15 @@ class Worker(object):
     def load_wsgi(self):
         try:
             self.wsgi = self.app.wsgi()
-        except SyntaxError as e:
+        except (SyntaxError, NameError) as e:
             if not self.cfg.reload:
                 raise
 
             self.log.exception(e)
 
             exc_type, exc_val, exc_tb = sys.exc_info()
-            self.reloader.add_extra_file(exc_val.filename)
+            if hasattr(exc_val, 'filename'):
+                self.reloader.add_extra_file(exc_val.filename)
 
             tb_string = traceback.format_exc(exc_tb)
             self.wsgi = util.make_fail_app(tb_string)


### PR DESCRIPTION
This small change adds `NameError` to the [exceptions handled](https://github.com/benoitc/gunicorn/blob/58108ef7e6836fc545f0614846ffed61f34c48fd/gunicorn/workers/base.py#L131) during wsgi loading [based on this earlier commit](https://github.com/benoitc/gunicorn/commit/d03891a4706dc3106f3d51074e0e6b14cbb8ca0c) ([pull request](https://github.com/benoitc/gunicorn/pull/994)).

The intention is to avoid the master gunicorn process exiting during development with `reload=True` if one were to introduce an error in the wsgi application which causes a `NameError` (e.g. adding a random string "asdf" to the end of a source file).

Note that since a `exceptions.NameError` has no `filename` attribute, the `self.reloader.add_extra_file(exc_val.filename)` line is skipped in this case. I'm not 100% sure of the implications of this and that should be reviewed; however it did not introduce any unit test failures.