### PR TITLE
move pytest cli args to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,8 @@ group = System Environment/Daemons
 
 [pytest]
 norecursedirs = examples lib local src
+testpaths = tests/
+addopts = --assert=plain
 
 [wheel]
 universal = 1

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 
 [testenv]
 usedevelop = True
-commands = py.test {posargs:tests/} --assert=plain
+commands = py.test {posargs}
 deps =
   -rrequirements_test.txt
   py26: unittest2


### PR DESCRIPTION
This makes the experience of running pytest consistent whether pytest was called from the command line using `py.test` or via `tox`.