### PR TITLE
fix unix socket locking

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -904,6 +904,20 @@ class Pidfile(Setting):
         If not set, no PID file will be written.
         """
 
+class LockFile(Setting):
+    name = "lockfile"
+    section = "Server Mechanics"
+    cli = ["--lock-file"]
+    meta = "FILE"
+    validator = validate_string
+    default = util.tmpfile(suffix=".lock", prefix="gunicorn-")
+
+    desc = """\
+        A filename to use for the lock file. A lock file is created when using unix sockets.
+        If not set, the default file 'gunicorn-<RANDOMSTRING>.lock'  will be created in the
+        temporary directory.
+        """
+
 class WorkerTmpDir(Setting):
     name = "worker_tmp_dir"
     section = "Server Mechanics"

--- a/gunicorn/lockfile.py
+++ b/gunicorn/lockfile.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+import os
+
+from gunicorn import util
+
+if os.name == 'nt':
+    import msvcrt
+
+    def _lock(fd):
+        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+
+
+    def _unlock(fd):
+        try:
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        except OSError:
+            return False
+        return True
+
+else:
+    import fcntl
+
+    def _lock(fd):
+        fcntl.lockf(fd, fcntl.LOCK_SH | fcntl.LOCK_NB)
+
+
+    def _unlock(fd):
+        try:
+            fcntl.lockf(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except:
+            print("no unlock")
+            return False
+
+        return True
+
+
+class LockFile(object):
+    """Manage a LOCK file"""
+
+    def __init__(self, fname):
+        self.fname = fname
+        fdir = os.path.dirname(self.fname)
+        if fdir and not os.path.isdir(fdir):
+            raise RuntimeError("%s doesn't exist. Can't create lock file." % fdir)
+        self._lockfile = open(self.fname, 'w+b')
+        # set permissions to -rw-r--r--
+        os.chmod(self.fname, 420)
+        self._locked = False
+
+    def lock(self):
+        _lock(self._lockfile.fileno())
+        self._locked = True
+
+    def unlock(self):
+        if not self.locked():
+            return
+
+        if _unlock(self._lockfile.fileno()):
+            self._lockfile.close()
+            util.unlink(self.fname)
+            self._lockfile = None
+            self._locked = False
+
+    def locked(self):
+        return self._lockfile is not None and self._locked
+
+    def name(self):
+        return self.fname

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -17,6 +17,7 @@ import resource
 import socket
 import stat
 import sys
+import tempfile
 import textwrap
 import time
 import traceback
@@ -37,6 +38,8 @@ timeout_default = object()
 CHUNK_SIZE = (16 * 1024)
 
 MAX_BODY = 1024 * 132
+
+normcase = os.path.normcase
 
 # Server and Date aren't technically hop-by-hop
 # headers, but they are in the purview of the
@@ -546,3 +549,14 @@ def make_fail_app(msg):
         return [msg]
 
     return app
+
+
+characters = ("abcdefghijklmnopqrstuvwxyz" +
+              "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+              "0123456789_")
+
+def tmpfile(suffix="", prefix="tmp"):
+    c = characters
+    rand_str = normcase("".join([random.choice(c) for _ in "123456"]))
+    fname = "".join([prefix, rand_str, suffix])
+    return os.path.join(tempfile.gettempdir(), fname)

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -35,8 +35,8 @@ def test_arbiter_shutdown_closes_listeners():
     listener2 = mock.Mock()
     arbiter.LISTENERS = [listener1, listener2]
     arbiter.stop()
-    listener1.close.assert_called_with()
-    listener2.close.assert_called_with()
+    listener1.close.assert_called_with(False)
+    listener2.close.assert_called_with(False)
 
 
 class PreloadedAppWithEnvSettings(DummyApplication):

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -1,0 +1,15 @@
+import os
+
+from gunicorn.lockfile import LockFile
+from gunicorn.util import tmpfile
+
+def test_lockfile():
+    lockname = tmpfile(prefix="gunicorn-tests", suffix=".lock")
+    lock_file = LockFile(lockname)
+    assert lock_file.locked() == False
+    assert os.path.exists(lockname)
+    lock_file.lock()
+    assert lock_file.locked() == True
+    lock_file.unlock()
+    assert lock_file.locked() == False
+    assert os.path.exists(lockname) == False

--- a/tests/test_sock.py
+++ b/tests/test_sock.py
@@ -1,5 +1,3 @@
-import fcntl
-
 try:
     import unittest.mock as mock
 except ImportError:
@@ -8,49 +6,31 @@ except ImportError:
 from gunicorn import sock
 
 
-@mock.patch('fcntl.lockf')
-@mock.patch('socket.fromfd')
-def test_unix_socket_init_lock(fromfd, lockf):
-    s = fromfd.return_value
-    sock.UnixSocket('test.sock', mock.Mock(), mock.Mock(), mock.Mock())
-    lockf.assert_called_with(s, fcntl.LOCK_SH | fcntl.LOCK_NB)
-
-
-@mock.patch('fcntl.lockf')
 @mock.patch('os.getpid')
 @mock.patch('os.unlink')
 @mock.patch('socket.fromfd')
-def test_unix_socket_close_delete_if_exlock(fromfd, unlink, getpid, lockf):
-    s = fromfd.return_value
+def test_unix_socket_close_delete_if_exlock(fromfd, unlink, getpid):
     gsock = sock.UnixSocket('test.sock', mock.Mock(), mock.Mock(), mock.Mock())
-    lockf.reset_mock()
-    gsock.close()
-    lockf.assert_called_with(s, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    gsock.close(False)
     unlink.assert_called_with('test.sock')
 
 
-@mock.patch('fcntl.lockf')
 @mock.patch('os.getpid')
 @mock.patch('os.unlink')
 @mock.patch('socket.fromfd')
-def test_unix_socket_close_keep_if_no_exlock(fromfd, unlink, getpid, lockf):
-    s = fromfd.return_value
+def test_unix_socket_close_keep_if_no_exlock(fromfd, unlink, getpid):
     gsock = sock.UnixSocket('test.sock', mock.Mock(), mock.Mock(), mock.Mock())
-    lockf.reset_mock()
-    lockf.side_effect = IOError('locked')
-    gsock.close()
-    lockf.assert_called_with(s, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    gsock.close(True)
     unlink.assert_not_called()
 
 
-@mock.patch('fcntl.lockf')
 @mock.patch('os.getpid')
+@mock.patch('os.unlink')
 @mock.patch('socket.fromfd')
-def test_unix_socket_not_deleted_by_worker(fromfd, getpid, lockf):
+def test_unix_socket_not_deleted_by_worker(fromfd, unlink, getpid):
     fd = mock.Mock()
-    gsock = sock.UnixSocket('name', mock.Mock(), mock.Mock(), fd)
-    lockf.reset_mock()
+    gsock = sock.UnixSocket('test.sock', mock.Mock(), mock.Mock(), fd)
     getpid.reset_mock()
-    getpid.return_value = mock.Mock()  # fake a pid change
-    gsock.close()
-    lockf.assert_not_called()
+    getpid.return_value = "fake"  # fake a pid change
+    gsock.close(False)
+    unlink.assert_not_called()


### PR DESCRIPTION
This change add proper file locking to gunicorn. By default "gunicorn.lock" is created in the temporary directory when a unix socket is bound.  In case someone want to fix the lock file path or use multiple gunicorn instance the "--lock-file" setting can be used to set the path of this file.

fix #1259