### PR TITLE
gthread: handle removed socket in the select loop

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -179,6 +179,9 @@ class ThreadWorker(base.Worker):
                     except EnvironmentError as e:
                         if e.errno != errno.EBADF:
                             raise
+                    except KeyError:
+                        # already removed by the system, continue
+                        pass
 
                 # close the socket
                 conn.close()


### PR DESCRIPTION
when it happend there are good chance the socket has been removed because it timeouted on the other end. So ignore it.

fix #1258