### PR TITLE
Add child_exit() callback to configuration

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -548,14 +548,15 @@ class Arbiter(object):
         self.cfg.pre_fork(self, worker)
         pid = os.fork()
         if pid != 0:
+            worker.pid = pid
             self.WORKERS[pid] = worker
             return pid
 
         # Process Child
-        worker_pid = os.getpid()
+        worker.pid = os.getpid()
         try:
             util._setproctitle("worker [%s]" % self.proc_name)
-            self.log.info("Booting worker with pid: %s", worker_pid)
+            self.log.info("Booting worker with pid: %s", worker.pid)
             self.cfg.post_fork(self, worker)
             worker.init_process()
             sys.exit(0)
@@ -573,7 +574,7 @@ class Arbiter(object):
                 sys.exit(self.WORKER_BOOT_ERROR)
             sys.exit(-1)
         finally:
-            self.log.info("Worker exiting (pid: %s)", worker_pid)
+            self.log.info("Worker exiting (pid: %s)", worker.pid)
             try:
                 worker.tmp.close()
                 self.cfg.worker_exit(self, worker)

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1634,6 +1634,23 @@ class PostRequest(Setting):
         """
 
 
+class ChildExit(Setting):
+    name = "child_exit"
+    section = "Server Hooks"
+    validator = validate_callable(2)
+    type = six.callable
+
+    def child_exit(server, worker):
+        pass
+    default = staticmethod(child_exit)
+    desc = """\
+        Called just after a worker has been exited, in the master process.
+
+        The callable needs to accept two instance variables for the Arbiter and
+        the just-exited Worker.
+        """
+
+
 class WorkerExit(Setting):
     name = "worker_exit"
     section = "Server Hooks"
@@ -1644,7 +1661,7 @@ class WorkerExit(Setting):
         pass
     default = staticmethod(worker_exit)
     desc = """\
-        Called just after a worker has been exited.
+        Called just after a worker has been exited, in the worker process.
 
         The callable needs to accept two instance variables for the Arbiter and
         the just-exited Worker.

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -38,6 +38,7 @@ class Worker(object):
         changes you'll want to do that in ``self.init_process()``.
         """
         self.age = age
+        self.pid = "[booting]"
         self.ppid = ppid
         self.sockets = sockets
         self.app = app
@@ -56,10 +57,6 @@ class Worker(object):
 
     def __str__(self):
         return "<Worker %s>" % self.pid
-
-    @property
-    def pid(self):
-        return os.getpid()
 
     def notify(self):
         """\

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -55,6 +55,18 @@ def test_arbiter_calls_worker_exit(mock_os_fork):
     arbiter.cfg.worker_exit.assert_called_with(arbiter, mock_worker)
 
 
+@mock.patch('os.waitpid')
+def test_arbiter_reap_workers(mock_os_waitpid):
+    mock_os_waitpid.side_effect = [(42, 0), (0, 0)]
+    arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
+    arbiter.cfg.settings['child_exit'] = mock.Mock()
+    mock_worker = mock.Mock()
+    arbiter.WORKERS = {42: mock_worker}
+    arbiter.reap_workers()
+    mock_worker.tmp.close.assert_called_with()
+    arbiter.cfg.child_exit.assert_called_with(arbiter, mock_worker)
+
+
 class PreloadedAppWithEnvSettings(DummyApplication):
     """
     Simple application that makes use of the 'preload' feature to


### PR DESCRIPTION
This adds a `child_exit()` callback to the Gunicorn configuration that works similar to `worker_exit()` but is called in the *master* process instead of the *child process*.

I also added some basic unit tests for the both.

A change to how `Worker.pid` is implemented was necessary in order for it to be meaningful in the master process (it would always be the PID of the master process, no information given about the worker process).

Our need for this is prometheus/client_python#115