### PR TITLE
http/wsgi.py: do not unquote path before injecting into environ

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -160,3 +160,4 @@ Hebert J <hebert@mail.ru>
 Kevin Littlejohn <kevin@littlejohn.id.au>
 Wolfgang Schnerring <wosc@wosc.de>
 Jason Madden <jason@nextthought.com>
+Jan-Philip Gehrcke <jgehrcke@googlemail.com>

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -9,7 +9,6 @@ import os
 import re
 import sys
 
-from gunicorn._compat import unquote_to_wsgi_str
 from gunicorn.six import string_types, binary_type, reraise
 from gunicorn import SERVER_SOFTWARE
 import gunicorn.util as util
@@ -197,7 +196,7 @@ def create(req, sock, client, server, cfg):
     path_info = req.path
     if script_name:
         path_info = path_info.split(script_name, 1)[1]
-    environ['PATH_INFO'] = unquote_to_wsgi_str(path_info)
+    environ['PATH_INFO'] = path_info
     environ['SCRIPT_NAME'] = script_name
 
     # override the environ with the correct remote and server address if


### PR DESCRIPTION
This is a follow-up to https://github.com/benoitc/gunicorn/issues/930, where we decided that WSGI `environ['PATH_INFO']` should not be an unquoted (percent-decoded) path, but the undecoded (original) path. This was then fixed in aiohttp's WSGI implementation, see https://github.com/KeepSafe/aiohttp/issues/177 -- but it looks like we missed taking care of Gunicorn's WSGI implementation.

In the current aiohttp implementation we find (https://github.com/KeepSafe/aiohttp/blob/master/aiohttp/wsgi.py):

```
path_info = uri_parts.path
[...]

environ['PATH_INFO'] = path_info
```

However, in `gunicorn/http/wsgi.py` we currently still find:
```
environ['PATH_INFO'] = unquote_to_wsgi_str(path_info)
```

This leads to a class of problems where escaped and non-escaped parts are not easily distinguishable anymore on framework-level, as vividly clarified by the following issue: https://code.djangoproject.com/ticket/15718
There, the behavior is partially controllable in Apache's mod_wsgi by setting `AllowEncodedSlashes On`.

There, the issue appeared with Django+mod_wsgi. In our case, the issue appeared with Falcon+Gunicorn, but factually it's exactly the same problem.

I think the most important insight is from https://github.com/KeepSafe/aiohttp/issues/177

> IIRC WSGI standard doesn't specifies path unquoting.

So, I went ahead and simply removed the unquoting operation (exactly as done in aiohttp's wsgi.py). I ran tests against Python 3.4, and nothing broke.

This change affects three worker types (async, gthread, sync):
```
$ grep -HR "wsgi.create" .
./gunicorn/workers/async.py:            resp, environ = wsgi.create(req, sock, addr,
./gunicorn/workers/gthread.py:            resp, environ = wsgi.create(req, conn.sock, conn.addr,
./gunicorn/workers/sync.py:            resp, environ = wsgi.create(req, client, addr,
```

I think we can just merge this, mainly motivated by the fact that aiohttp uses the same method.

Still, it would be nice to now add a test that breaks with the old behavior, and passes with the new one. However, I am not warm enough with the gunicorn test structure.

And of course the question is if applications out there in the world rely on that behavior ... :/

In our application we *have to* be able to distinguish real slashes from escaped slashes on framework level. That is, we have to use a custom branch of Gunicorn right now -- otherwise that information is lost once requests enter framework level.