### PR TITLE
do post_worker_init after load_wsgi

### DIFF
--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -117,9 +117,9 @@ class Worker(object):
 
         self.init_signals()
 
-        self.cfg.post_worker_init(self)
-
         self.load_wsgi()
+
+        self.cfg.post_worker_init(self)
 
         # Enter main run loop
         self.booted = True


### PR DESCRIPTION
After 81f65c2 it became impossible to get access to application in post_worker_init, because application not loaded yet. This patch return previous behaviour.