### PR TITLE
check auth before trying to own a file

### DIFF
--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -338,8 +338,9 @@ class Logger(object):
                 util.check_is_writeable(output)
                 h = logging.FileHandler(output)
                 # make sure the user can reopen the file
-                os.chown(h.baseFilename, self.cfg.user, self.cfg.group)
-
+                if not util.is_writable(h.baseFilename, self.cfg.user,
+                        self.cfg.group):
+                    os.chown(h.baseFilename, self.cfg.user, self.cfg.group)
             h.setFormatter(fmt)
             h._gunicorn = True
             log.addHandler(h)


### PR DESCRIPTION
This change will check if the file is writable before trying to own it. There is no reason to do a `os.fchown` if we can already write on it.

fix #1157