### PR TITLE
Unlock pylint and deal with a large swathe of lint failures.

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -31,6 +31,7 @@ pylint:
   disable:
     - import-error
     - too-many-locals
+    - wrong-import-position
 
 mccabe:
   run: false

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -27,5 +27,9 @@ pyflakes:
     # Access to a protected member $X of a client class
     - W0212
 
+pylint:
+  disable:
+    - too-many-locals
+
 mccabe:
   run: false

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -29,6 +29,7 @@ pyflakes:
 
 pylint:
   disable:
+    - bare-except
     - import-error
     - too-many-locals
     - wrong-import-position

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -29,6 +29,7 @@ pyflakes:
 
 pylint:
   disable:
+    - import-error
     - too-many-locals
 
 mccabe:

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -31,6 +31,7 @@ pylint:
   disable:
     - bare-except
     - import-error
+    - too-many-arguments
     - too-many-locals
     - wrong-import-position
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       env: TOXENV=py36-dev
     - python: nightly
       env: TOXENV=py37
-    - python: 3.5
+    - python: 3.6
       env: TOXENV=lint
   allow_failures:
     - env: TOXENV=py36-dev

--- a/gunicorn/_compat.py
+++ b/gunicorn/_compat.py
@@ -262,3 +262,14 @@ if PY26:
 
 else:
     from gunicorn.six.moves.urllib.parse import urlsplit
+
+try:
+    import html
+
+    def html_escape(s):
+        return html.escape(s)
+except ImportError:
+    import cgi
+
+    def html_escape(s):
+        return cgi.escape(s, quote=True)

--- a/gunicorn/app/pasterapp.py
+++ b/gunicorn/app/pasterapp.py
@@ -120,7 +120,7 @@ class PasterApplication(PasterBaseApplication):
 
 class PasterServerApplication(PasterBaseApplication):
 
-    def __init__(self, app, gcfg=None, host="127.0.0.1", port=None, *args, **kwargs):
+    def __init__(self, app, gcfg=None, host="127.0.0.1", port=None, **kwargs):
         self.cfg = Config()
         self.gcfg = gcfg  # need to hold this for app_config
         self.app = app
@@ -182,7 +182,6 @@ def run():
         gunicorn --paste development.ini
     """)
 
-    from gunicorn.app.pasterapp import PasterApplication
     PasterApplication("%(prog)s [OPTIONS] pasteconfig.ini").run()
 
 
@@ -206,5 +205,4 @@ def paste_server(app, gcfg=None, host="127.0.0.1", port=None, *args, **kwargs):
         gunicorn --paste development.ini
     """)
 
-    from gunicorn.app.pasterapp import PasterServerApplication
     PasterServerApplication(app, gcfg=gcfg, host=host, port=port, *args, **kwargs).run()

--- a/gunicorn/app/wsgiapp.py
+++ b/gunicorn/app/wsgiapp.py
@@ -61,8 +61,7 @@ class WSGIApplication(Application):
     def load(self):
         if self.cfg.paste is not None:
             return self.load_pasteapp()
-        else:
-            return self.load_wsgiapp()
+        return self.load_wsgiapp()
 
 
 def run():
