### PR TITLE
unblock the wait loop under python 3.5

### DIFF
--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -113,6 +113,8 @@ class Worker(object):
         [util.close_on_exec(s) for s in self.sockets]
         util.close_on_exec(self.tmp.fileno())
 
+        self.wait_fds = self.sockets + [self.PIPE[0]]
+
         self.log.close_on_exec()
 
         self.init_signals()
@@ -163,6 +165,9 @@ class Worker(object):
         if hasattr(signal, 'siginterrupt'):  # python >= 2.6
             signal.siginterrupt(signal.SIGTERM, False)
             signal.siginterrupt(signal.SIGUSR1, False)
+
+        if hasattr(signal, 'set_wakeup_fd'):
+            signal.set_wakeup_fd(self.PIPE[1])
 
     def handle_usr1(self, sig, frame):
         self.log.reopen_files()

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -32,7 +32,7 @@ class SyncWorker(base.Worker):
     def wait(self, timeout):
         try:
             self.notify()
-            ret = select.select(self.sockets, [], self.PIPE, timeout)
+            ret = select.select(self.wait_fds, [], [], timeout)
             if ret[0]:
                 return ret[0]
 
@@ -93,6 +93,9 @@ class SyncWorker(base.Worker):
 
             if ready is not None:
                 for listener in ready:
+                    if listener == self.PIPE[0]:
+                        continue
+
                     try:
                         self.accept(listener)
                     except EnvironmentError as e:


### PR DESCRIPTION
in python 3.5 the select is blocking when waiting for it which prevent quick
exit on SIGTERM.

The problem is described:
https://www.python.org/dev/peps/pep-0475/#backward-compatibility

This change fix it by listening for signal event on the worker pipe. Once an
event is triggered it will forcefully wake up the select and return.

fix #1256