### PR TITLE
fix sendfile option validation

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -281,6 +281,9 @@ Setting = SettingMeta('Setting', (Setting,), {})
 
 
 def validate_bool(val):
+    if val is None:
+        return
+
     if isinstance(val, bool):
         return val
     if not isinstance(val, six.string_types):


### PR DESCRIPTION
sendfile option don't set any default for now which makes the validation fail
(and then tests) since no boolean is given. For now just return when the value
is not set.