### PR TITLE
Use getfullargspec instead of getargspec (where available) to silence deprecation warning.

### DIFF
--- a/gunicorn/_compat.py
+++ b/gunicorn/_compat.py
@@ -262,3 +262,7 @@ if PY26:
 
 else:
     from gunicorn.six.moves.urllib.parse import urlsplit
+
+import inspect
+
+getargspec = getattr(inspect, 'getfullargspec', inspect.getargspec)

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -414,7 +414,7 @@ def validate_callable(arity):
                     "" % (obj_name, mod_name))
         if not six.callable(val):
             raise TypeError("Value is not six.callable: %s" % val)
-        if arity != -1 and arity != len(inspect.getargspec(val)[0]):
+        if arity != -1 and arity != len(_compat.getargspec(val)[0]):
             raise TypeError("Value must have an arity of: %s" % arity)
         return val
     return _validate_callable


### PR DESCRIPTION
Fixes #1515.