### PR TITLE
fix access logging in gaiohttp worker

### DIFF
--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -237,7 +237,9 @@ class Logger(object):
     def atoms(self, resp, req, environ, request_time):
         """ Gets atoms for log formating.
         """
-        status = resp.status.split(None, 1)[0]
+        status = resp.status
+        if isinstance(status, str):
+            status = status.split(None, 1)[0]
         atoms = {
             'h': environ.get('REMOTE_ADDR', '-'),
             'l': '-',
@@ -250,8 +252,8 @@ class Logger(object):
             'U': environ.get('PATH_INFO'),
             'q': environ.get('QUERY_STRING'),
             'H': environ.get('SERVER_PROTOCOL'),
-            'b': resp.sent and str(resp.sent) or '-',
-            'B': resp.sent,
+            'b': getattr(resp, 'sent', None) and str(resp.sent) or '-',
+            'B': getattr(resp, 'sent', None),
             'f': environ.get('HTTP_REFERER', '-'),
             'a': environ.get('HTTP_USER_AGENT', '-'),
             'T': request_time.seconds,
@@ -266,10 +268,17 @@ class Logger(object):
         else:
             req_headers = req
 
+        if hasattr(req_headers, "items"):
+            req_headers = req_headers.items()
+
         atoms.update(dict([("{%s}i" % k.lower(), v) for k, v in req_headers]))
 
+        resp_headers = resp.headers
+        if hasattr(resp_headers, "items"):
+            resp_headers = resp_headers.items()
+
         # add response headers
-        atoms.update(dict([("{%s}o" % k.lower(), v) for k, v in resp.headers]))
+        atoms.update(dict([("{%s}o" % k.lower(), v) for k, v in resp_headers]))
 
         return atoms
 

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -93,9 +93,12 @@ class Statsd(Logger):
         """
         Logger.access(self, resp, req, environ, request_time)
         duration_in_ms = request_time.seconds * 1000 + float(request_time.microseconds) / 10 ** 3
+        status = resp.status
+        if isinstance(status, str):
+            status = int(status.split(None, 1)[0])
         self.histogram("gunicorn.request.duration", duration_in_ms)
         self.increment("gunicorn.requests", 1)
-        self.increment("gunicorn.request.status.%d" % int(resp.status.split()[0]), 1)
+        self.increment("gunicorn.request.status.%d" % status, 1)
 
     # statsD methods
     # you can use those directly if you want

--- a/gunicorn/workers/_gaiohttp.py
+++ b/gunicorn/workers/_gaiohttp.py
@@ -4,6 +4,7 @@
 # See the NOTICE for more information.
 
 import asyncio
+import datetime
 import functools
 import logging
 import os
@@ -15,7 +16,12 @@ except ImportError:
 
 import gunicorn.workers.base as base
 
-from aiohttp.wsgi import WSGIServerHttpProtocol
+from aiohttp.wsgi import WSGIServerHttpProtocol as OldWSGIServerHttpProtocol
+
+
+class WSGIServerHttpProtocol(OldWSGIServerHttpProtocol):
+    def log_access(self, request, environ, response, time):
+        self.logger.access(response, request, environ, datetime.timedelta(0, 0, time))
 
 
 class AiohttpWorker(base.Worker):


### PR DESCRIPTION
Access logs were wrongly formatted when using gaiohttp worker

It also fixes the statsd instrumentation with this type of worker.