### PR TITLE
[eventlet] handle QUIT in a new coroutine

### DIFF
--- a/gunicorn/workers/geventlet.py
+++ b/gunicorn/workers/geventlet.py
@@ -94,6 +94,9 @@ class EventletWorker(AsyncWorker):
         self.patch()
         super(EventletWorker, self).init_process()
 
+    def handle_quit(self, sig, frame):
+        eventlet.spawn(super(EventletWorker, self).handle_quit, sig, frame)
+
     def timeout_ctx(self):
         return eventlet.Timeout(self.cfg.keepalive or None, False)
 
@@ -118,11 +121,7 @@ class EventletWorker(AsyncWorker):
 
         while self.alive:
             self.notify()
-            try:
-                eventlet.sleep(1.0)
-            except AssertionError:
-                self.alive = False
-                break
+            eventlet.sleep(1.0)
 
         self.notify()
         try:


### PR DESCRIPTION
Just like in the gevent worker, a blocking call should only be executed
from within a coroutine. The AssertionError around the main loop of the
eventlet worker can be removed, since it was there to catch
the exception raised by the sleep.