### PR TITLE
Add access_log_format to config example

### DIFF
--- a/examples/example_config.py
+++ b/examples/example_config.py
@@ -147,6 +147,7 @@ tmp_upload_dir = None
 errorlog = '-'
 loglevel = 'info'
 accesslog = '-'
+access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
 
 #
 # Process naming


### PR DESCRIPTION
The example given is the current default log format.

I found myself looking through the code to figure out how to set this, so hopefully this will save other peoples time.