### PR TITLE
Do not swallow exception raised during worker exit 

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -161,3 +161,4 @@ Kevin Littlejohn <kevin@littlejohn.id.au>
 Wolfgang Schnerring <wosc@wosc.de>
 Jason Madden <jason@nextthought.com>
 Eugene Obukhov <irvind25@gmail.com>
+Jan-Philip Gehrcke <jgehrcke@googlemail.com>

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -856,7 +856,7 @@ worker_exit
         def worker_exit(server, worker):
             pass
 
-Called just after a worker has been exited.
+Called in the worker, right before it terminates.
 
 The callable needs to accept two instance variables for the Arbiter and
 the just-exited Worker.

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -11,6 +11,7 @@ import select
 import signal
 import sys
 import time
+import traceback
 
 from gunicorn.errors import HaltServer, AppImportError
 from gunicorn.pidfile import Pidfile
@@ -535,7 +536,8 @@ class Arbiter(object):
                 worker.tmp.close()
                 self.cfg.worker_exit(self, worker)
             except:
-                pass
+                self.log.warning("Exception during worker exit:\n%s",
+                                  traceback.format_exc())
 
     def spawn_workers(self):
         """\


### PR DESCRIPTION
This tackles #1253.

I have also added a commit proposing a documentation change: when I read the current doc for the `worker_exit()` hook, I was not sure if it's actually executed *in* the worker process (right before it terminates), or in the master process (right after it has terminated).

Please have a look, thanks!