### PR TITLE
Fix NameError fileno in gunicorn.http.wsgi

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -353,7 +353,9 @@ class Response(object):
         if self.cfg.is_ssl or not self.can_sendfile():
             return False
 
-        if not util.has_fileno(respiter.filelike):
+        if util.has_fileno(respiter.filelike):
+            fileno = respiter.filelike.fileno()
+        else:
             return False
 
         try:


### PR DESCRIPTION
when fixing the fileno for BytesIO, actually setting fileno has been forogtten

tests said: 131 passed, 46 skipped