### PR TITLE
optionally send datadog tags with statsd

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -47,6 +47,7 @@ Dan Callaghan <dcallagh@redhat.com>
 Dan Sully <daniel-github@electricrain.com>
 Daniel Quinn <code@danielquinn.org>
 Dariusz Suchojad <dsuch-github@m.zato.io>
+David Black <github@dhb.is>
 David Vincelli <david@freshbooks.com>
 David Wolever <david@wolever.net>
 Denis Bilenko <denis.bilenko@gmail.com>

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -376,6 +376,17 @@ if not provided).
 
 .. versionadded:: 19.2
 
+dogstatsd_tags
+~~~~~~~~~~~~~~
+
+* ``--dogstatsd-tags DOGSTATSD_TAGS``
+* ``(empty string)``
+
+Comma-delimited list of static dogstatsd (datadog statsd) tags sent with all statsd metrics
+See: `Datadog Docs <https://docs.datadoghq.com/developers/dogstatsd/>`
+
+.. versionadded:: 20
+
 Process Naming
 --------------
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1478,6 +1478,20 @@ class StatsdHost(Setting):
     .. versionadded:: 19.1
     """
 
+# Datadog Statsd (dogstatsd) tags. https://docs.datadoghq.com/developers/dogstatsd/
+class DogstatsdTags(Setting):
+    name = "dogstatsd_tags"
+    section = "Logging"
+    cli = ["--dogstatsd-tags"]
+    meta = "DOGSTATSD_TAGS"
+    default = ""
+    validator = validate_string
+    desc = """\
+    A comma-delimited list of datadog statsd (dogstatsd) tags to append to statsd metrics.
+
+    .. versionadded:: 20
+    """
+
 class StatsdPrefix(Setting):
     name = "statsd_prefix"
     section = "Logging"

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -34,6 +34,8 @@ class Statsd(Logger):
         except Exception:
             self.sock = None
 
+        self.dogstatsd_tags = cfg.dogstatsd_tags
+
     # Log errors and warnings
     def critical(self, msg, *args, **kwargs):
         Logger.critical(self, msg, *args, **kwargs)
@@ -116,6 +118,11 @@ class Statsd(Logger):
         try:
             if isinstance(msg, str):
                 msg = msg.encode("ascii")
+
+            # http://docs.datadoghq.com/guides/dogstatsd/#datagram-format
+            if self.dogstatsd_tags:
+                msg = msg + b"|#" + self.dogstatsd_tags.encode('ascii')
+
             if self.sock:
                 self.sock.send(msg)
         except Exception:

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -59,6 +59,17 @@ def test_statsd_fail():
     logger.exception("No impact on logging")
 
 
+def test_dogstatsd_tags():
+    c = Config()
+    tags = 'yucatan,libertine:rhubarb'
+    c.set('dogstatsd_tags', tags)
+    logger = Statsd(c)
+    logger.sock = MockSocket(False)
+    logger.info("Twill", extra={"mtype": "gauge", "metric": "barb.westerly",
+                                "value": 2})
+    assert logger.sock.msgs[0] == b"barb.westerly:2|g|#" + tags.encode('ascii')
+
+
 def test_instrument():
     logger = Statsd(Config())
     # Capture logged messages


### PR DESCRIPTION
The datadog hosted metrics service uses a slightly forked statsd protocol in order to add arbitrary key/value tags to metrics. This PR allows the user to set a static list of datadog tags to send along with statsd metrics. I would like to be able to e.g. send the tags "app_name:my_awesome_web_app" and "stage:prod" along with my stats. This lets you easily create dashboard that only show stats from the prod stage.