### PR TITLE
Remove gunicorn_paster and paste serve integration

### DIFF
--- a/gunicorn/app/pasterapp.py
+++ b/gunicorn/app/pasterapp.py
@@ -5,7 +5,6 @@
 
 # pylint: skip-file
 
-import os
 import pkg_resources
 import sys
 
@@ -16,10 +15,6 @@ except ImportError:
 
 from paste.deploy import loadapp, loadwsgi
 SERVER = loadwsgi.SERVER
-
-from gunicorn.app.base import Application
-from gunicorn.config import Config, get_default_config_file
-from gunicorn import util
 
 
 def _has_logging_config(paste_file):
@@ -68,141 +63,3 @@ def paste_config(gconfig, config_url, relative_to, global_conf=None):
 def load_pasteapp(config_url, relative_to, global_conf=None):
     return loadapp(config_url, relative_to=relative_to,
             global_conf=global_conf)
-
-class PasterBaseApplication(Application):
-    gcfg = None
-
-    def app_config(self):
-        return paste_config(self.cfg, self.cfgurl, self.relpath,
-                global_conf=self.gcfg)
-
-    def load_config(self):
-        super(PasterBaseApplication, self).load_config()
-
-        # reload logging conf
-        if hasattr(self, "cfgfname"):
-            parser = ConfigParser.ConfigParser()
-            parser.read([self.cfgfname])
-            if parser.has_section('loggers'):
-                from logging.config import fileConfig
-                config_file = os.path.abspath(self.cfgfname)
-                fileConfig(config_file, dict(__file__=config_file,
-                                             here=os.path.dirname(config_file)))
-
-
-class PasterApplication(PasterBaseApplication):
-
-    def init(self, parser, opts, args):
-        if len(args) != 1:
-            parser.error("No application name specified.")
-
-        cwd = util.getcwd()
-        cfgfname = os.path.normpath(os.path.join(cwd, args[0]))
-        cfgfname = os.path.abspath(cfgfname)
-        if not os.path.exists(cfgfname):
-            parser.error("Config file not found: %s" % cfgfname)
-
-        self.cfgurl = 'config:%s' % cfgfname
-        self.relpath = os.path.dirname(cfgfname)
-        self.cfgfname = cfgfname
-
-        sys.path.insert(0, self.relpath)
-        pkg_resources.working_set.add_entry(self.relpath)
-
-        return self.app_config()
-
-    def load(self):
-        # chdir to the configured path before loading,
-        # default is the current dir
-        os.chdir(self.cfg.chdir)
-
-        return load_pasteapp(self.cfgurl, self.relpath, global_conf=self.gcfg)
-
-
-class PasterServerApplication(PasterBaseApplication):
-
-    def __init__(self, app, gcfg=None, host="127.0.0.1", port=None, **kwargs):
-        # pylint: disable=super-init-not-called
-        self.cfg = Config()
-        self.gcfg = gcfg  # need to hold this for app_config
-        self.app = app
-        self.callable = None
-
-        gcfg = gcfg or {}
-        cfgfname = gcfg.get("__file__")
-        if cfgfname is not None:
-            self.cfgurl = 'config:%s' % cfgfname
-            self.relpath = os.path.dirname(cfgfname)
-            self.cfgfname = cfgfname
-
-        cfg = kwargs.copy()
-
-        if port and not host.startswith("unix:"):
-            bind = "%s:%s" % (host, port)
-        else:
-            bind = host
-        cfg["bind"] = bind.split(',')
-
-        if gcfg:
-            for k, v in gcfg.items():
-                cfg[k] = v
-            cfg["default_proc_name"] = cfg['__file__']
-
-        try:
-            for k, v in cfg.items():
-                if k.lower() in self.cfg.settings and v is not None:
-                    self.cfg.set(k.lower(), v)
-        except Exception as e:
-            print("\nConfig error: %s" % str(e), file=sys.stderr)
-            sys.stderr.flush()
-            sys.exit(1)
-
-        if cfg.get("config"):
-            self.load_config_from_file(cfg["config"])
-        else:
-            default_config = get_default_config_file()
-            if default_config is not None:
-                self.load_config_from_file(default_config)
-
-    def load(self):
-        return self.app
-
-
-def run():
-    """\
-    The ``gunicorn_paster`` command for launching Paster compatible
-    applications like Pylons or Turbogears2
-    """
-    util.warn("""This command is deprecated.
-
-    You should now use the `--paste` option. Ex.:
-
-        gunicorn --paste development.ini
-    """)
-
-    from gunicorn.app.pasterapp import PasterApplication
-    PasterApplication("%(prog)s [OPTIONS] pasteconfig.ini").run()
-
-
-def paste_server(app, gcfg=None, host="127.0.0.1", port=None, **kwargs):
-    """\
-    A paster server.
-
-    Then entry point in your paster ini file should looks like this:
-
-    [server:main]
-    use = egg:gunicorn#main
-    host = 127.0.0.1
-    port = 5000
-
-    """
-
-    util.warn("""This command is deprecated.
-
-    You should now use the `--paste` option. Ex.:
-
-        gunicorn --paste development.ini
-    """)
-
-    from gunicorn.app.pasterapp import PasterServerApplication
-    PasterServerApplication(app, gcfg=gcfg, host=host, port=port, **kwargs).run()

--- a/setup.py
+++ b/setup.py
@@ -104,10 +104,6 @@ setup(
     entry_points="""
     [console_scripts]
     gunicorn=gunicorn.app.wsgiapp:run
-    gunicorn_paster=gunicorn.app.pasterapp:run
-
-    [paste.server_runner]
-    main=gunicorn.app.pasterapp:paste_server
     """,
     extras_require=extra_require,
 )


### PR DESCRIPTION
The `--paste` option still works, but using egg:gunicorn in the server
block of an ini file will no longer work and the `gunicorn_paster`
script is gone.

These features were deprecated in 19.0.

Close #1189