### PR TITLE
[RFC] Add a worker_id attribute to workers

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -537,11 +537,20 @@ class Arbiter(object):
                                   "value": active_worker_count,
                                   "mtype": "gauge"})
 
+    def _next_worker_id(self):
+        """
+        Find the first free worker id for the next worker.
+        """
+        candidate = 1
+        while candidate in set(w.worker_id for w in self.WORKERS.values()):
+            candidate += 1
+        return candidate
+
     def spawn_worker(self):
         self.worker_age += 1
         worker = self.worker_class(self.worker_age, self.pid, self.LISTENERS,
                                    self.app, self.timeout / 2.0,
-                                   self.cfg, self.log)
+                                   self.cfg, self.log, self._next_worker_id())
         self.cfg.pre_fork(self, worker)
         pid = os.fork()
         if pid != 0:

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -31,7 +31,7 @@ class Worker(object):
 
     PIPE = []
 
-    def __init__(self, age, ppid, sockets, app, timeout, cfg, log):
+    def __init__(self, age, ppid, sockets, app, timeout, cfg, log, worker_id):
         """\
         This is called pre-fork so it shouldn't do anything to the
         current process. If there's a need to make process wide
@@ -53,6 +53,7 @@ class Worker(object):
         self.alive = True
         self.log = log
         self.tmp = WorkerTmp(cfg)
+        self.worker_id = worker_id
 
     def __str__(self):
         return "<Worker %s>" % self.pid

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -10,6 +10,8 @@ try:
 except ImportError:
     import mock
 
+import pytest
+
 import gunicorn.app.base
 import gunicorn.arbiter
 
@@ -77,3 +79,25 @@ def test_env_vars_available_during_preload():
     # Note that we aren't making any assertions here, they are made in the
     # dummy application object being loaded here instead.
     gunicorn.arbiter.Arbiter(PreloadedAppWithEnvSettings())
+
+
+class DummyWorkerWithID(object):
+    def __init__(self, worker_id):
+        self.worker_id = worker_id
+
+
+@pytest.mark.parametrize("existing_ids,expected_next_id", [
+    ([], 1),      # First worker.
+    ([1, 2], 3),  # Following worker.
+    ([1, 3], 2),  # A worker has died.
+])
+def test_next_worker_id(existing_ids, expected_next_id):
+    """Ensure Worker._next_worker_id picks the correct next id."""
+    arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
+    arbiter.WORKERS = dict(
+        (pid, DummyWorkerWithID(id))
+        for pid, id
+        in enumerate(existing_ids)
+    )
+
+    assert arbiter._next_worker_id() == expected_next_id

--- a/tests/test_gaiohttp.py
+++ b/tests/test_gaiohttp.py
@@ -28,7 +28,8 @@ class WorkerTests(unittest.TestCase):
                                              'app',
                                              'timeout',
                                              Config(),
-                                             'log')
+                                             'log',
+                                             1)
 
     def tearDown(self):
         self.loop.close()


### PR DESCRIPTION
This is my own attempt to fix #1352.

The ID starts at 1 and is increased for each new worker.  If a worker terminates, its ID is reused.  Therefore the highest ID is also the number of active workers.

It doesn’t add any APIs to actually retrieve it within applications (that could be added later?), but it’s already super useful in the `post_fork` callback (and any other callback that receives the `worker` argument for that matter).

Is this something that you would accept?  My understanding is that the master process is in any case single-threaded so there’s no need for locking?  Where would I put documentation?

Let me know what you think!