### PR TITLE
set CONTENT_LENGTH to max integer when receiving chunked encoding req…

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -12,7 +12,7 @@ import sys
 from gunicorn._compat import unquote_to_wsgi_str
 from gunicorn.http.message import HEADER_RE
 from gunicorn.http.errors import InvalidHeader, InvalidHeaderName
-from gunicorn.six import string_types, binary_type, reraise
+from gunicorn.six import string_types, binary_type, reraise, MAXSIZE
 from gunicorn import SERVER_SOFTWARE
 import gunicorn.util as util
 
@@ -82,6 +82,7 @@ def base_environ(cfg):
         "wsgi.multiprocess": (cfg.workers > 1),
         "wsgi.run_once": False,
         "wsgi.file_wrapper": FileWrapper,
+        "CONTENT_LENGTH": MAXSIZE,
         "SERVER_SOFTWARE": SERVER_SOFTWARE,
     }
 


### PR DESCRIPTION
set CONTENT_LENGTH to max integer when receiving chunked encoding requests

After looking at the code of Django or Werkzeug it seems that some WSGI frameworks considers that the body is empty when the `CONTENT_LENGTH` environ key is not present:

- django: https://github.com/django/django/blob/master/django/core/handlers/wsgi.py#L109-L112
- https://github.com/pallets/werkzeug/blob/master/werkzeug/wsgi.py#L205-L210

So waiting for a better  spec set the size to max since we know that Gunicorn is able to handle chunked encoding.

fix #1264