@@ -70,7 +69,6 @@ def run():
     The ``gunicorn`` command line runner for launching Gunicorn with
     generic WSGI applications.
     """
-    from gunicorn.app.wsgiapp import WSGIApplication
     WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]").run()
 
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -399,6 +399,8 @@ def validate_class(val):
     return validate_string(val)
 
 
+# pylint: disable=deprecated-method
+# We may use getargspec here but only when getfullargspec is not available.
 def validate_callable(arity):
     def _validate_callable(val):
         if isinstance(val, six.string_types):
@@ -452,10 +454,12 @@ def validate_group(val):
             raise ConfigError("No such group: '%s'" % val)
 
 
+# pylint: disable=deprecated-method
+# We may use getargspec here but only when getfullargspec is not available.
 def validate_post_request(val):
     val = validate_callable(-1)(val)
 
-    largs = len(inspect.getargspec(val)[0])
+    largs = len(_compat.getargspec(val)[0])
     if largs == 4:
         return val
     elif largs == 3:

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -5,6 +5,8 @@
 
 # Please remember to run "make -C docs html" after update "desc" attributes.
 
+# pylint: disable=duplicate-bases,no-staticmethod-decorator
+
 import copy
 import grp
 import inspect
@@ -32,7 +34,7 @@ PLATFORM = sys.platform
 
 
 def wrap_method(func):
-    def _wrapped(instance, *args, **kwargs):
+    def _wrapped(_instance, *args, **kwargs):
         return func(*args, **kwargs)
     return _wrapped
 
@@ -151,8 +153,8 @@ class Config(object):
         pn = self.settings['proc_name'].get()
         if pn is not None:
             return pn
-        else:
-            return self.settings['default_proc_name'].get()
+
+        return self.settings['default_proc_name'].get()
 
     @property
     def logger_class(self):
@@ -314,6 +316,7 @@ class Setting(object):
     def get(self):
         return self.value
 
+    # pylint: disable=not-callable
     def set(self, val):
         if not six.callable(self.validator):
             raise TypeError('Invalid validator: %s' % self.name)

--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -109,12 +109,12 @@ class SafeAtoms(dict):
             kl = k.lower()
             if kl in self:
                 return super(SafeAtoms, self).__getitem__(kl)
-            else:
-                return "-"
+            return "-"
+
         if k in self:
             return super(SafeAtoms, self).__getitem__(k)
-        else:
-            return '-'
+
+        return '-'
 
 
 def parse_syslog_address(addr):
@@ -309,6 +309,7 @@ class Logger(object):
 
         return atoms
 
+    # pylint: disable=logging-not-lazy
     def access(self, resp, req, environ, request_time):
         """ See http://httpd.apache.org/docs/2.0/logs.html#combined
         for format details
@@ -332,6 +333,7 @@ class Logger(object):
         """ return date in Apache Common Log Format """
         return time.strftime('[%d/%b/%Y:%H:%M:%S %z]')
 
+    # pylint: disable=not-context-manager
     def reopen_files(self):
         if self.cfg.capture_output and self.cfg.errorlog != "-":
             for stream in sys.stdout, sys.stderr:
@@ -373,6 +375,7 @@ class Logger(object):
             if getattr(h, "_gunicorn", False):
                 return h
 
+    # pylint: disable=protected-access
     def _set_handler(self, log, output, fmt, stream=None):
         # remove previous gunicorn log handler
         h = self._get_gunicorn_handler(log)
@@ -397,6 +400,7 @@ class Logger(object):
             h._gunicorn = True
             log.addHandler(h)
 
+    # pylint: disable=protected-access
     def _set_syslog_handler(self, log, cfg, fmt, name):
         # setup format
         if not cfg.syslog_prefix:

--- a/gunicorn/http/body.py
+++ b/gunicorn/http/body.py
@@ -210,7 +210,7 @@ class Body(object):
 
         while size > self.buf.tell():
             data = self.reader.read(1024)
-            if not len(data):
+            if not data:
                 break
             self.buf.write(data)
 
@@ -245,10 +245,10 @@ class Body(object):
 
         return b"".join(ret)
 
-    def readlines(self, size=None):
+    def readlines(self, _size=None):
         ret = []
         data = self.read()
-        while len(data):
+        while data:
             pos = data.find(b"\n")
             if pos < 0:
                 ret.append(data)

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -53,7 +53,7 @@ class Message(object):
         self.unreader.unread(unused)
         self.set_body_reader()
 
-    def parse(self):
+    def parse(self, _unreader):
         raise NotImplementedError()
 
     def parse_headers(self, data):
@@ -64,7 +64,7 @@ class Message(object):
 
         # Parse headers into key/value pairs paying attention
         # to continuation lines.
-        while len(lines):
+        while lines:
             if len(headers) >= self.limit_request_fields:
                 raise LimitRequestHeaders("limit request headers fields")
 
@@ -81,7 +81,7 @@ class Message(object):
             name, value = name.strip(), [value.lstrip()]
 
             # Consume value continuation lines
-            while len(lines) and lines[0].startswith((" ", "\t")):
+            while lines and lines[0].startswith((" ", "\t")):
                 curr = lines.pop(0)
                 header_length += len(curr)
                 if header_length > self.limit_request_field_size > 0:

