### PR TITLE
Reject requests like "GET / HTTP/1a1"

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -23,7 +23,7 @@ DEFAULT_MAX_HEADERFIELD_SIZE = 8190
 
 HEADER_RE = re.compile("[\x00-\x1F\x7F()<>@,;:\[\]={} \t\\\\\"]")
 METH_RE = re.compile(r"[A-Z0-9$-_.]{3,20}")
-VERSION_RE = re.compile(r"HTTP/(\d+).(\d+)")
+VERSION_RE = re.compile(r"HTTP/(\d+)\.(\d+)")
 
 
 class Message(object):

--- a/tests/requests/invalid/018.http
+++ b/tests/requests/invalid/018.http
@@ -1,0 +1,3 @@
+GET /test HTTP/111\r\n
+Host: localhost\r\n
+\r\n

--- a/tests/requests/invalid/018.py
+++ b/tests/requests/invalid/018.py
@@ -1,0 +1,2 @@
+from gunicorn.http.errors import InvalidHTTPVersion
+request = InvalidHTTPVersion


### PR DESCRIPTION
Numbers must be separated by dot. This makes life
a little bit harder for attackers who would like to inject specially crafted packets after GET / (e.g. in nginx there are sometimes regular expressions like (?P<action>[^.]).html