### PR TITLE
Doc tweaks around threads setting

### DIFF
--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -113,7 +113,7 @@ How Many Threads?
 ===================
 
 Since Gunicorn 19, a threads option can be used to process requests in multiple
-threads. Using threads assumes use of the sync worker. One benefit from threads
+threads. Using threads assumes use of the gthread worker. One benefit from threads
 is that requests can take longer than the worker timeout while notifying the
 master process that it is not frozen and should not be killed. Depending on the
 system, using multiple threads, multiple worker processes, or some mixture, may

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -148,6 +148,8 @@ application's work load.
 
 If it is not defined, the default is ``1``.
 
+This setting only affects the Gthread worker type.
+
 .. _worker-connections:
 
 worker_connections
@@ -1214,4 +1216,3 @@ The variables are passed to the the PasteDeploy entrypoint. Example::
     $ gunicorn -b 127.0.0.1:8000 --paste development.ini --paste-global FOO=1 --paste-global BAR=2
 
 .. versionadded:: 19.7
-

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -654,6 +654,8 @@ class WorkerThreads(Setting):
         application's work load.
 
         If it is not defined, the default is ``1``.
+
+        This setting only affects the Gthread worker type.
         """
 
 


### PR DESCRIPTION
In response to #1045 minor tweaks to the documentation to emphasize that
the `--threads` setting is only applied to the `gthread` worker.