### PR TITLE
Add a configurable amount of jitter between spawning new Workers.

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -588,7 +588,7 @@ class Arbiter(object):
 
         for i in range(self.num_workers - len(self.WORKERS.keys())):
             self.spawn_worker()
-            time.sleep(0.1 * random.random())
+            time.sleep(self.cfg.spawn_worker_sleep_time * random.uniform(1,2))
 
     def kill_workers(self, sig):
         """\

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -588,7 +588,7 @@ class Arbiter(object):
 
         for i in range(self.num_workers - len(self.WORKERS.keys())):
             self.spawn_worker()
-            time.sleep(self.cfg.spawn_worker_sleep_time * random.uniform(1,2))
+            time.sleep(self.cfg.spawn_jitter_time * random.uniform(1,2))
 
     def kill_workers(self, sig):
         """\

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1832,6 +1832,7 @@ if sys.version_info >= (2, 7):
         Ciphers to use (see stdlib ssl module's)
         """
 
+
 class PasteGlobalConf(Setting):
     name = "raw_paste_global_conf"
     action = "append"
@@ -1858,7 +1859,7 @@ class SpawnWorkerSleepTime(Setting):
     section = "Worker Processes"
     cli = ['--spawn-worker-sleep-time']
     validator = validate_float
-    default = 0.1
+    default = 0.05
     desc = """\
     Minimum time to sleep between spawning workers in seconds.
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1854,15 +1854,15 @@ class PasteGlobalConf(Setting):
         .. versionadded:: 20.0
         """
 
-class SpawnWorkerSleepTime(Setting):
-    name = "spawn_worker_sleep_time"
+class SpawnJitterTime(Setting):
+    name = "spawn_jitter_time"
     section = "Worker Processes"
-    cli = ['--spawn-worker-sleep-time']
+    cli = ['--spawn-jitter-time']
     validator = validate_float
     default = 0.05
     desc = """\
     Minimum time to sleep between spawning workers in seconds.
 
     The amount of time spent sleeping between spawning new workers will jitter
-    from spawn-worker-sleep-time to 2 * spawn-worker-sleep-time.
+    from spawn-jitter-time to 2 * spawn-jitter-time.
     """

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -346,6 +346,15 @@ def validate_pos_int(val):
     return val
 
 
+def validate_float(val):
+    if not val:
+        return 0.0
+    try:
+        return float(val)
+    except TypeError:
+        raise TypeError("Value is not a float: %s" % val)
+
+
 def validate_string(val):
     if val is None:
         return None
@@ -1823,7 +1832,6 @@ if sys.version_info >= (2, 7):
         Ciphers to use (see stdlib ssl module's)
         """
 
-
 class PasteGlobalConf(Setting):
     name = "raw_paste_global_conf"
     action = "append"
@@ -1844,3 +1852,16 @@ class PasteGlobalConf(Setting):
 
         .. versionadded:: 20.0
         """
+
+class SpawnWorkerSleepTime(Setting):
+    name = "spawn_worker_sleep_time"
+    section = "Worker Processes"
+    cli = ['--spawn-worker-sleep-time']
+    validator = validate_float
+    default = 0.1
+    desc = """\
+    Minimum time to sleep between spawning workers in seconds.
+
+    The amount of time spent sleeping between spawning new workers will jitter
+    from spawn-worker-sleep-time to 2 * spawn-worker-sleep-time.
+    """


### PR DESCRIPTION
We've been using this pathc in order to prevent thundering herds of new workers when hot
restarting some of our highest QPS services.
