### PR TITLE
Remove dead code found using vulture

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -470,22 +470,6 @@ def validate_chdir(val):
     return path
 
 
-def validate_file(val):
-    if val is None:
-        return None
-
-    # valid if the value is a string
-    val = validate_string(val)
-
-    # transform relative paths
-    path = os.path.abspath(os.path.normpath(os.path.join(util.getcwd(), val)))
-
-    # test if the path exists
-    if not os.path.exists(path):
-        raise ConfigError("%r not found" % val)
-
-    return path
-
 def validate_hostport(val):
     val = validate_string(val)
     if val is None:

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -29,7 +29,6 @@ except ImportError:
 # with sending files in blocks over 2GB.
 BLKSIZE = 0x3FFFFFFF
 
-NORMALIZE_SPACE = re.compile(r'(?:\r\n)?[ \t]+')
 HEADER_VALUE_RE = re.compile(r'[\x00-\x1F\x7F]')
 
 log = logging.getLogger(__name__)

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -13,7 +13,6 @@ from gunicorn.glogging import Logger
 from gunicorn import six
 
 # Instrumentation constants
-STATSD_DEFAULT_PORT = 8125
 METRIC_VAR = "metric"
 VALUE_VAR = "value"
 MTYPE_VAR = "mtype"


### PR DESCRIPTION
https://pypi.python.org/pypi/vulture

In particular the removal of `get_maxfd()` means the `resource` module is no longer required (which is not available on Windows) and so helps with #524.