### PR TITLE
Add gthread and gaiohttp to settings docs

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -102,7 +102,7 @@ A string referring to one of the following bundled classes:
 * ``eventlet`` - Requires eventlet >= 0.9.7
 * ``gevent``   - Requires gevent >= 0.13
 * ``tornado``  - Requires tornado >= 0.2
-* ``gthread``  - Requires Python 3
+* ``gthread``  - Requires >= Python 2. Python 2 requires the futures package to be installed
 * ``gaiohttp``  - Requires Python 3 and aiohttp >= 0.21.5
 
 Optionally, you can provide your own worker by giving Gunicorn a

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -102,6 +102,8 @@ A string referring to one of the following bundled classes:
 * ``eventlet`` - Requires eventlet >= 0.9.7
 * ``gevent``   - Requires gevent >= 0.13
 * ``tornado``  - Requires tornado >= 0.2
+* ``gthread``  - Requires Python 3
+* ``gaiohttp``  - Requires Python 3 and aiohttp >= 0.21.5
 
 Optionally, you can provide your own worker by giving Gunicorn a
 Python path to a subclass of ``gunicorn.workers.base.Worker``.


### PR DESCRIPTION
Added the worker class types of `gthread` and `gaiohttp` to the settings docs.