### PR TITLE
Catch io.UnsupportedOperation exception for io.BytesIO.fileno()

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -355,7 +355,7 @@ class Response(object):
 
         try:
             fileno = respiter.filelike.fileno()
-        except AttributeError:
+        except (AttributeError, io.UnsupportedOperation):
             return False
 
         try:


### PR DESCRIPTION
See #1174.