### PR TITLE
Use EPOLLEXCLUSIVE to avoid thundering herd problem

### DIFF
--- a/gunicorn/selectors.py
+++ b/gunicorn/selectors.py
@@ -397,7 +397,9 @@ if hasattr(select, 'epoll'):
 
         def register(self, fileobj, events, data=None):
             key = super(EpollSelector, self).register(fileobj, events, data)
-            epoll_events = 0
+            # EPOLLEXCLUSIVE (linux 3.5) to avoid thundering herd
+            # http://man7.org/linux/man-pages/man2/epoll_ctl.2.html
+            epoll_events = (1 << 28)
             if events & EVENT_READ:
                 epoll_events |= select.EPOLLIN
             if events & EVENT_WRITE:


### PR DESCRIPTION
linux 4.5 introduced EPOLLEXCLUSIVE which can be used to avoid thundering herd problem.
http://man7.org/linux/man-pages/man2/epoll_ctl.2.html

Before linux 4.5, this flag is just ignored.