### PR TITLE
initialize  the group access list for a worker when initgroups is set

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -987,6 +987,23 @@ class Umask(Setting):
         """
 
 
+class Initgroups(Setting):
+    name = "initgroups"
+    section = "Server Mechanics"
+    cli = ["--initgroups"]
+    validator = validate_bool
+    action = 'store_true'
+    default = False
+
+    desc = """\
+        If true, set the worker process's group access list with all of the
+        groups of which the specified username is a member, plus the specified
+        group id.
+
+        .. versionadded:: 19.7
+        """
+
+
 class TmpUploadDir(Setting):
     name = "tmp_upload_dir"
     section = "Server Mechanics"

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -102,7 +102,8 @@ class Worker(object):
             for k, v in self.cfg.env.items():
                 os.environ[k] = v
 
-        util.set_owner_process(self.cfg.uid, self.cfg.gid)
+        util.set_owner_process(self.cfg.uid, self.cfg.gid,
+                               initgroups=self.cfg.initgroups)
 
         # Reseed the random number generator
         util.seed()


### PR DESCRIPTION
Allows the possibility to initialise the group access list when needed to separate privileges

fix #1287