### PR TITLE
Add some more knobs to the setproctitle functionality

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -103,6 +103,10 @@ class Arbiter(object):
         self.num_workers = self.cfg.workers
         self.timeout = self.cfg.timeout
         self.proc_name = self.cfg.proc_name
+        self.proc_name_format = self.cfg.proc_name_format
+        self.proc_name_prefix = self.cfg.proc_name_prefix
+        self.worker_identifier = self.cfg.worker_identifier
+        self.master_identifier = self.cfg.master_identifier
 
         self.log.debug('Current configuration:\n{0}'.format(
             '\n'.join(
@@ -183,7 +187,7 @@ class Arbiter(object):
     def run(self):
         "Main master loop."
         self.start()
-        util._setproctitle("master [%s]" % self.proc_name)
+        util._setproctitle(self.proc_name_format, self.proc_name_prefix, self.master_identifier, self.proc_name)
 
         try:
             self.manage_workers()
@@ -309,12 +313,16 @@ class Arbiter(object):
             self.master_name = "Master"
             self.master_pid = 0
             self.proc_name = self.cfg.proc_name
+            self.proc_name_format = self.cfg.proc_name_format
+            self.proc_name_prefix = self.cfg.proc_name_prefix
+            self.worker_identifier = self.cfg.worker_identifier
+            self.master_identifier = self.cfg.master_identifier
             del os.environ['GUNICORN_PID']
             # rename the pidfile
             if self.pidfile is not None:
                 self.pidfile.rename(self.cfg.pidfile)
             # reset proctitle
-            util._setproctitle("master [%s]" % self.proc_name)
+            util._setproctitle(self.proc_name_format, self.proc_name_prefix, self.master_identifier, self.proc_name)
 
     def wakeup(self):
         """\
@@ -456,7 +464,7 @@ class Arbiter(object):
             self.pidfile.create(self.pid)
 
         # set new proc_name
-        util._setproctitle("master [%s]" % self.proc_name)
+        util._setproctitle(self.proc_name_format, self.proc_name_prefix, self.master_identifier, self.proc_name)
 
         # spawn new workers
         for i in range(self.cfg.workers):
@@ -551,7 +559,7 @@ class Arbiter(object):
         # Process Child
         worker_pid = os.getpid()
         try:
-            util._setproctitle("worker [%s]" % self.proc_name)
+            util._setproctitle(self.proc_name_format, self.proc_name_prefix, self.worker_identifier, self.proc_name)
             self.log.info("Booting worker with pid: %s", worker_pid)
             self.cfg.post_fork(self, worker)
             worker.init_process()

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -133,6 +133,22 @@ class Config(object):
         return self.settings['group'].get()
 
     @property
+    def proc_name_format(self):
+        return self.settings["proc_name_format"].get()
+
+    @property
+    def proc_name_prefix(self):
+        return self.settings["proc_name_prefix"].get()
+
+    @property
+    def master_identifier(self):
+        return self.settings["master_identifier"].get()
+
+    @property
+    def worker_identifier(self):
+        return self.settings["worker_identifier"].get()
+
+    @property
     def proc_name(self):
         pn = self.settings['proc_name'].get()
         if pn is not None:
@@ -1342,6 +1358,82 @@ class StatsdPrefix(Setting):
 
     .. versionadded:: 19.2
     """
+
+
+class ProcnameFormat(Setting):
+    name = "proc_name_format"
+    section = "Process Naming"
+    cli = ["--name-format"]
+    meta = "STRING"
+    validator = validate_string
+    default = "{proc_name_prefix}: {identifier} [{proc_name}]"
+    desc = """\
+        The format to use with setproctitle for process naming. Should be in the form of a Python format string with places for "proc_name_prefix", "identifier", and "proc_name".
+
+        If not set, defaults to "{proc_name_prefix}: {master_identifier} [{proc_name}]" and "{proc_name_prefix}: {worker_identifier} [{proc_name}]"
+
+        This affects things like ``ps`` and ``top``. If you're going to be
+        running more than one instance of Gunicorn you'll probably want to set a
+        name to tell them apart. This requires that you install the setproctitle
+        module.
+        """
+
+
+class ProcnamePrefix(Setting):
+    name = "proc_name_prefix"
+    section = "Process Naming"
+    cli = ["--name-prefix"]
+    meta = "STRING"
+    validator = validate_string
+    default = "gunicorn"
+    desc = """\
+        A prefix to use with setproctitle for process naming. Fills the "proc_name_prefix" portion of the proc_name_format string.
+
+        If not set, defaults to "gunicorn".
+
+        This affects things like ``ps`` and ``top``. If you're going to be
+        running more than one instance of Gunicorn you'll probably want to set a
+        name to tell them apart. This requires that you install the setproctitle
+        module.
+        """
+
+
+class WorkerIdentifier(Setting):
+    name = "worker_identifier"
+    section = "Process Naming"
+    cli = ["--name-worker"]
+    meta = "STRING"
+    validator = validate_string
+    default = "worker"
+    desc = """\
+        How to identify worker processes when using setproctitle. Fills the "identifier" portion of the proc_name_format string.
+
+        If not set, defaults to "worker".
+
+        This affects things like ``ps`` and ``top``. If you're going to be
+        running more than one instance of Gunicorn you'll probably want to set a
+        name to tell them apart. This requires that you install the setproctitle
+        module.
+        """
+
+
+class MasterIdentifier(Setting):
+    name = "master_identifier"
+    section = "Process Naming"
+    cli = ["--name-master"]
+    meta = "STRING"
+    validator = validate_string
+    default = "master"
+    desc = """\
+        How to identify the master process when using setproctitle. Fills the "identifier" portion of the proc_name_format string.
+
+        If not set, defaults to "master".
+
+        This affects things like ``ps`` and ``top``. If you're going to be
+        running more than one instance of Gunicorn you'll probably want to set a
+        name to tell them apart. This requires that you install the setproctitle
+        module.
+        """
 
 
 class Procname(Setting):

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1368,9 +1368,12 @@ class ProcnameFormat(Setting):
     validator = validate_string
     default = "{proc_name_prefix}: {identifier} [{proc_name}]"
     desc = """\
-        The format to use with setproctitle for process naming. Should be in the form of a Python format string with places for "proc_name_prefix", "identifier", and "proc_name".
+        The format to use with setproctitle for process naming. Should be in
+        the form of a Python format string with places for "proc_name_prefix",
+        "identifier", and "proc_name".
 
-        If not set, defaults to "{proc_name_prefix}: {master_identifier} [{proc_name}]" and "{proc_name_prefix}: {worker_identifier} [{proc_name}]"
+        If not set, defaults to "{proc_name_prefix}: {master_identifier} [{proc_name}]"
+        and "{proc_name_prefix}: {worker_identifier} [{proc_name}]"
 
         This affects things like ``ps`` and ``top``. If you're going to be
         running more than one instance of Gunicorn you'll probably want to set a
@@ -1387,7 +1390,8 @@ class ProcnamePrefix(Setting):
     validator = validate_string
     default = "gunicorn"
     desc = """\
-        A prefix to use with setproctitle for process naming. Fills the "proc_name_prefix" portion of the proc_name_format string.
+        A prefix to use with setproctitle for process naming. Fills the
+        "proc_name_prefix" portion of the proc_name_format string.
 
         If not set, defaults to "gunicorn".
 
@@ -1406,7 +1410,8 @@ class WorkerIdentifier(Setting):
     validator = validate_string
     default = "worker"
     desc = """\
-        How to identify worker processes when using setproctitle. Fills the "identifier" portion of the proc_name_format string.
+        How to identify worker processes when using setproctitle. Fills the
+        "identifier" portion of the proc_name_format string.
 
         If not set, defaults to "worker".
 
@@ -1425,7 +1430,8 @@ class MasterIdentifier(Setting):
     validator = validate_string
     default = "master"
     desc = """\
-        How to identify the master process when using setproctitle. Fills the "identifier" portion of the proc_name_format string.
+        How to identify the master process when using setproctitle. Fills the
+        "identifier" portion of the proc_name_format string.
 
         If not set, defaults to "master".
 

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -56,10 +56,10 @@ hop_headers = set("""
 try:
     from setproctitle import setproctitle
 
-    def _setproctitle(title):
-        setproctitle("gunicorn: %s" % title)
+    def _setproctitle(fmt, prefix, identifier, proc_name):
+        setproctitle(fmt.format(proc_name_prefix=prefix, identifier=identifier, proc_name=proc_name))
 except ImportError:
-    def _setproctitle(title):
+    def _setproctitle(fmt, prefix, identifier, proc_name):
         return
 
 


### PR DESCRIPTION
 -  the existing implementation falls short because start-stop-daemon is unable to work with gunicorn if setproctitle is used or even
installed
 - allow users to set the format of process names
 - allow users to override the "gunicorn" prefix
 - allow users to override the "master" and "worker" identifiers

Closes https://github.com/benoitc/gunicorn/issues/1372