### PR TITLE
feat(import_app): print original exception on AppImportError

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -388,8 +388,7 @@ def import_app(module):
         app = eval(obj, mod.__dict__)
     except NameError:
         exc_type, exc_value, exc_traceback = sys.exc_info()
-        traceback.print_exception(exc_type, exc_value, exc_traceback,
-                                  limit=3, file=sys.stdout)
+        traceback.print_exception(exc_type, exc_value, exc_traceback)
         raise AppImportError("Failed to find application: %r" % module)
 
     if app is None:

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -387,8 +387,7 @@ def import_app(module):
     try:
         app = eval(obj, mod.__dict__)
     except NameError:
-        exc_type, exc_value, exc_traceback = sys.exc_info()
-        traceback.print_exception(exc_type, exc_value, exc_traceback)
+        traceback.print_exception(*sys.exc_info())
         raise AppImportError("Failed to find application: %r" % module)
 
     if app is None:

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -387,6 +387,9 @@ def import_app(module):
     try:
         app = eval(obj, mod.__dict__)
     except NameError:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        traceback.print_exception(exc_type, exc_value, exc_traceback,
+                                  limit=3, file=sys.stdout)
         raise AppImportError("Failed to find application: %r" % module)
 
     if app is None:

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -24,6 +24,7 @@ import inspect
 import errno
 import warnings
 import cgi
+import logging
 
 from gunicorn.errors import AppImportError
 from gunicorn.six import text_type
@@ -384,10 +385,12 @@ def import_app(module):
 
     mod = sys.modules[module]
 
+    is_debug = logging.root.level == logging.DEBUG
     try:
         app = eval(obj, mod.__dict__)
     except NameError:
-        traceback.print_exception(*sys.exc_info())
+        if is_debug:
+            traceback.print_exception(*sys.exc_info())
         raise AppImportError("Failed to find application: %r" % module)
 
     if app is None:


### PR DESCRIPTION
Useful when you have a NameError in the code that creates your app.