### PR TITLE
Add --server_name and --no_server_name options #825

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -463,7 +463,7 @@ server_name
 ~~~~~~~~~~~~~~~~~~~
 
 * ``--server_name STRING``
-* ``gunicorn\X.Y.Z``
+* ``gunicorn/X.Y.Z``
 
 Server name to use in the ``Server`` HTTP Header on responses.
 

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -459,6 +459,22 @@ Set to ``*`` to disable checking of Front-end IPs (useful for setups
 where you don't know in advance the IP address of Front-end, but
 you still trust the environment)
 
+server_name
+~~~~~~~~~~~~~~~~~~~
+
+* ``--server_name STRING``
+* ``gunicorn\X.Y.Z``
+
+Server name to use in the ``Server`` HTTP Header on responses.
+
+server_name
+~~~~~~~~~~~~~~~~~~~
+
+* ``--no_server_name``
+* ``None``
+
+If set, the ``Server`` HTTP Header will not be returned on responses.
+
 Logging
 -------
 
@@ -1003,4 +1019,3 @@ ciphers
 * ``TLSv1``
 
 Ciphers to use (see stdlib ssl module's)
-

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -21,6 +21,7 @@ import textwrap
 
 from gunicorn import __version__
 from gunicorn import _compat
+from gunicorn import SERVER_SOFTWARE
 from gunicorn.errors import ConfigError
 from gunicorn import six
 from gunicorn import util
@@ -1835,4 +1836,36 @@ class PasteGlobalConf(Setting):
             $ gunicorn -b 127.0.0.1:8000 --paste development.ini --paste-global FOO=1 --paste-global BAR=2
 
         .. versionadded:: 20.0
+        """
+
+
+class ServerName(Setting):
+    name = "server_name"
+    section = "Server Mechanics"
+    cli = ["--server-name"]
+    validator = validate_string
+    default = SERVER_SOFTWARE
+
+    desc = """\
+        Server name to use in the ``Server`` HTTP Header on responses.
+
+        If not set, the default Gunicorn server name will be used:
+        ``gunicorn\X.Y.Z``.
+
+        .. versionadded:: 19.6
+        """
+
+
+class NoServerName(Setting):
+    name = "no_server_name"
+    section = "Server Mechanics"
+    cli = ["--no-server-name"]
+    validator = validate_bool
+    action = "store_true"
+    default = False
+
+    desc = """\
+        If set, the ``Server`` HTTP Header will not be returned on responses.
+
+        .. versionadded:: 19.6
         """

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1850,7 +1850,7 @@ class ServerName(Setting):
         Server name to use in the ``Server`` HTTP Header on responses.
 
         If not set, the default Gunicorn server name will be used:
-        ``gunicorn\X.Y.Z``.
+        ``gunicorn/X.Y.Z``.
 
         .. versionadded:: 19.6
         """

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -214,7 +214,6 @@ class Response(object):
     def __init__(self, req, sock, cfg):
         self.req = req
         self.sock = sock
-        self.version = SERVER_SOFTWARE
         self.status = None
         self.chunked = False
         self.must_close = False
@@ -320,10 +319,12 @@ class Response(object):
         headers = [
             "HTTP/%s.%s %s\r\n" % (self.req.version[0],
                 self.req.version[1], self.status),
-            "Server: %s\r\n" % self.version,
             "Date: %s\r\n" % util.http_date(),
             "Connection: %s\r\n" % connection
         ]
+        if self.cfg and self.cfg.no_server_name is False \
+                and self.cfg.server_name:
+            headers.append("Server: %s\r\n" % self.cfg.server_name)
         if self.chunked:
             headers.append("Transfer-Encoding: chunked\r\n")
         return headers

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ import sys
 import pytest
 
 from gunicorn import config
+from gunicorn import SERVER_SOFTWARE
 from gunicorn.app.base import Application
 from gunicorn.workers.sync import SyncWorker
 from gunicorn import glogging
@@ -285,3 +286,17 @@ def test_always_use_configured_logger():
     c.set('statsd_host', 'localhost:12345')
     # still uses custom logger over statsd
     assert c.logger_class == MyLogger
+
+
+def test_server_name():
+    c = config.Config()
+    assert c.server_name == SERVER_SOFTWARE
+    c.set('server_name', 'Server x.y')
+    assert c.server_name == 'Server x.y'
+
+
+def test_no_server_name():
+    c = config.Config()
+    assert c.no_server_name == False
+    c.set('no_server_name', True)
+    assert c.no_server_name == True

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -3,7 +3,9 @@
 import t
 import pytest
 
+from gunicorn import config
 from gunicorn import util
+from gunicorn import SERVER_SOFTWARE
 from gunicorn.http.body import Body, LengthReader, EOFReader
 from gunicorn.http.wsgi import Response
 from gunicorn.http.unreader import Unreader, IterUnreader, SocketUnreader
@@ -226,3 +228,37 @@ def test_eof_reader_read_invalid_size():
         reader.read([100])
     with pytest.raises(ValueError):
         reader.read(-100)
+
+
+def test_server_name_response_header():
+    """ tests whether the http server name is set correctly """
+
+    def get_server_name_header_value(headers):
+        """ return the value of the ``Server`` HTTP Header """
+        for header in headers:
+            if header[:8] == 'Server: ':
+                return header[8:].strip()
+        return None
+
+    mocked_socket = mock.MagicMock()
+    mocked_socket.sendall = mock.MagicMock()
+
+    mocked_request = mock.MagicMock()
+    c = config.Config()
+
+    # use case: return default server header
+    response = Response(mocked_request, mocked_socket, c)
+    headers = response.default_headers()
+    assert get_server_name_header_value(headers) == SERVER_SOFTWARE
+
+    # use case: return custom server header
+    c.set('server_name', 'Server x.y')
+    response = Response(mocked_request, mocked_socket, c)
+    headers = response.default_headers()
+    assert get_server_name_header_value(headers) == 'Server x.y'
+
+    # use case: return no server header
+    c.set('no_server_name', True)
+    response = Response(mocked_request, mocked_socket, c)
+    headers = response.default_headers()
+    assert get_server_name_header_value(headers) is None


### PR DESCRIPTION
Set `--server_name` to return a different HTTP Server response header than `gunicorn/19.6.0`.
Set `--no_server_name` to no longer return the header.