### PR TITLE
Update arbiter.py to not leave tmp files around (fix #1327)

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -565,6 +565,10 @@ class Arbiter(object):
             self.WORKERS[pid] = worker
             return pid
 
+        # Do not inherit the temporary files of other workers
+        for sibling in self.WORKERS.values():
+            sibling.tmp.close()
+        
         # Process Child
         worker_pid = os.getpid()
         try:


### PR DESCRIPTION
(deleted) tmp files left around #1327