--- a/gunicorn/http/parser.py
+++ b/gunicorn/http/parser.py
@@ -7,6 +7,7 @@ from gunicorn.http.message import Request
 from gunicorn.http.unreader import SocketUnreader, IterUnreader
 
 
+# pylint: disable=not-callable
 class Parser(object):
 
     mesg_class = None

--- a/gunicorn/http/unreader.py
+++ b/gunicorn/http/unreader.py
@@ -40,7 +40,7 @@ class Unreader(object):
 
         while self.buf.tell() < size:
             chunk = self.chunk()
-            if not len(chunk):
+            if not chunk:
                 ret = self.buf.getvalue()
                 self.buf = six.BytesIO()
                 return ret

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -113,6 +113,7 @@ def proxy_environ(req):
     }
 
 
+# pylint: disable=too-many-branches
 def create(req, sock, client, server, cfg):
     resp = Response(req, sock, cfg)
 
@@ -183,7 +184,7 @@ def create(req, sock, client, server, cfg):
                 server = host.split(':')
                 if len(server) == 1:
                     if url_scheme == "http":
-                        server.append(80),
+                        server.append(80)
                     elif url_scheme == "https":
                         server.append(443)
                     else:

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -80,7 +80,7 @@ class Statsd(Logger):
                         pass
 
             # Log to parent logger only if there is something to say
-            if msg is not None and len(msg) > 0:
+            if msg:
                 Logger.log(self, lvl, msg, *args, **kwargs)
         except Exception:
             Logger.warning(self, "Failed to log to statsd", exc_info=True)
@@ -108,7 +108,7 @@ class Statsd(Logger):
         self._sock_send("{0}{1}:{2}|c|@{3}".format(self.prefix, name, value, sampling_rate))
 
     def decrement(self, name, value, sampling_rate=1.0):
-        self._sock_send("{0){1}:-{2}|c|@{3}".format(self.prefix, name, value, sampling_rate))
+        self._sock_send("{0}{1}:-{2}|c|@{3}".format(self.prefix, name, value, sampling_rate))
 
     def histogram(self, name, value):
         self._sock_send("{0}{1}:{2}|ms".format(self.prefix, name, value))

--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -61,11 +61,6 @@ except ImportError:
     has_inotify = False
 
 
-class InotifyReloader():
-    def __init__(self, callback=None):
-        raise ImportError('You must have the inotify module installed to use '
-                          'the inotify reloader')
-
 if has_inotify:
 
     class InotifyReloader(threading.Thread):
@@ -74,7 +69,7 @@ if has_inotify:
                       | inotify.constants.IN_MOVE_SELF | inotify.constants.IN_MOVED_FROM
                       | inotify.constants.IN_MOVED_TO)
 
-        def __init__(self, extra_files=None, callback=None):
+        def __init__(self, _extra_files=None, callback=None):
             super(InotifyReloader, self).__init__()
             self.setDaemon(True)
             self._callback = callback
@@ -112,6 +107,13 @@ if has_inotify:
                 filename = event[3]
 
                 self._callback(filename)
+
+else:
+
+    class InotifyReloader():
+        def __init__(self, _callback=None):
+            raise ImportError('You must have the inotify module installed to use '
+                              'the inotify reloader')
 
 
 preferred_reloader = InotifyReloader if has_inotify else Reloader

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -31,7 +31,7 @@ class BaseSocket(object):
 
         self.sock = self.set_options(sock, bound=bound)
 
-    def __str__(self, name):
+    def __str__(self):
         return "<socket %d>" % self.sock.fileno()
 
     def __getattr__(self, name):
@@ -94,7 +94,7 @@ class TCP6Socket(TCPSocket):
     FAMILY = socket.AF_INET6
 
     def __str__(self):
-        (host, port, fl, sc) = self.sock.getsockname()
+        (host, port, _fl, _sc) = self.sock.getsockname()
         return "http://[%s]:%d" % (host, port)
 
 

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -49,7 +49,7 @@ try:
     def _setproctitle(title):
         setproctitle("gunicorn: %s" % title)
 except ImportError:
