### PR TITLE
submit coverage report to couverture.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ setuptools-*
 *.egg-info
 nohup.out
 .coverage
+coverage.xml
 examples/frameworks/pylonstest/PasteScript*
 examples/frameworks/pylonstest/pylonstest.egg-info/
 examples/frameworks/django/testing/testdb.sql

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,20 @@ cache:
   directories:
     - .tox
     - $HOME/.cache/pip
+after_script:
+  - |
+      if [ ! -f coverage.xml ]; then
+          echo "No coverage.xml found; skipping sending coverage to couverture.io"
+          return
+      fi
+      if [ $TRAVIS_PULL_REQUEST != false ]; then
+          REAL_COMMIT=$(git log -n 1 $TRAVIS_COMMIT_RANGE --format="%H")
+          PR_NUM=$TRAVIS_PULL_REQUEST
+      else
+          REAL_COMMIT=$TRAVIS_COMMIT
+      fi
+      curl \
+          --verbose \
+          --header "X-Couverture-Pull-Request: $PR_NUM" \
+          --data-binary @coverage.xml \
+          "https://app.couverture.io/coverage/github/benoitc/gunicorn/$REAL_COMMIT/$TOXENV"

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ group = System Environment/Daemons
 [tool:pytest]
 norecursedirs = examples lib local src
 testpaths = tests/
-addopts = --assert=plain
+addopts = --assert=plain --cov=gunicorn --cov-report=xml
 
 [wheel]
 universal = 1


### PR DESCRIPTION
This publishes coverage reports of each travis build to www.couverture.io

Steps needed to be taken by @benoitc in order for this to work:
* go to www.couverture.io and click "enable" on the gunicorn repository.

I will iterate on this PR as necessary once the step mentioned above is completed. Thanks! :)