### PR TITLE
reuse util.is_fileobject

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -353,7 +353,7 @@ class Response(object):
         if self.cfg.is_ssl or not self.can_sendfile():
             return False
 
-        if not util.is_fileobject(respiter.filelike):
+        if not util.has_fileno(respiter.filelike):
             return False
 
         try:

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -353,9 +353,7 @@ class Response(object):
         if self.cfg.is_ssl or not self.can_sendfile():
             return False
 
-        try:
-            fileno = respiter.filelike.fileno()
-        except AttributeError:
+        if not util.is_fileobject(respiter.filelike):
             return False
 
         try:

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -510,7 +510,7 @@ def to_bytestring(value, encoding="utf8"):
 
     return value.encode(encoding)
 
-def is_fileobject(obj):
+def has_fileno(obj):
     if not hasattr(obj, "fileno"):
         return False
 

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -511,13 +511,13 @@ def to_bytestring(value, encoding="utf8"):
     return value.encode(encoding)
 
 def is_fileobject(obj):
-    if not hasattr(obj, "tell") or not hasattr(obj, "fileno"):
+    if not hasattr(obj, "fileno"):
         return False
 
     # check BytesIO case and maybe others
     try:
         obj.fileno()
-    except (IOError, io.UnsupportedOperation):
+    except (AttributeError, IOError, io.UnsupportedOperation):
         return False
 
     return True


### PR DESCRIPTION
`util.is_fileobject` usage was removed due to the use of the `tell` method check.
This change remove this check wich allows us to completely test if
fileno() is usable. Also it handle most of the exceptions around created by
breaking changes across Python versions. Hopefully we are good now.

fix #1174