### PR TITLE
Add support for --reload-engine

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -23,6 +23,7 @@ import shlex
 from gunicorn import __version__
 from gunicorn import _compat
 from gunicorn.errors import ConfigError
+from gunicorn.reloader import reloader_engines
 from gunicorn import six
 from gunicorn import util
 
@@ -496,6 +497,13 @@ def validate_hostport(val):
         raise TypeError("Value must consist of: hostname:port")
 
 
+def validate_reload_engine(val):
+    if val not in reloader_engines:
+        raise ConfigError("Invalid reload_engine: %r" % val)
+
+    return val
+
+
 def get_default_config_file():
     config_path = os.path.join(os.path.abspath(os.getcwd()),
             'gunicorn.conf.py')
@@ -836,6 +844,26 @@ class Reload(Setting):
            In order to use the inotify reloader, you must have the ``inotify``
            package installed.
         '''
+
+
+class ReloadEngine(Setting):
+    name = "reload_engine"
+    section = "Debugging"
+    cli = ["--reload-engine"]
+    meta = "STRING"
+    validator = validate_reload_engine
+    default = "auto"
+    desc = """\
+        The implementation that should be used to power :ref:`reload`.
+
+        Valid engines are:
+
+        * 'auto'
+        * 'poll'
+        * 'inotify' (requires inotify)
+
+        .. versionadded:: 19.7
+        """
 
 
 class Spew(Setting):

--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -115,3 +115,9 @@ if has_inotify:
 
 
 preferred_reloader = InotifyReloader if has_inotify else Reloader
+
+reloader_engines = {
+    'auto': preferred_reloader,
+    'poll': Reloader,
+    'inotify': InotifyReloader,
+}

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -15,7 +15,7 @@ import traceback
 from gunicorn import six
 from gunicorn import util
 from gunicorn.workers.workertmp import WorkerTmp
-from gunicorn.reloader import preferred_reloader
+from gunicorn.reloader import reloader_engines
 from gunicorn.http.errors import (
     InvalidHeader, InvalidHeaderName, InvalidRequestLine, InvalidRequestMethod,
     InvalidHTTPVersion, LimitRequestLine, LimitRequestHeaders,
@@ -119,7 +119,8 @@ class Worker(object):
                 time.sleep(0.1)
                 sys.exit(0)
 
-            self.reloader = preferred_reloader(callback=changed)
+            reloader_cls = reloader_engines[self.cfg.reload_engine]
+            self.reloader = reloader_cls(callback=changed)
             self.reloader.start()
 
         self.load_wsgi()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ import pytest
 
 from gunicorn import config
 from gunicorn.app.base import Application
+from gunicorn.errors import ConfigError
 from gunicorn.workers.sync import SyncWorker
 from gunicorn import glogging
 from gunicorn.instrument import statsd
@@ -150,6 +151,17 @@ def test_callable_validation():
     assert c.pre_fork == func
     pytest.raises(TypeError, c.set, "pre_fork", 1)
     pytest.raises(TypeError, c.set, "pre_fork", lambda x: True)
+
+
+def test_reload_engine_validation():
+    c = config.Config()
+
+    assert c.reload_engine == "auto"
+
+    c.set('reload_engine', 'poll')
+    assert c.reload_engine == 'poll'
+
+    pytest.raises(ConfigError, c.set, "reload_engine", "invalid")
 
 
 def test_callable_validation_for_string():


### PR DESCRIPTION
Currently, gunicorn automatically uses the preferred reloader (inotify
if present with fallback to polling). However, it would be useful in
some scenarios if users could force polling.

The solution for this is to add a new configuration option called
'reload_engine' which takes one of three options: ['auto', 'poll',
'inotify'].

Fixes #1459