-    def _setproctitle(title):
+    def _setproctitle(_title):
         return
 
 
@@ -61,7 +61,7 @@ except ImportError:
         if not hasattr(package, 'rindex'):
             raise ValueError("'package' not set to a string")
         dot = len(package)
-        for x in range(level, 1, -1):
+        for _ in range(level, 1, -1):
             try:
                 dot = package.rindex('.', 0, dot)
             except ValueError:
@@ -340,7 +340,7 @@ def write_error(sock, status_int, reason, mesg):
     %s""") % (str(status_int), reason, len(html), html)
     write_nonblock(sock, http.encode('latin1'))
 
-
+# pylint: disable=eval-used
 def import_app(module):
     parts = module.split(":", 1)
     if len(parts) == 1:
@@ -401,6 +401,7 @@ def is_hoppish(header):
     return header.lower().strip() in hop_headers
 
 
+# pylint: disable=protected-access
 def daemonize(enable_stdio_inheritance=False):
     """\
     Standard daemonization of a process.
@@ -537,7 +538,7 @@ def warn(msg):
 def make_fail_app(msg):
     msg = to_bytestring(msg)
 
-    def app(environ, start_response):
+    def app(_environ, start_response):
         start_response("500 Internal Server Error", [
             ("Content-Type", "text/plain"),
             ("Content-Length", str(len(msg)))

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -20,9 +20,9 @@ import traceback
 import inspect
 import errno
 import warnings
-import cgi
 import logging
 
+from gunicorn import _compat
 from gunicorn.errors import AppImportError
 from gunicorn.six import text_type
 from gunicorn.workers import SUPPORTED_WORKERS
@@ -329,7 +329,7 @@ def write_error(sock, status_int, reason, mesg):
         %(mesg)s
       </body>
     </html>
-    """) % {"reason": reason, "mesg": cgi.escape(mesg)}
+    """) % {"reason": reason, "mesg": _compat.html_escape(mesg)}
 
     http = textwrap.dedent("""\
     HTTP/1.1 %s %s\r

--- a/gunicorn/workers/_gaiohttp.py
+++ b/gunicorn/workers/_gaiohttp.py
@@ -60,7 +60,7 @@ class AiohttpWorker(base.Worker):
             proto, proto.connection_lost, self.connections, False)
         return proto
 
-    def factory(self, wsgi, addr):
+    def factory(self, wsgi, _addr):
         # are we in debug level
         is_debug = self.log.loglevel == logging.DEBUG
 
@@ -74,7 +74,7 @@ class AiohttpWorker(base.Worker):
             access_log_format=self.cfg.access_log_format)
         return self.wrap_protocol(proto)
 
-    def get_factory(self, sock, addr):
+    def get_factory(self, _sock, addr):
         return functools.partial(self.factory, self.wsgi, addr)
 
     @asyncio.coroutine

--- a/gunicorn/workers/async.py
+++ b/gunicorn/workers/async.py
@@ -3,6 +3,8 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
+# pylint: disable=too-many-branches,too-many-nested-blocks
+
 from datetime import datetime
 import errno
 import socket

--- a/gunicorn/workers/geventlet.py
+++ b/gunicorn/workers/geventlet.py
@@ -134,9 +134,12 @@ class EventletWorker(AsyncWorker):
         self.notify()
         try:
             with eventlet.Timeout(self.cfg.graceful_timeout) as t:
-                [a.kill(eventlet.StopServe()) for a in acceptors]
-                [a.wait() for a in acceptors]
+                for a in acceptors:
+                    a.kill(eventlet.StopServe())
+                for a in acceptors:
+                    a.wait()
         except eventlet.Timeout as te:
             if te != t:
                 raise
-            [a.kill() for a in acceptors]
+            for a in acceptors:
+                a.kill()

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -87,6 +87,7 @@ class GeventWorker(AsyncWorker):
     def timeout_ctx(self):
         return gevent.Timeout(self.cfg.keepalive, False)
 
+    # pylint: disable=not-callable
     def run(self):
         servers = []
         ssl_args = {}
@@ -143,13 +144,15 @@ class GeventWorker(AsyncWorker):
 
             # Force kill all active the handlers
             self.log.warning("Worker graceful timeout (pid:%s)" % self.pid)
-            [server.stop(timeout=1) for server in servers]
+            for server in servers:
+                server.stop(timeout=1)
         except:
             pass
 
-    def handle_request(self, *args):
+    def handle_request(self, listener_name, req, sock, addr):
         try:
-            super(GeventWorker, self).handle_request(*args)
+            super(GeventWorker, self).handle_request(listener_name, req, sock,
+                                                     addr)
         except gevent.GreenletExit:
             pass
         except SystemExit:

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -211,7 +211,7 @@ class ThreadWorker(base.Worker):
             if self.nr_conns < self.worker_connections:
                 # wait for an event
                 events = self.poller.select(1.0)
-                for key, mask in events:
+                for key, _mask in events:
                     callback = key.data
                     callback(key.fileobj)
 
@@ -241,6 +241,7 @@ class ThreadWorker(base.Worker):
 
         futures.wait(self.futures, timeout=self.cfg.graceful_timeout)
 
+    # pylint: disable=bare-except
     def finish_request(self, fs):
         if fs.cancelled():
             self.nr_conns -= 1
@@ -310,6 +311,7 @@ class ThreadWorker(base.Worker):
 
         return (False, conn)
 
+    # pylint: disable=too-many-branches
     def handle_request(self, req, conn):
         environ = {}
         resp = None

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -108,7 +108,7 @@ class ThreadWorker(base.Worker):
         self._lock = RLock()
         super(ThreadWorker, self).init_process()
 
-    def handle_quit(self, sig, frame):
+    def handle_quit(self, _sig, _frame):
         self.alive = False
         # worker_int callback
         self.cfg.worker_int(self)

--- a/gunicorn/workers/gtornado.py
+++ b/gunicorn/workers/gtornado.py
@@ -3,6 +3,8 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
+# pylint: disable=protected-access
+
 import copy
 import os
 import sys

--- a/tests/support.py
+++ b/tests/support.py
@@ -33,6 +33,8 @@ def requires_mac_ver(*min_version):
         return wrapper
     return decorator
 
+# pylint: disable=unused-import
+
 try:
     from types import SimpleNamespace
 except ImportError:

--- a/tests/t.py
+++ b/tests/t.py
@@ -7,10 +7,11 @@
 import os
 import tempfile
 
-dirname = os.path.dirname(__file__)
-
 from gunicorn.http.parser import RequestParser
 from gunicorn.six import BytesIO
+
+
+dirname = os.path.dirname(__file__)
 
 
 def data_source(fname):
@@ -29,7 +30,7 @@ class request(object):
     def __call__(self, func):
         def run():
             src = data_source(self.fname)
-            func(src, RequestParser(src))
+            func(src, RequestParser(src, None))
         run.func_name = func.func_name
         return run
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -77,7 +77,7 @@ def test_property_access():
     assert os.getegid() == c.gid
 
     # Proc name
-    assert "gunicorn" == c.proc_name
+    assert c.proc_name == 'gunicorn'
 
     # Not a config property
     pytest.raises(AttributeError, getattr, c, "foo")
@@ -145,7 +145,7 @@ def test_str_to_list_validation():
 
 def test_callable_validation():
     c = config.Config()
-    def func(a, b):
+    def func(_a, _b):
         pass
     c.set("pre_fork", func)
     assert c.pre_fork == func
@@ -273,13 +273,13 @@ def test_default_config_file(create_config_file):
 def test_post_request():
     c = config.Config()
 
-    def post_request_4(worker, req, environ, resp):
+    def post_request_4(_worker, _req, _environ, _resp):
         return 4
 
-    def post_request_3(worker, req, environ):
+    def post_request_3(_worker, _req, _environ):
         return 3
 
-    def post_request_2(worker, req):
+    def post_request_2(_worker, _req):
         return 2
 
     c.set("post_request", post_request_4)
@@ -295,7 +295,7 @@ def test_post_request():
 def test_nworkers_changed():
     c = config.Config()
 
-    def nworkers_changed_3(server, new_value, old_value):
+    def nworkers_changed_3(_server, _new_value, _old_value):
         return 3
 
     c.set("nworkers_changed", nworkers_changed_3)

--- a/tests/test_gaiohttp.py
+++ b/tests/test_gaiohttp.py
@@ -5,13 +5,13 @@
 
 # pylint: disable=protected-access
 
-import asyncio
 import unittest
 import pytest
 
 aiohttp = pytest.importorskip("aiohttp")
 WSGIServerHttpProtocol = pytest.importorskip("aiohttp.wsgi.WSGIServerHttpProtocol")
 
+import asyncio
 from gunicorn.workers import gaiohttp
 from gunicorn.workers._gaiohttp import _wrp
 from gunicorn.config import Config

--- a/tests/test_gaiohttp.py
+++ b/tests/test_gaiohttp.py
@@ -3,7 +3,7 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
-# pylint: disable=protected-access,wrong-import-position
+# pylint: disable=protected-access
 
 import asyncio
 import unittest

--- a/tests/test_gaiohttp.py
+++ b/tests/test_gaiohttp.py
@@ -3,13 +3,15 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
+# pylint: disable=protected-access,wrong-import-position
+
+import asyncio
 import unittest
 import pytest
 
 aiohttp = pytest.importorskip("aiohttp")
 WSGIServerHttpProtocol = pytest.importorskip("aiohttp.wsgi.WSGIServerHttpProtocol")
 
-import asyncio
 from gunicorn.workers import gaiohttp
 from gunicorn.workers._gaiohttp import _wrp
 from gunicorn.config import Config
@@ -65,7 +67,7 @@ class WorkerTests(unittest.TestCase):
         self.assertIsInstance(f, WSGIServerHttpProtocol)
 
     @mock.patch('gunicorn.workers._gaiohttp.asyncio')
-    def test__run(self, m_asyncio):
+    def test__run(self, _):
         self.worker.ppid = 1
         self.worker.alive = True
         self.worker.servers = []
@@ -85,7 +87,7 @@ class WorkerTests(unittest.TestCase):
         self.assertTrue(self.worker.notify.called)
 
     @mock.patch('gunicorn.workers._gaiohttp.asyncio')
-    def test__run_unix_socket(self, m_asyncio):
+    def test__run_unix_socket(self, _):
         self.worker.ppid = 1
         self.worker.alive = True
         self.worker.servers = []

--- a/tests/test_pidfile.py
+++ b/tests/test_pidfile.py
@@ -32,7 +32,7 @@ def test_validate_no_file(_open):
 
 @mock.patch(builtin('open'), new_callable=mock.mock_open, read_data='1')
 @mock.patch('os.kill')
-def test_validate_file_pid_exists(kill, _open):
+def test_validate_file_pid_exists(_, _open):
     pidfile = gunicorn.pidfile.Pidfile('test.pid')
     assert pidfile.validate() == 1
 

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -26,6 +26,7 @@ from gunicorn import selectors
 import support
 
 
+# pylint: disable=redefined-builtin
 if hasattr(socket, 'socketpair'):
     socketpair = socket.socketpair
 else:
@@ -47,7 +48,6 @@ else:
                 c.close()
                 raise
 
-
 def find_ready_matching(ready, flag):
     match = []
     for key, events in ready:
@@ -68,7 +68,7 @@ class BaseSelectorTestCase(object):
         s = self.SELECTOR()
         self.addCleanup(s.close)
 
-        rd, wr = self.make_socketpair()
+        rd, _ = self.make_socketpair()
 
         key = s.register(rd, selectors.EVENT_READ, "data")
         self.assertIsInstance(key, selectors.SelectorKey)
@@ -94,7 +94,7 @@ class BaseSelectorTestCase(object):
         s = self.SELECTOR()
         self.addCleanup(s.close)
 
-        rd, wr = self.make_socketpair()
+        rd, _ = self.make_socketpair()
 
         s.register(rd, selectors.EVENT_READ)
         s.unregister(rd)
@@ -132,7 +132,7 @@ class BaseSelectorTestCase(object):
         s = self.SELECTOR()
         self.addCleanup(s.close)
 
-        rd, wr = self.make_socketpair()
+        rd, _ = self.make_socketpair()
 
         key = s.register(rd, selectors.EVENT_READ)
 
@@ -183,7 +183,7 @@ class BaseSelectorTestCase(object):
         s = self.SELECTOR()
         self.addCleanup(s.close)
 
-        rd, wr = self.make_socketpair()
+        rd, _ = self.make_socketpair()
 
         key = s.register(rd, selectors.EVENT_READ, "data")
         self.assertEqual(key, s.get_key(rd))
@@ -195,7 +195,7 @@ class BaseSelectorTestCase(object):
         s = self.SELECTOR()
         self.addCleanup(s.close)
 
-        rd, wr = self.make_socketpair()
+        rd, _ = self.make_socketpair()
 
         keys = s.get_map()
         self.assertFalse(keys)
@@ -210,6 +210,7 @@ class BaseSelectorTestCase(object):
 
         # unknown file obj
         with self.assertRaises(KeyError):
+            # pylint: disable=pointless-statement
             keys[999999]
 
         # Read-only mapping
@@ -268,7 +269,7 @@ class BaseSelectorTestCase(object):
         r2w = {}
         w2r = {}
 
-        for i in range(NUM_SOCKETS):
+        for _ in range(NUM_SOCKETS):
             rd, wr = self.make_socketpair()
             s.register(rd, selectors.EVENT_READ)
             s.register(wr, selectors.EVENT_WRITE)
@@ -287,7 +288,7 @@ class BaseSelectorTestCase(object):
             wr = random.choice(ready_writers)
             wr.send(MSG)
 
-            for i in range(10):
+            for _ in range(10):
                 ready = s.select()
                 ready_readers = find_ready_matching(ready,
                                                     selectors.EVENT_READ)
@@ -340,7 +341,7 @@ class BaseSelectorTestCase(object):
         s = self.SELECTOR()
         self.addCleanup(s.close)
 
-        rd, wr = self.make_socketpair()
+        rd, _ = self.make_socketpair()
 
         orig_alrm_handler = signal.signal(signal.SIGALRM, lambda *args: None)
         self.addCleanup(signal.signal, signal.SIGALRM, orig_alrm_handler)
@@ -378,7 +379,7 @@ class ScalableSelectorMixIn:
         s = self.SELECTOR()
         self.addCleanup(s.close)
 
-        for i in range(NUM_FDS // 2):
+        for _ in range(NUM_FDS // 2):
             try:
                 rd, wr = self.make_socketpair()
             except (IOError, OSError):

--- a/tests/treq.py
+++ b/tests/treq.py
@@ -253,7 +253,7 @@ class request(object):
         p = RequestParser(cfg, sender())
         for req in p:
             self.same(req, sizer, matcher, cases.pop(0))
-        assert cases
+        assert not cases
 
     def same(self, req, sizer, matcher, exp):
         assert req.method == exp["method"]

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,3 @@ commands = prospector
 deps =
   ; TODO: See https://github.com/landscapeio/prospector/pull/205
   prospector
-  pytest==3.0.5
-  tornado
-  gevent

--- a/tox.ini
+++ b/tox.ini
@@ -18,3 +18,4 @@ deps =
   prospector
   pytest==3.0.5
   tornado
+  gevent

--- a/tox.ini
+++ b/tox.ini
@@ -15,5 +15,5 @@ deps =
 commands = prospector
 deps =
   ; TODO: See https://github.com/landscapeio/prospector/pull/205
-  pylint<1.7
   prospector
+  pytest

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,5 @@ commands = prospector
 deps =
   ; TODO: See https://github.com/landscapeio/prospector/pull/205
   prospector
-  pytest
+  pytest==3.0.5
+  tornado


### PR DESCRIPTION
This is mostly trivial stuff. There was at least one bug found, being bad format string in statsd decrement. This will want a significant amount of review though as I'm not amazingly familiar with the codebase so I may have made a bad change in fixing things.

The main area I'd like reviewed is the removal of the imports in the run functions in `gunicorn.app.wsgiapp` and `gunicorn.app.pasterapp`.

I've left it as a bunch of smaller commits for now but I can squash them down if desired.

Fixes #1518