### PR TITLE
Refactor socket activation and fd inheritance

### DIFF
--- a/gunicorn/systemd.py
+++ b/gunicorn/systemd.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+import os
+
+SD_LISTEN_FDS_START = 3
+
+
+def listen_fds(unset_environment=True):
+    """
+    Get the number of sockets inherited from systemd socket activation.
+
+    :param unset_environment: clear systemd environment variables unless False
+    :type unset_environment: bool
+    :return: the number of sockets to inherit from systemd socket activation
+    :rtype: int
+
+    Returns zero immediately if $LISTEN_PID is not set to the current pid.
+    Otherwise, returns the number of systemd activation sockets specified by
+    $LISTEN_FDS.
+
+    When $LISTEN_PID matches the current pid, unsets the environment variables
+    unless the ``unset_environment`` flag is ``False``.
+
+    .. note::
+        Unlike the sd_listen_fds C function, this implementation does not set
+        the FD_CLOEXEC flag because the gunicorn arbiter never needs to do this.
+
+    .. seealso::
+        `<https://www.freedesktop.org/software/systemd/man/sd_listen_fds.html>`_
+
+    """
+    fds = int(os.environ.get('LISTEN_FDS', 0))
+    listen_pid = int(os.environ.get('LISTEN_PID', 0))
+
+    if listen_pid != os.getpid():
+        return 0
+
+    if unset_environment:
+        os.environ.pop('LISTEN_PID', None)
+        os.environ.pop('LISTEN_FDS', None)
+
+    return fds

--- a/tests/test_sock.py
+++ b/tests/test_sock.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
 try:
     import unittest.mock as mock
 except ImportError:
@@ -6,13 +11,29 @@ except ImportError:
 from gunicorn import sock
 
 
-@mock.patch('os.close')
-@mock.patch('os.getpid')
+def test_socket_close():
+    listener1 = mock.Mock()
+    listener1.getsockname.return_value = ('127.0.0.1', '80')
+    listener2 = mock.Mock()
+    listener2.getsockname.return_value = ('192.168.2.5', '80')
+    sock.close_sockets([listener1, listener2])
+    listener1.close.assert_called_with()
+    listener2.close.assert_called_with()
+
+
 @mock.patch('os.unlink')
-@mock.patch('socket.fromfd')
-def test_unix_socket_close_unlink(fromfd, unlink, getpid, close):
-    fd = 42
-    gsock = sock.UnixSocket('test.sock', mock.Mock(), mock.Mock(), fd=fd)
-    gsock.close()
-    unlink.assert_called_with("test.sock")
-    close.assert_called_with(fd)
+def test_unix_socket_close_unlink(unlink):
+    listener = mock.Mock()
+    listener.getsockname.return_value = '/var/run/test.sock'
+    sock.close_sockets([listener])
+    listener.close.assert_called_with()
+    unlink.assert_called_once_with('/var/run/test.sock')
+
+
+@mock.patch('os.unlink')
+def test_unix_socket_close_without_unlink(unlink):
+    listener = mock.Mock()
+    listener.getsockname.return_value = '/var/run/test.sock'
+    sock.close_sockets([listener], False)
+    listener.close.assert_called_with()
+    assert not unlink.called, 'unlink should not have been called'

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+from contextlib import contextmanager
+import os
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+import pytest
+
+from gunicorn import systemd
+
+
+@contextmanager
+def check_environ(unset=True):
+    """
+    A context manager that asserts post-conditions of ``listen_fds`` at exit.
+
+    This helper is used to ease checking of the test post-conditions for the
+    systemd socket activation tests that parametrize the call argument.
+    """
+
+    with mock.patch.dict(os.environ):
+        old_fds = os.environ.get('LISTEN_FDS', None)
+        old_pid = os.environ.get('LISTEN_PID', None)
+
+        yield
+
+        if unset:
+            assert 'LISTEN_FDS' not in os.environ, \
+                "LISTEN_FDS should have been unset"
+            assert 'LISTEN_PID' not in os.environ, \
+                "LISTEN_PID should have been unset"
+        else:
+            new_fds = os.environ.get('LISTEN_FDS', None)
+            new_pid = os.environ.get('LISTEN_PID', None)
+            assert new_fds == old_fds, \
+                "LISTEN_FDS should not have been changed"
+            assert new_pid == old_pid, \
+                "LISTEN_PID should not have been changed"
+
+
+@pytest.mark.parametrize("unset", [True, False])
+def test_listen_fds_ignores_wrong_pid(unset):
+    with mock.patch.dict(os.environ):
+        os.environ['LISTEN_FDS'] = str(5)
+        os.environ['LISTEN_PID'] = str(1)
+        with check_environ(False):  # early exit — never changes the environment
+            assert systemd.listen_fds(unset) == 0, \
+                "should ignore listen fds not intended for this pid"
+
+
+@pytest.mark.parametrize("unset", [True, False])
+def test_listen_fds_returns_count(unset):
+    with mock.patch.dict(os.environ):
+        os.environ['LISTEN_FDS'] = str(5)
+        os.environ['LISTEN_PID'] = str(os.getpid())
+        with check_environ(unset):
+            assert systemd.listen_fds(unset) == 5, \
+                "should return the correct count of fds"


### PR DESCRIPTION
Track the use of systemd socket activation and gunicorn socket inheritance
in the arbiter. Unify the logic of creating gunicorn sockets from each of
these sources to always use the socket name to determine the type rather
than checking the configured addresses. The configured addresses are only
used when there is no inheritance from systemd or a parent arbiter.

Fix #1298
