### PR TITLE
Reading Django's settings-file to use as gunicorn config source

### DIFF
--- a/docs/source/configure.rst
+++ b/docs/source/configure.rst
@@ -77,7 +77,14 @@ settings. If you have ideas for providing settings to WSGI applications or
 pulling information from Django's settings.py feel free to open an issue_ to
 let us know.
 
+
+One sugestion on doing so on example's read_django_settings.py_. You can contribute improving this or leaving you commeng on issue 1086_.
+
 .. _issue: http://github.com/benoitc/gunicorn/issues
+
+.. _read_django_settings.py: gunicorn/examples/read_django_settings.py
+.. _1086: https://github.com/benoitc/gunicorn/issues/1086
+
 
 Paster Applications
 -------------------

--- a/examples/local_settings.py
+++ b/examples/local_settings.py
@@ -1,0 +1,8 @@
+from production_settings import *
+#  Depending on situation, it could be 'development_settings', etc
+# from the imported files comes the values of variables below: DEBUG, BIND_PORT, WORKER_PROCCESS
+#  or any other you need/want.
+
+print "{'DEBUG': %s, 'BIND_PORT': %s, 'WORKER_PROCCESS': %s, }" % \
+      (str(DEBUG), str(BIND_PORT), str(WORKER_PROCCESS))
+

--- a/examples/read_django_settings.py
+++ b/examples/read_django_settings.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+#  Use this config file in your script like this:
+#  gunicorn project_name.wsgi:application -c read_django_settings.py
+#
+#  this way you can keep you script deploy-independent and share settings already defined on Django's
+#  settings with Gunicorn.
+#
+
+import multiprocessing
+import os
+import sys
+import ast
+from subprocess import Popen, PIPE, CalledProcessError
+
+SERVER_SOFTWARE = "Not Gunicorn"
+log_level = "warning"
+proc_name = "WebProject"
+bind = "127.0.0.1:8001"
+graceful_timeout = 10
+timeout = 90
+worker = 1
+
+try:
+    sys.path.append(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'project_name'))
+    script_file = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'project_name/local_settings.py') # or 'settings.py'
+    print script_file
+    process = Popen(['python', script_file], stdout=PIPE)
+    out, err = process.communicate()
+    #  See 'project_name/local_settings.py' to see how variables come from Django's Settings
+    #  In this sample we are using 'local_settings' to manage different settings for production/development/etc
+    #  (like this: http://lethain.com/development-to-deployment-in-django/), but you can call django's settings.py
+    #  too, which also calls 'local_settings.py'.
+    #
+    #  All conditions below show be adapte to fit your needs:
+    try:
+        dict_params = ast.literal_eval(out)
+        if 'BIND_PORT' in dict_params:
+            bind = "127.0.0.1:" + str(dict_params['BIND_PORT'])
+            print u"\nBIND_PORT. Obtained: %s" % str(bind)
+        if 'DEBUG' in dict_params:
+            if bool(dict_params['DEBUG']):
+                worker = 1
+                log_level = 'debug'
+                debug = True
+                proc_name += "_debug"
+        if 'WORKER_PROCCESS' in dict_params:
+            if int(dict_params['WORKER_PROCCESS']) == 0:
+                workers = multiprocessing.cpu_count() * 2 + 1
+                print u"\nWORKER_PROCCESS. Calculated: %s proccess" % str(workers)
+            else:
+                workers = int(dict_params['WORKER_PROCCESS'])
+                print u"\nWORKER_PROCCESS. Obtained: %s proccess" % str(workers)
+    except ValueError:
+        pass
+except CalledProcessError:
+    pass


### PR DESCRIPTION
This is the way I found to set gunicorn parameters on Django's settings file... Probably not the most elegant way, but works fine...

____
Sorry about the (very long) delay on this...
I was having some difficulties with Git..
Now I deleted the previous fork, re-make the changes, and am trying to PR again. Hope it works now...