### PR TITLE
Document pidfile naming format change in 19.6.0

### DIFF
--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -10,6 +10,8 @@ Core & Logging
 
 - improvement of the binary upgrade behaviour using ``USR2``: remove file
   locking (:issue:`1270`)
+- PID file naming format has been changed from ``<name>.pid.oldbin`` to
+  ``<name>.pid.2`` (:issue:`1270`)
 - add the ``--capture-output`` setting to capture stdout/stderr to the log
   file (:issue:`1271`)
 - Allow disabling ``sendfile()`` via the ``SENDFILE`` environment variable

--- a/docs/source/signals.rst
+++ b/docs/source/signals.rst
@@ -63,6 +63,10 @@ option), Gunicorn will also load the new version.
 Upgrading to a new binary on the fly
 ====================================
 
+.. versionchanged:: 19.6.0
+   PID file naming format has been changed from ``<name>.pid.oldbin`` to
+   ``<name>.pid.2``.
+
 If you need to replace the Gunicorn binary with a new one (when
 upgrading to a new version or adding/removing server modules), you can
 do it without any service downtime - no incoming requests will be


### PR DESCRIPTION
Fixes #1382