### PR TITLE
fix infinite recursion when destroying sockets

### DIFF
--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -53,11 +53,15 @@ class BaseSocket(object):
         sock.bind(self.cfg_addr)
 
     def close(self):
+        if self.sock is None:
+            return
+
         try:
             self.sock.close()
         except socket.error as e:
             self.log.info("Error while closing socket %s", str(e))
-        del self.sock
+
+        self.sock = None
 
 
 class TCPSocket(BaseSocket):


### PR DESCRIPTION
By having a `getattr` implementation that proxies to the `sock`
attribute, there is a risk of infinite recursion when the socket
attribute is absent. After closing the socket and destroying it,
the recursion can be prevented by setting the attribute to `None`.