### PR TITLE
Bumping MAX_REQUEST_LINE to 32768

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -17,7 +17,7 @@ from gunicorn.http.errors import InvalidProxyLine, ForbiddenProxyRequest
 from gunicorn.six import BytesIO
 from gunicorn._compat import urlsplit
 
-MAX_REQUEST_LINE = 8190
+MAX_REQUEST_LINE = 32768
 MAX_HEADERS = 32768
 MAX_HEADERFIELD_SIZE = 8190
 


### PR DESCRIPTION
My application (https://github.com/airbnb/caravel) emits large URLs in
some rare cases. I like having stateful URLs in my app, but in some rare
corner cases: a markup widget where users can input a larger amount of
text, think documentation for the dashboard they are working on. 

I hate to refactor the entire app to use POST requests for this corner case
when it seems I can just bump the MAX_REQUEST_LINE and get more mileage.

Caravel typically runs on intranets where DOS attacks are not a concern.

From my understanding this change won't affect anyone, it will just
allow a wider spectrum when configuring their app. Note that other web
servers allow configuring this beyond 32k.

This past issue is related to this PR:
https://github.com/benoitc/gunicorn/issues/376