### PR TITLE
[gevent] remove obsolete exception clauses in run

### DIFF
--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -114,20 +114,9 @@ class GeventWorker(AsyncWorker):
             server.start()
             servers.append(server)
 
-        try:
-            while self.alive:
-                self.notify()
-                gevent.sleep(1.0)
-
-        except KeyboardInterrupt:
-            pass
-        except:
-            for server in servers:
-                try:
-                    server.stop()
-                except:
-                    pass
-            raise
+        while self.alive:
+            self.notify()
+            gevent.sleep(1.0)
 
         try:
             # Stop accepting requests


### PR DESCRIPTION
Since the changes from #1126, errors are not raised into the main
loop during a non-graceful shutdown. Therefore, these exception
clauses shouldn't be needed anymore.