### PR TITLE
don't check if a file is writable using os.stat

### DIFF
--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -338,9 +338,13 @@ class Logger(object):
                 util.check_is_writeable(output)
                 h = logging.FileHandler(output)
                 # make sure the user can reopen the file
-                if not util.is_writable(h.baseFilename, self.cfg.user,
-                        self.cfg.group):
+                try:
                     os.chown(h.baseFilename, self.cfg.user, self.cfg.group)
+                except OSError:
+                    # it's probably OK there, we assume the user has given
+                    # /dev/null as a parameter.
+                    pass
+
             h.setFormatter(fmt)
             h._gunicorn = True
             log.addHandler(h)

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -162,21 +162,6 @@ def chown(path, uid, gid):
     gid = abs(gid) & 0x7FFFFFFF  # see note above.
     os.chown(path, uid, gid)
 
-def is_writable(path, uid, gid):
-    gid = abs(gid) & 0x7FFFFFFF
-    st = os.stat(path)
-
-    if st.st_uid == uid:
-        return st.st_mode & st.S_IWUSR != 0
-
-    user = pwd.getpwuid(uid)[0]
-    groups = [g.gr_gid for g in grp.getgrall() if user in g.gr_mem]
-    groups.append(gid)
-
-    if st.st_gid in groups:
-        return st.st_mode & stat.S_IWGRP != 0
-
-    return st.st_mode & stat.S_IWOTH != 0
 
 if sys.platform.startswith("win"):
     def _waitfor(func, pathname, waitall=False):


### PR DESCRIPTION
Some systems edisable like SELINUX disable some flags so ignore the possible
error while chowning a log file. The error will be raised later anyway.

fix #1171