### PR TITLE
Fix "TypeError: 'OSError' object is not subscriptable" in py3

### DIFF
--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -43,7 +43,7 @@ class BaseSocket(object):
             try:
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
             except socket.error as err:
-                if err[0] not in (errno.ENOPROTOOPT, errno.EINVAL):
+                if err.errno not in (errno.ENOPROTOOPT, errno.EINVAL):
                     raise
         if not bound:
             self.bind(sock)


### PR DESCRIPTION
In python3 the exception object is not iterable and must use either the `args` attribute or in this case `errno` (equivalent to `.args[0]`).