### PR TITLE
Fallback to the original behavior if prefix is not available (#1068)

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -42,6 +42,10 @@ application specific configuration.
    Loading the config from a Python module requires the ``python:``
    prefix.
 
+.. versionchanged:: 19.8
+   Pre-19.4 behavior of loading a config file without a ``python:``
+   prefix is now restored.
+
 Server Socket
 -------------
 

--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -121,12 +121,14 @@ class Application(BaseApplication):
         if location.startswith("python:"):
             module_name = location[len("python:"):]
             cfg = self.get_config_from_module_name(module_name)
-        else:
-            if location.startswith("file:"):
-                filename = location[len("file:"):]
-            else:
-                filename = location
+        elif location.startswith("file:"):
+            filename = location[len("file:"):]
             cfg = self.get_config_from_filename(filename)
+        else:
+            try:
+                cfg = self.get_config_from_module_name(location)
+            except ImportError:
+                cfg = self.get_config_from_filename(location)
 
         for k, v in cfg.items():
             # Ignore unknown names

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -519,6 +519,10 @@ class ConfigFile(Setting):
         .. versionchanged:: 19.4
            Loading the config from a Python module requires the ``python:``
            prefix.
+
+        .. versionchanged:: 19.8
+           Pre-19.4 behavior of loading a config file without a ``python:``
+           prefix is now restored.
         """
 
 class Bind(Setting):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -238,6 +238,20 @@ def test_load_config_module():
     assert app.cfg.proc_name == "fooey"
 
 
+@pytest.mark.parametrize("options", [
+    ["-c", cfg_module()],
+    ["-c", cfg_file()],
+])
+def test_load_fallback(options):
+    cmdline = ["prog_name"]
+    cmdline.extend(options)
+    with AltArgs(cmdline):
+        app = NoConfigApp()
+    assert app.cfg.bind == ["unix:/tmp/bar/baz"]
+    assert app.cfg.workers == 3
+    assert app.cfg.proc_name == "fooey"
+
+
 def test_cli_overrides_config():
     with AltArgs(["prog_name", "-c", cfg_file(), "-b", "blarney"]):
         app = NoConfigApp()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -242,7 +242,7 @@ def test_load_config_module():
     ["-c", cfg_module()],
     ["-c", cfg_file()],
 ])
-def test_load_fallback(options):
+def test_load_config_fallback(options):
     cmdline = ["prog_name"]
     cmdline.extend(options)
     with AltArgs(cmdline):


### PR DESCRIPTION
I needed to restore the original behavior because some external applications was actually relying on the behavior.

https://github.com/apache/incubator-airflow/blob/1.8.0/airflow/bin/cli.py#L775

I believe this needs to be fixed in gunicorn side because the caller of `gunicorn` cannot know how gunicorn behaves on `-c` before it actually invokes `gunicorn`.