### PR TITLE
[eventlet] close sockets at graceful shutdown

### DIFF
--- a/gunicorn/workers/geventlet.py
+++ b/gunicorn/workers/geventlet.py
@@ -54,6 +54,7 @@ def _eventlet_serve(sock, handle, concurrency):
             gt.link(_eventlet_stop, server_gt, conn)
             conn, addr, gt = None, None, None
         except eventlet.StopServe:
+            sock.close()
             pool.waitall()
             return
 


### PR DESCRIPTION
Implement early closing of sockets for eventlet graceful shutdown, just like we have in gevent.

Ineffectual without #1221, but with that applied both workers immediately refuse new connections once graceful shutdown starts.