### PR TITLE
allow --reload without any value

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -822,8 +822,10 @@ class Reload(Setting):
     section = 'Debugging'
     cli = ['--reload']
     validator = validate_reloader
+    const = 'auto'
     default = 'off'
     meta = 'RELOADER_TYPE'
+    nargs = '?'
 
     desc = '''\
         Restart workers when code changes.


### PR DESCRIPTION
The documentation suggests that the value is optional, but without
this change it is not.