### PR TITLE
Fix delayed socket close caused by circular ref from assigning traceback to local var

### DIFF
--- a/gunicorn/_compat.py
+++ b/gunicorn/_compat.py
@@ -107,11 +107,8 @@ def _wrap_error(exc, mapping, key):
     new_err = new_err_cls(*exc.args)
 
     # raise a new exception with the original traceback
-    if hasattr(exc, '__traceback__'):
-        traceback = exc.__traceback__
-    else:
-        traceback = sys.exc_info()[2]
-    six.reraise(new_err_cls, new_err, traceback)
+    six.reraise(new_err_cls, new_err,
+                exc.__traceback__ if hasattr(exc, '__traceback__') else sys.exc_info()[2])
 
 if PY33:
     import builtins

--- a/gunicorn/workers/async.py
+++ b/gunicorn/workers/async.py
@@ -55,13 +55,11 @@ class AsyncWorker(base.Worker):
             except StopIteration as e:
                 self.log.debug("Closing connection. %s", e)
             except ssl.SSLError:
-                exc_info = sys.exc_info()
                 # pass to next try-except level
-                six.reraise(exc_info[0], exc_info[1], exc_info[2])
+                six.reraise(*sys.exc_info())
             except EnvironmentError:
-                exc_info = sys.exc_info()
                 # pass to next try-except level
-                six.reraise(exc_info[0], exc_info[1], exc_info[2])
+                six.reraise(*sys.exc_info())
             except Exception as e:
                 self.handle_error(req, client, addr, e)
         except ssl.SSLError as e:

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -339,9 +339,8 @@ class ThreadWorker(base.Worker):
                 self.log.debug("Closing connection.")
                 return False
         except EnvironmentError:
-            exc_info = sys.exc_info()
             # pass to next try-except level
-            six.reraise(exc_info[0], exc_info[1], exc_info[2])
+            six.reraise(*sys.exc_info())
         except Exception:
             if resp and resp.headers_sent:
                 # If the requests have already been sent, we should close the

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -182,9 +182,8 @@ class SyncWorker(base.Worker):
                 if hasattr(respiter, "close"):
                     respiter.close()
         except EnvironmentError:
-            exc_info = sys.exc_info()
             # pass to next try-except level
-            six.reraise(exc_info[0], exc_info[1], exc_info[2])
+            six.reraise(*sys.exc_info())
         except Exception:
             if resp and resp.headers_sent:
                 # If the requests have already been sent, we should close the


### PR DESCRIPTION
As part of pulling in 2e231d20d51677949067247d8133734943ca0a72 and a3f6df5b7e37eba4d45c841b0c0c5b3fc983258b, EPIPEs result in the `EnvironmentError` exception handler in `handle()` being run. In many environments, EPIPEs can be extremely common. The exception handler stores the traceback into a local variable, creating a circular reference, and prevents the system socket (holding a fd open along with other socket resources) from being closed until the next Python full garbage collection cycle. The behavior of `sys.exec_info()` is documented at https://docs.python.org/2/library/sys.html#sys.exc_info with a large red warning statement. This new exception path for EPIPEs can create significant additional resource usage for gunicorn installations.

Removing the assignment into `exc_info` causes the socket fd to be freed quickly (handled by ref counting), as was the case before the two prior patches were merged.

This commit also fixes the `ssl.SSLError` path.