### PR TITLE
lockfile improvements

### DIFF
--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -53,7 +53,7 @@ class BaseSocket(object):
     def bind(self, sock):
         sock.bind(self.cfg_addr)
 
-    def close(self, locked=False):
+    def close(self):
         if self.sock is None:
             return
 
@@ -63,6 +63,9 @@ class BaseSocket(object):
             self.log.info("Error while closing socket %s", str(e))
 
         self.sock = None
+
+    def destroy(self):
+        pass
 
 
 class TCPSocket(BaseSocket):
@@ -120,10 +123,12 @@ class UnixSocket(BaseSocket):
         util.chown(self.cfg_addr, self.conf.uid, self.conf.gid)
         os.umask(old_umask)
 
-    def close(self, locked=False):
-        if self.parent == os.getpid() and not locked:
-            os.unlink(self.cfg_addr)
+    def close(self):
         super(UnixSocket, self).close()
+
+    def destroy(self):
+        if self.parent == os.getpid():
+            os.unlink(self.cfg_addr)
 
 
 def _sock_type(addr):

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -35,8 +35,8 @@ def test_arbiter_shutdown_closes_listeners():
     listener2 = mock.Mock()
     arbiter.LISTENERS = [listener1, listener2]
     arbiter.stop()
-    listener1.close.assert_called_with(False)
-    listener2.close.assert_called_with(False)
+    listener1.close.assert_called_with()
+    listener2.close.assert_called_with()
 
 
 class PreloadedAppWithEnvSettings(DummyApplication):

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -6,10 +6,10 @@ from gunicorn.util import tmpfile
 def test_lockfile():
     lockname = tmpfile(prefix="gunicorn-tests", suffix=".lock")
     lock_file = LockFile(lockname)
-    assert lock_file.locked() == False
+    assert lock_file.released() == True
     assert os.path.exists(lockname)
-    lock_file.lock()
-    assert lock_file.locked() == True
-    lock_file.unlock()
-    assert lock_file.locked() == False
+    lock_file.acquire()
+    assert lock_file.released() == False
+    lock_file.release()
+    assert lock_file.released() == True
     assert os.path.exists(lockname) == False

--- a/tests/test_sock.py
+++ b/tests/test_sock.py
@@ -11,17 +11,8 @@ from gunicorn import sock
 @mock.patch('socket.fromfd')
 def test_unix_socket_close_delete_if_exlock(fromfd, unlink, getpid):
     gsock = sock.UnixSocket('test.sock', mock.Mock(), mock.Mock(), mock.Mock())
-    gsock.close(False)
+    gsock.destroy()
     unlink.assert_called_with('test.sock')
-
-
-@mock.patch('os.getpid')
-@mock.patch('os.unlink')
-@mock.patch('socket.fromfd')
-def test_unix_socket_close_keep_if_no_exlock(fromfd, unlink, getpid):
-    gsock = sock.UnixSocket('test.sock', mock.Mock(), mock.Mock(), mock.Mock())
-    gsock.close(True)
-    unlink.assert_not_called()
 
 
 @mock.patch('os.getpid')
@@ -32,5 +23,5 @@ def test_unix_socket_not_deleted_by_worker(fromfd, unlink, getpid):
     gsock = sock.UnixSocket('test.sock', mock.Mock(), mock.Mock(), fd)
     getpid.reset_mock()
     getpid.return_value = "fake"  # fake a pid change
-    gsock.close(False)
+    gsock.destroy()
     unlink.assert_not_called()


### PR DESCRIPTION
- rename LockFile.lock  to acquire
- rename LockFile.unlock to release
- move the lockfile management in sepate functions inside the arbiter
- remove the "closed" argument from the socket.close method and add a new "destroy" function that will be called whent  the socket can be unlinked (cal release)
- fix tests

related to #1263 discussion