### PR TITLE
Allow configuring logger_class with statsd_host

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -616,7 +616,10 @@ statsd_host
 ``host:port`` of the statsd server to log to.
 
 Note: enabling this switches the default *logger_class* to
-``gunicorn.instrument.statsd.Statsd``
+``gunicorn.instrument.statsd.Statsd``. If you wish to use statsd with
+a custom *logger_class*, you should make sure your class is API
+compatible with ``gunicorn.instrument.statsd.Statsd``, or inherit from
+it.
 
 .. versionadded:: 19.1
 

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -532,6 +532,10 @@ The logger you want to use to log events in Gunicorn.
 The default class (``gunicorn.glogging.Logger``) handle most of
 normal usages in logging. It provides error and access logging.
 
+If you enable statsd support, then a special subclass
+(``gunicorn.instrument.statsd.Statsd``) is used instead, which handles
+sending the metrics to *statsd_host*
+
 You can provide your own worker by giving Gunicorn a
 Python path to a subclass like ``gunicorn.glogging.Logger``.
 Alternatively the syntax can also load the Logger class
@@ -610,6 +614,9 @@ statsd_host
 * ``None``
 
 ``host:port`` of the statsd server to log to.
+
+Note: enabling this switches the default *logger_class* to
+``gunicorn.instrument.statsd.Statsd``
 
 .. versionadded:: 19.1
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -147,7 +147,7 @@ class Config(object):
             uri = "gunicorn.glogging.Logger"
 
         # if statsd is on, automagically switch to the statsd logger
-        if 'statsd_host' in self.settings and self.settings['statsd_host'].value is not None:
+        if uri is not None and 'statsd_host' in self.settings and self.settings['statsd_host'].value is not None:
             logger_class = util.load_class("gunicorn.instrument.statsd.Statsd",
                 section="gunicorn.loggers")
         else:

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -144,16 +144,18 @@ class Config(object):
         uri = self.settings['logger_class'].get()
         if uri == "simple":
             # support the default
-            uri = "gunicorn.glogging.Logger"
+            uri = LoggerClass.default
 
-        # if statsd is on, automagically switch to the statsd logger
-        if uri is not None and 'statsd_host' in self.settings and self.settings['statsd_host'].value is not None:
-            logger_class = util.load_class("gunicorn.instrument.statsd.Statsd",
-                section="gunicorn.loggers")
-        else:
-            logger_class = util.load_class(uri,
-                default="gunicorn.glogging.Logger",
-                section="gunicorn.loggers")
+        # if default logger is in use, and statsd is on, automagically switch
+        # to the statsd logger
+        if uri == LoggerClass.default:
+            if 'statsd_host' in self.settings and self.settings['statsd_host'].value is not None:
+                uri = "gunicorn.instrument.statsd.Statsd"
+
+        logger_class = util.load_class(
+            uri,
+            default="gunicorn.glogging.Logger",
+            section="gunicorn.loggers")
 
         if hasattr(logger_class, "install"):
             logger_class.install()


### PR DESCRIPTION
Currently if you configure statsd_host, a configured logger_class will never be used.

I think this makes a user configured logger class always take priority.

(This is PoC change, I will come back and add tests/docs if it's worth pursuing)