### PR TITLE
Set CWD and Python path before and after config

### DIFF
--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -75,7 +75,17 @@ class BaseApplication(object):
             sys.stderr.flush()
             sys.exit(1)
 
+
 class Application(BaseApplication):
+
+    def chdir(self):
+        # chdir to the configured path before loading,
+        # default is the current dir
+        os.chdir(self.cfg.chdir)
+
+        # add the path to sys.path
+        if self.cfg.chdir not in sys.path:
+            sys.path.insert(0, self.cfg.chdir)
 
     def get_config_from_filename(self, filename):
 
@@ -142,6 +152,9 @@ class Application(BaseApplication):
         # optional settings from apps
         cfg = self.init(parser, args, args.args)
 
+        # set up import paths and follow symlinks
+        self.chdir()
+
         # Load up the any app specific configuration
         if cfg:
             for k, v in cfg.items():
@@ -173,6 +186,10 @@ class Application(BaseApplication):
             if k == "args":
                 continue
             self.cfg.set(k.lower(), v)
+
+        # current directory might be changed by the config now
+        # set up import paths and follow symlinks
+        self.chdir()
 
     def run(self):
         if self.cfg.check_config:

--- a/gunicorn/app/pasterapp.py
+++ b/gunicorn/app/pasterapp.py
@@ -163,10 +163,6 @@ class PasterServerApplication(PasterBaseApplication):
                 self.load_config_from_file(default_config)
 
     def load(self):
-        # chdir to the configured path before loading,
-        # default is the current dir
-        os.chdir(self.cfg.chdir)
-
         return self.app
 
 

--- a/gunicorn/app/wsgiapp.py
+++ b/gunicorn/app/wsgiapp.py
@@ -4,7 +4,6 @@
 # See the NOTICE for more information.
 
 import os
-import sys
 
 from gunicorn.errors import ConfigError
 from gunicorn.app.base import Application
@@ -37,23 +36,11 @@ class WSGIApplication(Application):
         self.cfg.set("default_proc_name", args[0])
         self.app_uri = args[0]
 
-    def chdir(self):
-        # chdir to the configured path before loading,
-        # default is the current dir
-        os.chdir(self.cfg.chdir)
-
-        # add the path to sys.path
-        sys.path.insert(0, self.cfg.chdir)
-
     def load_wsgiapp(self):
-        self.chdir()
-
         # load the app
         return util.import_app(self.app_uri)
 
     def load_pasteapp(self):
-        self.chdir()
-
         # load the paste app
         from .pasterapp import load_pasteapp
         return load_pasteapp(self.cfgurl, self.relpath, global_conf=self.cfg.paste_global_conf)


### PR DESCRIPTION
The config may be specified as a Python module, in which case we want
to ensure that the Python path is fixed up properly before we try to
load it. That means we should follow symlinks and add the current working
directory before and after the configuration is loaded.

Fix #1349