### PR TITLE
fix non-decimal values problem in `umask` config.(issue 1325)

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -48,6 +48,13 @@ def make_settings(ignore=None):
     return settings
 
 
+def auto_int(_, x):
+    if x.startswith('0') and not x.lower().startswith('0x'):
+        # for compatible with octal numbers in python3
+        x = x.replace('0', '0o', 1)
+    return int(x, 0)
+
+
 class Config(object):
 
     def __init__(self, usage=None, prog=None):
@@ -1043,14 +1050,13 @@ class Group(Setting):
         change the worker processes group.
         """
 
-
 class Umask(Setting):
     name = "umask"
     section = "Server Mechanics"
     cli = ["-m", "--umask"]
     meta = "INT"
     validator = validate_pos_int
-    type = int
+    type = auto_int
     default = 0
     desc = """\
         A bit mask for the file mode on files written by Gunicorn.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -357,3 +357,16 @@ def test_reload(options, expected):
     with AltArgs(cmdline):
         app = NoConfigApp()
     assert app.cfg.reload == expected
+
+
+@pytest.mark.parametrize("options, expected", [
+    (["--umask 0", "myapp:app"], 0),
+    (["--umask", "0xFF", "myapp:app"], 255),
+    (["--umask", "0022", "myapp:app"], 18),
+])
+def test_umask_config(options, expected):
+    cmdline = ["prog_name"]
+    cmdline.extend(options)
+    with AltArgs(cmdline):
+        app = NoConfigApp()
+    assert app.cfg.umask == expected


### PR DESCRIPTION
because we define `type=int` in `umask` , error occur in this line of `argparse`:
[https://github.com/bewest/argparse/blob/master/argparse.py#L2248](https://github.com/bewest/argparse/blob/master/argparse.py#L2248).
thus i change umask type to auto_int function.