### PR TITLE
Fixed traceback formatting for syntax errors

### DIFF
--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -142,7 +142,7 @@ class Worker(object):
                 exc_type, exc_val, exc_tb = sys.exc_info()
                 self.reloader.add_extra_file(exc_val.filename)
 
-                tb_string = traceback.format_exc(exc_tb)
+                tb_string = traceback.format_tb(exc_tb)
                 self.wsgi = util.make_fail_app(tb_string)
             finally:
                 del exc_tb


### PR DESCRIPTION
Without this patch, on current Gunicorn version I get the following traceback if I have a syntax error in my program:
```
  ...
  File "/home/mars/myproject/views/item.py", line 494
    return render(request, 'add_item.html',
         ^
SyntaxError: invalid syntax

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/gunicorn/arbiter.py", line 515, in spawn_worker
    worker.init_process()
  File "/usr/lib/python3.5/site-packages/aiohttp-0.21.2-py3.5-linux-x86_64.egg/aiohttp/worker.py", line 30, in init_process
    super().init_process()
  File "/usr/lib/python3.5/site-packages/gunicorn/workers/base.py", line 122, in init_process
    self.load_wsgi()
  File "/usr/lib/python3.5/site-packages/gunicorn/workers/base.py", line 140, in load_wsgi
    tb_string = traceback.format_exc(exc_tb)
  File "/usr/lib/python3.5/traceback.py", line 163, in format_exc
    return "".join(format_exception(*sys.exc_info(), limit=limit, chain=chain))
  File "/usr/lib/python3.5/traceback.py", line 117, in format_exception
    type(value), value, tb, limit=limit).format(chain=chain))
  File "/usr/lib/python3.5/traceback.py", line 474, in __init__
    capture_locals=capture_locals)
  File "/usr/lib/python3.5/traceback.py", line 332, in extract
    if limit >= 0:
TypeError: unorderable types: traceback() >= int()
```
This patch removes additional "During handling of the above exception..." traceback.