### PR TITLE
don't kill ourself on reload

### DIFF
--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -90,6 +90,10 @@ class Worker(object):
             def changed(fname):
                 self.log.info("Worker reloading: %s modified", fname)
                 self.alive = False
+                self.cfg.worker_int(self)
+                time.sleep(0.1)
+                sys.exit(0)
+
             self.reloader = Reloader(callback=changed)
             self.reloader.start()
 

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -89,7 +89,7 @@ class Worker(object):
         if self.cfg.reload:
             def changed(fname):
                 self.log.info("Worker reloading: %s modified", fname)
-                os.kill(self.pid, signal.SIGQUIT)
+                self.alive = False
             self.reloader = Reloader(callback=changed)
             self.reloader.start()
 


### PR DESCRIPTION
Killing ourself when using the `--reload` option trigger an infinite loop under some monitoring services like the one in pycharm and don't reload the file.

Instead set self.alive as False which will trigger later the worker exit. Note that if we want to force the exit we could also use sys.exit(0) .

fix #1129