### PR TITLE
$FORWARDED_ALLOW_IPS

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1014,14 +1014,17 @@ class ForwardedAllowIPS(Setting):
     cli = ["--forwarded-allow-ips"]
     meta = "STRING"
     validator = validate_string_to_list
-    default = "127.0.0.1"
+    default = os.environ.get("FORWARDED_ALLOW_IPS", "127.0.0.1")
     desc = """\
         Front-end's IPs from which allowed to handle set secure headers.
         (comma separate).
 
         Set to ``*`` to disable checking of Front-end IPs (useful for setups
         where you don't know in advance the IP address of Front-end, but
-        you still trust the environment)
+        you still trust the environment).
+
+        By default, the value of the ``FORWARDED_ALLOW_IPS`` environment
+        variable. If it is not defined, the default is ``"127.0.0.1"``.
         """
 
 


### PR DESCRIPTION
This pull request gives gunicorn the ability to have the `ForwardedAllowIPS` setting (e.g. `--forwarded-allow-ips`) default configured via the environment variable `FORWARDED_ALLOW_IPS`. Similar behavior is currently in gunicorn for `$WEB_CONCURRENCY` and the `Workers` setting.

This will allow Heroku users to have a better default Gunicorn configuration out of the box, and will alleviate the need to use ProxyFix middleware in WSGI applications, without effecting their codebase.

:sparkles: :cake: :sparkles: