### PR TITLE
Add --paste-global-conf option

### DIFF
--- a/gunicorn/app/wsgiapp.py
+++ b/gunicorn/app/wsgiapp.py
@@ -56,7 +56,7 @@ class WSGIApplication(Application):
 
         # load the paste app
         from .pasterapp import load_pasteapp
-        return load_pasteapp(self.cfgurl, self.relpath, global_conf=None)
+        return load_pasteapp(self.cfgurl, self.relpath, global_conf=self.cfg.paste_global_conf)
 
     def load(self):
         if self.cfg.paste is not None:

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1791,7 +1791,7 @@ class PasteGlobalConf(Setting):
     name = "raw_paste_global_conf"
     action = "append"
     section = "Server Mechanics"
-    cli = ["--paste-global-conf"]
+    cli = ["--paste-global"]
     meta = "CONF"
     validator = validate_list_string
     default = []
@@ -1799,8 +1799,10 @@ class PasteGlobalConf(Setting):
     desc = """\
         Set a PasteDeploy global config variable (key=value).
 
+        The option can be specified multiple times.
+
         The variables are passed to the the PasteDeploy entrypoint. Ex.::
 
-            $ gunicorn -b 127.0.0.1:8000 --paste development.ini --paste-global-conf FOO=1
+            $ gunicorn -b 127.0.0.1:8000 --paste development.ini --paste-global FOO=1 --paste-global BAR=2
 
         """


### PR DESCRIPTION
While bootstraping gunicorn with `paster` (PasteScript) or `pserve` (Pyramid) is now discouraged, no options are provided for PasteDeploy users to set global configuration variables from the commandline.

This patch adds the new commandline option `--paste-global-conf KEY=VALUE` so that the users can pass arbitrary global_conf values to the PasteDeploy entrypoint.