### PR TITLE
Introduce --startup-timeout option

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -210,6 +210,16 @@ you're sure of the repercussions for sync workers. For the non sync
 workers it just means that the worker process is still communicating and
 is not tied to the length of time required to handle a single request.
 
+.. _startup-timeout:
+
+startup_timeout
+~~~~~~~~~~~~~~~
+
+* ``--startup-timeout INT``
+* ``30``
+
+Timeout for workers startup.
+
 .. _graceful-timeout:
 
 graceful_timeout
@@ -319,6 +329,24 @@ because it consumes less system resources.
 .. note::
    In order to use the inotify reloader, you must have the ``inotify``
    package installed.
+
+.. _reload-engine:
+
+reload_engine
+~~~~~~~~~~~~~
+
+* ``--reload-engine STRING``
+* ``auto``
+
+The implementation that should be used to power :ref:`reload`.
+
+Valid engines are:
+
+* 'auto'
+* 'poll'
+* 'inotify' (requires inotify)
+
+.. versionadded:: 19.7
 
 .. _spew:
 
@@ -1138,7 +1166,7 @@ ssl_version
 ~~~~~~~~~~~
 
 * ``--ssl-version``
-* ``3``
+* ``_SSLMethod.PROTOCOL_TLS``
 
 SSL version to use (see stdlib ssl module's)
 
@@ -1152,7 +1180,7 @@ cert_reqs
 ~~~~~~~~~
 
 * ``--cert-reqs``
-* ``0``
+* ``VerifyMode.CERT_NONE``
 
 Whether client certificate is required (see stdlib ssl module's)
 

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -491,6 +491,8 @@ class Arbiter(object):
         workers = list(self.WORKERS.items())
         for (pid, worker) in workers:
             try:
+                if not worker.booted and time.time() - worker.tmp.last_update() <= self.cfg.startup_timeout:
+                    continue
                 if time.time() - worker.tmp.last_update() <= self.timeout:
                     continue
             except (OSError, ValueError):

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -715,6 +715,19 @@ class Timeout(Setting):
         """
 
 
+class StartupTimeout(Setting):
+    name = 'startup_timeout'
+    section = "Worker Processes"
+    cli = ["--startup-timeout"]
+    meta = "INT"
+    validator = validate_pos_int
+    type = int
+    default = 30
+    desc = """\
+        Timeout for workers startup.
+        """
+
+
 class GracefulTimeout(Setting):
     name = "graceful_timeout"
     section = "Worker Processes"


### PR DESCRIPTION
One of my app requires several minutes to startup(loads a lot of data), the `timeout` option seems not quite right for allowing workers to startup within some time.

I think adding a `--startup-timeout` option would be better to allow workers to startup in a certain amount of time while booted workers silent for more than `--timeout` seconds are still get killed and restarted.