### PR TITLE
Add --delay-pidfile option for on the fly upgrades

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -945,6 +945,21 @@ class Pidfile(Setting):
         If not set, no PID file will be written.
         """
 
+class DelayPidfile(Setting):
+    name = "delay_pidfile"
+    section = "Server Mechanics"
+    cli = ["--delay-pidfile"]
+    validator = validate_bool
+    action = "store_true"
+    default = False
+    desc = """\
+        If pidfile is set, delay creation until workers have booted.
+
+        This setting is useful during on the fly upgrades as a mechanism for
+        signaling when a graceful shutdown of the old master process should be
+        initiated.
+        """
+
 class WorkerTmpDir(Setting):
     name = "worker_tmp_dir"
     section = "Server Mechanics"

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -53,6 +53,7 @@ class Worker(object):
         self.alive = True
         self.log = log
         self.tmp = WorkerTmp(cfg)
+        self.start_time = self.tmp.last_update()
 
     def __str__(self):
         return "<Worker %s>" % self.pid


### PR DESCRIPTION
When running very high QPS services, we've ran into race conditions where the pidfile gets created before all of the workers have finished booting, which then leads the wrapper we have for Gunicorn to handle hot restarts (Rainbow Saddle) killing the old master before the new master is fully booted.

This flag will delay pidfile creation until all of the workers have booted, ensuring we don't tear down the old master until the new one is ready.
