### PR TITLE
Enable CI testing on Windows using Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+version: '{branch}.{build}'
+environment:
+  matrix:
+    - TOXENV: lint
+      PYTHON: "C:\\Python35-x64"
+    - TOXENV: py27
+      PYTHON: "C:\\Python27-x64"
+    - TOXENV: py35
+      PYTHON: "C:\\Python35-x64"
+    - TOXENV: py36
+      PYTHON: "C:\\Python36-x64"
+matrix:
+  allow_failures:
+    - TOXENV: py27
+    - TOXENV: py35
+    - TOXENV: py36
+init: SET "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+install:
+  - pip install tox
+  # Convert from Linux to Windows style paths to work around:
+  # https://github.com/landscapeio/prospector/issues/203
+  - sed -i "s_/_\\\_g" .prospector.yaml
+build: off
+test_script: tox
+cache:
+  # Not including the .tox directory since it takes longer to download/extract
+  # the cache archive than for tox to clean install from the pip cache.
+  - '%LOCALAPPDATA%\pip\Cache -> tox.ini'
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_status_changed: false


### PR DESCRIPTION
Currently everything but the prospector lint job fails, however having CI set up makes it easier to see what work remains for #524.

Fixes #1467.