### PR TITLE
update django doc url to 1.8 lts

### DIFF
--- a/gunicorn/app/djangoapp.py
+++ b/gunicorn/app/djangoapp.py
@@ -154,7 +154,7 @@ def run():
 
         gunicorn myproject.wsgi:application
 
-    See https://docs.djangoproject.com/en/1.5/howto/deployment/wsgi/gunicorn/
+    See https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/gunicorn/
     for more info.""")
     from gunicorn.app.djangoapp import DjangoApplication
     DjangoApplication("%(prog)s [OPTIONS] [SETTINGS_PATH]").run()

--- a/gunicorn/management/commands/run_gunicorn.py
+++ b/gunicorn/management/commands/run_gunicorn.py
@@ -98,7 +98,7 @@ class Command(BaseCommand):
 
             gunicorn myproject.wsgi:application
 
-        See https://docs.djangoproject.com/en/1.5/howto/deployment/wsgi/gunicorn/
+        See https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/gunicorn/
         for more info.""")
 
         if args:


### PR DESCRIPTION
When updating our company's gunicorn I noticed the doc link for django was out of date.  Looks like django removed all docs before 1.7.  Another option, which would avoid updating these docs every few years would be to point those urls to `dev`, eg: https://docs.djangoproject.com/en/dev/howto/deployment/wsgi/gunicorn/

Thanks for the project!