### PR TITLE
Add environment variables to gunicorn access log format

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -471,31 +471,30 @@ access_log_format
 
 The access log format.
 
-===========  ===========
-Identifier   Description
-===========  ===========
-h            remote address
-l            ``'-'``
-u            user name
-t            date of the request
-r            status line (e.g. ``GET / HTTP/1.1``)
-m            request method
-U            URL path without query string
-q            query string
-H            protocol
-s            status
-B            response length
-b            response length or ``'-'`` (CLF format)
-f            referer
-a            user agent
-T            request time in seconds
-D            request time in microseconds
-L            request time in decimal seconds
-p            process ID
-{Header}i    request header
-{Header}o    response header
-{Variable}e  environment variable
-===========  ===========
+==========  ===========
+Identifier  Description
+==========  ===========
+h           remote address
+l           ``'-'``
+u           user name
+t           date of the request
+r           status line (e.g. ``GET / HTTP/1.1``)
+m           request method
+U           URL path without query string
+q           query string
+H           protocol
+s           status
+B           response length
+b           response length or ``'-'`` (CLF format)
+f           referer
+a           user agent
+T           request time in seconds
+D           request time in microseconds
+L           request time in decimal seconds
+p           process ID
+{Header}i   request header
+{Header}o   response header
+==========  ===========
 
 errorlog
 ~~~~~~~~

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -471,30 +471,31 @@ access_log_format
 
 The access log format.
 
-==========  ===========
-Identifier  Description
-==========  ===========
-h           remote address
-l           ``'-'``
-u           user name
-t           date of the request
-r           status line (e.g. ``GET / HTTP/1.1``)
-m           request method
-U           URL path without query string
-q           query string
-H           protocol
-s           status
-B           response length
-b           response length or ``'-'`` (CLF format)
-f           referer
-a           user agent
-T           request time in seconds
-D           request time in microseconds
-L           request time in decimal seconds
-p           process ID
-{Header}i   request header
-{Header}o   response header
-==========  ===========
+===========  ===========
+Identifier   Description
+===========  ===========
+h            remote address
+l            ``'-'``
+u            user name
+t            date of the request
+r            status line (e.g. ``GET / HTTP/1.1``)
+m            request method
+U            URL path without query string
+q            query string
+H            protocol
+s            status
+B            response length
+b            response length or ``'-'`` (CLF format)
+f            referer
+a            user agent
+T            request time in seconds
+D            request time in microseconds
+L            request time in decimal seconds
+p            process ID
+{Header}i    request header
+{Header}o    response header
+{Variable}e  environment variable
+===========  ===========
 
 errorlog
 ~~~~~~~~

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1074,30 +1074,31 @@ class AccessLogFormat(Setting):
     desc = """\
         The access log format.
 
-        ==========  ===========
-        Identifier  Description
-        ==========  ===========
-        h           remote address
-        l           ``'-'``
-        u           user name
-        t           date of the request
-        r           status line (e.g. ``GET / HTTP/1.1``)
-        m           request method
-        U           URL path without query string
-        q           query string
-        H           protocol
-        s           status
-        B           response length
-        b           response length or ``'-'`` (CLF format)
-        f           referer
-        a           user agent
-        T           request time in seconds
-        D           request time in microseconds
-        L           request time in decimal seconds
-        p           process ID
-        {Header}i   request header
-        {Header}o   response header
-        ==========  ===========
+        ===========  ===========
+        Identifier   Description
+        ===========  ===========
+        h            remote address
+        l            ``'-'``
+        u            user name
+        t            date of the request
+        r            status line (e.g. ``GET / HTTP/1.1``)
+        m            request method
+        U            URL path without query string
+        q            query string
+        H            protocol
+        s            status
+        B            response length
+        b            response length or ``'-'`` (CLF format)
+        f            referer
+        a            user agent
+        T            request time in seconds
+        D            request time in microseconds
+        L            request time in decimal seconds
+        p            process ID
+        {Header}i    request header
+        {Header}o    response header
+        {Variable}e  environment variable
+        ===========  ===========
         """
 
 

--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -303,6 +303,10 @@ class Logger(object):
         # add response headers
         atoms.update(dict([("{%s}o" % k.lower(), v) for k, v in resp_headers]))
 
+        # add environ variables
+        environ_variables = environ.items()
+        atoms.update(dict([("{%s}e" % k.lower(), v) for k, v in environ_variables]))
+
         return atoms
 
     def access(self, resp, req, environ, request_time):


### PR DESCRIPTION
Add environment variables to gunicorn access log format using `{Variable}e`.

Updated the docs to include the new identifier.