### PR TITLE
lock domain socket and remove on last arbiter exit

### DIFF
--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -4,6 +4,7 @@
 # See the NOTICE for more information.
 
 import errno
+import fcntl
 import os
 import socket
 import stat
@@ -105,6 +106,8 @@ class UnixSocket(BaseSocket):
                     raise ValueError("%r is not a socket" % addr)
         self.parent = os.getpid()
         super(UnixSocket, self).__init__(addr, conf, log, fd=fd)
+        # each arbiter grabs a shared lock on the unix socket.
+        fcntl.lockf(self.sock, fcntl.LOCK_SH | fcntl.LOCK_NB)
 
     def __str__(self):
         return "unix:%s" % self.cfg_addr
@@ -117,9 +120,17 @@ class UnixSocket(BaseSocket):
 
 
     def close(self):
-        super(UnixSocket, self).close()
         if self.parent == os.getpid():
-            os.unlink(self.cfg_addr)
+            # attempt to acquire an exclusive lock on the unix socket.
+            # if we're the only arbiter running, the lock will succeed, and
+            # we can safely rm the socket.
+            try:
+                fcntl.lockf(self.sock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except:
+                pass
+            else:
+                os.unlink(self.cfg_addr)
+        super(UnixSocket, self).close()
 
 
 def _sock_type(addr):


### PR DESCRIPTION
This fixes a bug where during a hot restart, any unix domain sockets are removed when the original arbiter is TERM'd.

Sequence:
* First arbiter starts (socket file created)
* New arbiter starts via USR2 (all is well)
* First arbiter exits via TERM (socket file is removed)

For the fix, every arbiter grabs a read lock on startup. On exit, every arbiter attempts to grab a write lock -- if successful, we're the only arbiter running and the socket file can be safely removed.