### PR TITLE
only the arbiter should unlink the unix socket

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -368,6 +368,7 @@ class Arbiter(object):
         if self.reexec_pid == 0 and self.master_pid == 0:
             for l in self.LISTENERS:
                 l.close()
+                l.unlink()
 
         self.LISTENERS = []
         sig = signal.SIGTERM

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -64,6 +64,9 @@ class BaseSocket(object):
 
         self.sock = None
 
+    def unlink(self):
+        return True
+
 
 class TCPSocket(BaseSocket):
 
@@ -120,8 +123,11 @@ class UnixSocket(BaseSocket):
         os.umask(old_umask)
 
     def close(self):
-        os.unlink(self.cfg_addr)
         super(UnixSocket, self).close()
+
+    def unlink(self):
+        os.unlink(self.cfg_addr)
+
 
 
 def _sock_type(addr):

--- a/tests/test_sock.py
+++ b/tests/test_sock.py
@@ -12,4 +12,5 @@ from gunicorn import sock
 def test_unix_socket_close_unlink(fromfd, unlink, getpid):
     gsock = sock.UnixSocket('test.sock', mock.Mock(), mock.Mock(), mock.Mock())
     gsock.close()
+    gsock.unlink()
     unlink.assert_called_with("test.sock")


### PR DESCRIPTION
make unlink explicitly done by the arbiter.

 fix #1298
