### PR TITLE
Fix validate_reload by returning the validated value

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -256,7 +256,7 @@ reload
 ~~~~~~
 
 * ``--reload RELOADER_TYPE``
-* ``None``
+* ``off``
 
 Restart workers when code changes.
 
@@ -270,8 +270,8 @@ application code or the reload will not work as designed.
 When using this option, you can optionally specify whether you would
 like to use file system polling or the kernel's inotify API to watch
 for changes. Generally, inotify should be preferred if available
-because it consumes less system resources. If no preference is given,
-inotify will attempted with a fallback to FS polling.
+because it consumes less system resources. The default behavior (auto)
+is to attempt inotify with a fallback to FS polling.
 
 Note: In order to use the inotify reloader, you must have the 'inotify'
 package installed.

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -501,6 +501,8 @@ def validate_reloader(val):
             'Invalid reloader type. Must be one of: %s' % choices
         )
 
+    return val
+
 
 def get_default_config_file():
     config_path = os.path.join(os.path.abspath(os.getcwd()),

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -492,9 +492,9 @@ def validate_hostport(val):
 
 def validate_reloader(val):
     if val is None:
-        val = 'default'
+        val = 'auto'
 
-    choices = ['poll', 'inotify', 'default']
+    choices = ['auto', 'poll', 'inotify', 'off']
 
     if val not in choices:
         raise ConfigError(
@@ -822,9 +822,7 @@ class Reload(Setting):
     section = 'Debugging'
     cli = ['--reload']
     validator = validate_reloader
-    nargs = '?'
-    const = 'default'
-    default = None
+    default = 'off'
     meta = 'RELOADER_TYPE'
 
     desc = '''\
@@ -840,8 +838,8 @@ class Reload(Setting):
         When using this option, you can optionally specify whether you would
         like to use file system polling or the kernel's inotify API to watch
         for changes. Generally, inotify should be preferred if available
-        because it consumes less system resources. If no preference is given,
-        inotify will attempted with a fallback to FS polling.
+        because it consumes less system resources. The default behavior (auto)
+        is to attempt inotify with a fallback to FS polling.
 
         Note: In order to use the inotify reloader, you must have the 'inotify'
         package installed.

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -115,7 +115,7 @@ class Worker(object):
         self.load_wsgi()
 
         # start the reloader
-        if self.cfg.reload:
+        if self.cfg.reload and self.cfg.reload != 'off':
             def changed(fname):
                 self.log.info("Worker reloading: %s modified", fname)
                 self.alive = False


### PR DESCRIPTION
When '--reload=RELOADER_TYPE' was implemented, `validate_reload()` was
added but in one of the last refactorings, it lost the return statement
at the end of the function. As a result, the '--reload' config value was
totally broken.

This resolves the issue by adding the missing return.

My first commit failed because the default value of the setting (`None`) was not the same as the output of its validator when `None` was passed in. At this point, I realized that trying to keep ``--reload`` (with no argument) is virtually impossible because of the ambiguity when we allow `--reload` by itself and `--reload RELOADER_TYPE`. For instance, running `gunicorn --reload myapp:app` now results in an error because `myapp:app` is now seen as the argument to `--reload` instead of the app module name.

I think the best thing to do here is to eliminate the ambiguity by always requiring an argument to `--reload`, set the default to `off`, and add the `auto` option which does the inotify (if available) and fallback to polling.