### PR TITLE
Unlock pylint and fix lint errors

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -27,5 +27,30 @@ pyflakes:
     # Access to a protected member $X of a client class
     - W0212
 
+pylint:
+  disable:
+    - bare-except
+    - duplicate-bases
+    - duplicate-except
+    - eval-used
+    - import-error
+    - import-self
+    - logging-not-lazy
+    - no-staticmethod-decorator
+    - not-callable
+    - not-context-manager
+    - pointless-statement
+    - protected-access
+    - redefined-builtin
+    - too-many-arguments
+    - too-many-branches
+    - too-many-function-args
+    - too-many-locals
+    - too-many-nested-blocks
+    - unused-argument
+    - unused-import
+    - unused-variable
+    - wrong-import-position
+
 mccabe:
   run: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       env: TOXENV=py36-dev
     - python: nightly
       env: TOXENV=py37
-    - python: 3.5
+    - python: 3.6
       env: TOXENV=lint
   allow_failures:
     - env: TOXENV=py36-dev

--- a/gunicorn/_compat.py
+++ b/gunicorn/_compat.py
@@ -262,3 +262,37 @@ if PY26:
 
 else:
     from gunicorn.six.moves.urllib.parse import urlsplit
+
+
+import inspect
+
+if hasattr(inspect, 'signature'):
+    positionals = (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    )
+
+    def get_arity(f):
+        sig = inspect.signature(f)
+        arity = 0
+
+        for param in sig.parameters.values():
+            if param.kind in positionals:
+                arity += 1
+
+        return arity
+else:
+    def get_arity(f):
+        return len(inspect.getargspec(f)[0])
+
+
+try:
+    import html
+
+    def html_escape(s):
+        return html.escape(s)
+except ImportError:
+    import cgi
+
+    def html_escape(s):
+        return cgi.escape(s, quote=True)

--- a/gunicorn/app/wsgiapp.py
+++ b/gunicorn/app/wsgiapp.py
@@ -61,8 +61,7 @@ class WSGIApplication(Application):
     def load(self):
         if self.cfg.paste is not None:
             return self.load_pasteapp()
-        else:
-            return self.load_wsgiapp()
+        return self.load_wsgiapp()
 
 
 def run():

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -588,7 +588,7 @@ class Arbiter(object):
             sys.stderr.flush()
             sys.exit(self.APP_LOAD_ERROR)
         except:
-            self.log.exception("Exception in worker process"),
+            self.log.exception("Exception in worker process")
             if not worker.booted:
                 sys.exit(self.WORKER_BOOT_ERROR)
             sys.exit(-1)

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -173,8 +173,8 @@ class Arbiter(object):
         are queued. Child signals only wake up the master.
         """
         # close old PIPE
-        if self.PIPE:
-            [os.close(p) for p in self.PIPE]
+        for p in self.PIPE:
+            os.close(p)
 
         # initialize the pipe
         self.PIPE = pair = os.pipe()
@@ -185,7 +185,8 @@ class Arbiter(object):
         self.log.close_on_exec()
 
         # initialize all signals
-        [signal.signal(s, self.signal) for s in self.SIGNALS]
+        for s in self.SIGNALS:
+            signal.signal(s, self.signal)
         signal.signal(signal.SIGCHLD, self.handle_chld)
 
     def signal(self, sig, frame):
@@ -454,7 +455,8 @@ class Arbiter(object):
         # do we need to change listener ?
         if old_address != self.cfg.address:
             # close all listeners
-            [l.close() for l in self.LISTENERS]
+            for l in self.LISTENERS:
+                l.close()
             # init new listeners
             self.LISTENERS = sock.create_sockets(self.cfg, self.log)
             listeners_str = ",".join([str(l) for l in self.LISTENERS])

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -205,7 +205,7 @@ class Arbiter(object):
             while True:
                 self.maybe_promote_master()
 
-                sig = self.SIG_QUEUE.pop(0) if len(self.SIG_QUEUE) else None
+                sig = self.SIG_QUEUE.pop(0, None)
                 if sig is None:
                     self.sleep()
                     self.murder_workers()

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -414,7 +414,7 @@ def validate_callable(arity):
                     "" % (obj_name, mod_name))
         if not six.callable(val):
             raise TypeError("Value is not six.callable: %s" % val)
-        if arity != -1 and arity != len(inspect.getargspec(val)[0]):
+        if arity != -1 and arity != _compat.get_arity(val):
             raise TypeError("Value must have an arity of: %s" % arity)
         return val
     return _validate_callable
@@ -452,7 +452,7 @@ def validate_group(val):
 def validate_post_request(val):
     val = validate_callable(-1)(val)
 
-    largs = len(inspect.getargspec(val)[0])
+    largs = _compat.get_arity(val)
     if largs == 4:
         return val
     elif largs == 3:

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -151,8 +151,7 @@ class Config(object):
         pn = self.settings['proc_name'].get()
         if pn is not None:
             return pn
-        else:
-            return self.settings['default_proc_name'].get()
+        return self.settings['default_proc_name'].get()
 
     @property
     def logger_class(self):

--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -109,12 +109,10 @@ class SafeAtoms(dict):
             kl = k.lower()
             if kl in self:
                 return super(SafeAtoms, self).__getitem__(kl)
-            else:
-                return "-"
+            return "-"
         if k in self:
             return super(SafeAtoms, self).__getitem__(k)
-        else:
-            return '-'
+        return '-'
 
 
 def parse_syslog_address(addr):

--- a/gunicorn/http/body.py
+++ b/gunicorn/http/body.py
@@ -210,7 +210,7 @@ class Body(object):
 
         while size > self.buf.tell():
             data = self.reader.read(1024)
-            if not len(data):
+            if not data:
                 break
             self.buf.write(data)
 
@@ -248,7 +248,7 @@ class Body(object):
     def readlines(self, size=None):
         ret = []
         data = self.read()
-        while len(data):
+        while data:
             pos = data.find(b"\n")
             if pos < 0:
                 ret.append(data)

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -53,7 +53,7 @@ class Message(object):
         self.unreader.unread(unused)
         self.set_body_reader()
 
-    def parse(self):
+    def parse(self, unreader):
         raise NotImplementedError()
 
     def parse_headers(self, data):

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -64,7 +64,7 @@ class Message(object):
 
         # Parse headers into key/value pairs paying attention
         # to continuation lines.
-        while len(lines):
+        while lines:
             if len(headers) >= self.limit_request_fields:
                 raise LimitRequestHeaders("limit request headers fields")
 
@@ -81,7 +81,7 @@ class Message(object):
             name, value = name.strip(), [value.lstrip()]
 
             # Consume value continuation lines
-            while len(lines) and lines[0].startswith((" ", "\t")):
+            while lines and lines[0].startswith((" ", "\t")):
                 curr = lines.pop(0)
                 header_length += len(curr)
                 if header_length > self.limit_request_field_size > 0:

--- a/gunicorn/http/unreader.py
+++ b/gunicorn/http/unreader.py
@@ -40,7 +40,7 @@ class Unreader(object):
 
         while self.buf.tell() < size:
             chunk = self.chunk()
-            if not len(chunk):
+            if not chunk:
                 ret = self.buf.getvalue()
                 self.buf = six.BytesIO()
                 return ret

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -183,7 +183,7 @@ def create(req, sock, client, server, cfg):
                 server = host.split(':')
                 if len(server) == 1:
                     if url_scheme == "http":
-                        server.append(80),
+                        server.append(80)
                     elif url_scheme == "https":
                         server.append(443)
                     else:

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -80,7 +80,7 @@ class Statsd(Logger):
                         pass
 
             # Log to parent logger only if there is something to say
-            if msg is not None and len(msg) > 0:
+            if msg:
                 Logger.log(self, lvl, msg, *args, **kwargs)
         except Exception:
             Logger.warning(self, "Failed to log to statsd", exc_info=True)

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -108,7 +108,7 @@ class Statsd(Logger):
         self._sock_send("{0}{1}:{2}|c|@{3}".format(self.prefix, name, value, sampling_rate))
 
     def decrement(self, name, value, sampling_rate=1.0):
-        self._sock_send("{0){1}:-{2}|c|@{3}".format(self.prefix, name, value, sampling_rate))
+        self._sock_send("{0}{1}:-{2}|c|@{3}".format(self.prefix, name, value, sampling_rate))
 
     def histogram(self, name, value):
         self._sock_send("{0}{1}:{2}|ms".format(self.prefix, name, value))

--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -61,11 +61,6 @@ except ImportError:
     has_inotify = False
 
 
-class InotifyReloader():
-    def __init__(self, callback=None):
-        raise ImportError('You must have the inotify module installed to use '
-                          'the inotify reloader')
-
 if has_inotify:
 
     class InotifyReloader(threading.Thread):
@@ -112,6 +107,13 @@ if has_inotify:
                 filename = event[3]
 
                 self._callback(filename)
+
+else:
+
+    class InotifyReloader():
+        def __init__(self, callback=None):
+            raise ImportError('You must have the inotify module installed to '
+                              'use the inotify reloader')
 
 
 preferred_reloader = InotifyReloader if has_inotify else Reloader

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -31,7 +31,7 @@ class BaseSocket(object):
 
         self.sock = self.set_options(sock, bound=bound)
 
-    def __str__(self, name):
+    def __str__(self):
         return "<socket %d>" % self.sock.fileno()
 
     def __getattr__(self, name):

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -20,9 +20,9 @@ import traceback
 import inspect
 import errno
 import warnings
-import cgi
 import logging
 
+from gunicorn import _compat
 from gunicorn.errors import AppImportError
 from gunicorn.six import text_type
 from gunicorn.workers import SUPPORTED_WORKERS
@@ -329,7 +329,7 @@ def write_error(sock, status_int, reason, mesg):
         %(mesg)s
       </body>
     </html>
-    """) % {"reason": reason, "mesg": cgi.escape(mesg)}
+    """) % {"reason": reason, "mesg": _compat.html_escape(mesg)}
 
     http = textwrap.dedent("""\
     HTTP/1.1 %s %s\r

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -101,7 +101,8 @@ class Worker(object):
             util.close_on_exec(p)
 
         # Prevent fd inheritance
-        [util.close_on_exec(s) for s in self.sockets]
+        for s in self.sockets:
+            util.close_on_exec(s)
         util.close_on_exec(self.tmp.fileno())
 
         self.wait_fds = self.sockets + [self.PIPE[0]]
@@ -155,7 +156,8 @@ class Worker(object):
 
     def init_signals(self):
         # reset signaling
-        [signal.signal(s, signal.SIG_DFL) for s in self.SIGNALS]
+        for s in self.SIGNALS:
+            signal.signal(s, signal.SIG_DFL)
         # init new signaling
         signal.signal(signal.SIGQUIT, self.handle_quit)
         signal.signal(signal.SIGTERM, self.handle_exit)

--- a/gunicorn/workers/geventlet.py
+++ b/gunicorn/workers/geventlet.py
@@ -134,9 +134,12 @@ class EventletWorker(AsyncWorker):
         self.notify()
         try:
             with eventlet.Timeout(self.cfg.graceful_timeout) as t:
-                [a.kill(eventlet.StopServe()) for a in acceptors]
-                [a.wait() for a in acceptors]
+                for a in acceptors:
+                    a.kill(eventlet.StopServe())
+                for a in acceptors:
+                    a.wait()
         except eventlet.Timeout as te:
             if te != t:
                 raise
-            [a.kill() for a in acceptors]
+            for a in acceptors:
+                a.kill()

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -143,7 +143,8 @@ class GeventWorker(AsyncWorker):
 
             # Force kill all active the handlers
             self.log.warning("Worker graceful timeout (pid:%s)" % self.pid)
-            [server.stop(timeout=1) for server in servers]
+            for server in servers:
+                server.stop(timeout=1)
         except:
             pass
 

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -148,9 +148,10 @@ class GeventWorker(AsyncWorker):
         except:
             pass
 
-    def handle_request(self, *args):
+    def handle_request(self, listener_name, req, sock, addr): #arguments-differ
         try:
-            super(GeventWorker, self).handle_request(*args)
+            super(GeventWorker, self).handle_request(listener_name, req, sock,
+                                                     addr)
         except gevent.GreenletExit:
             pass
         except SystemExit:

--- a/tests/t.py
+++ b/tests/t.py
@@ -29,7 +29,7 @@ class request(object):
     def __call__(self, func):
         def run():
             src = data_source(self.fname)
-            func(src, RequestParser(src))
+            func(src, RequestParser(src, None))
         run.func_name = func.func_name
         return run
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -77,7 +77,7 @@ def test_property_access():
     assert os.getegid() == c.gid
 
     # Proc name
-    assert "gunicorn" == c.proc_name
+    assert c.proc_name == "gunicorn" # misplaced-comparison-constant
 
     # Not a config property
     pytest.raises(AttributeError, getattr, c, "foo")

--- a/tests/treq.py
+++ b/tests/treq.py
@@ -74,7 +74,7 @@ class request(object):
             yield lines[:pos+2]
             lines = lines[pos+2:]
             pos = lines.find(b"\r\n")
-        if len(lines):
+        if lines:
             yield lines
 
     def send_bytes(self):
@@ -137,7 +137,7 @@ class request(object):
     def match_read(self, req, body, sizes):
         data = self.szread(req.body.read, sizes)
         count = 1000
-        while len(body):
+        while body:
             if body[:len(data)] != data:
                 raise AssertionError("Invalid body data read: %r != %r" % (
                                         data, body[:len(data)]))
@@ -148,9 +148,9 @@ class request(object):
             if count <= 0:
                 raise AssertionError("Unexpected apparent EOF")
 
-        if len(body):
+        if body:
             raise AssertionError("Failed to read entire body: %r" % body)
-        elif len(data):
+        elif data:
             raise AssertionError("Read beyond expected body: %r" % data)
         data = req.body.read(sizes())
         if data:
@@ -159,7 +159,7 @@ class request(object):
     def match_readline(self, req, body, sizes):
         data = self.szread(req.body.readline, sizes)
         count = 1000
-        while len(body):
+        while body:
             if body[:len(data)] != data:
                 raise AssertionError("Invalid data read: %r" % data)
             if b'\n' in data[:-1]:
@@ -170,9 +170,9 @@ class request(object):
                 count -= 1
             if count <= 0:
                 raise AssertionError("Apparent unexpected EOF")
-        if len(body):
+        if body:
             raise AssertionError("Failed to read entire body: %r" % body)
-        elif len(data):
+        elif data:
             raise AssertionError("Read beyond expected body: %r" % data)
         data = req.body.readline(sizes())
         if data:
@@ -190,7 +190,7 @@ class request(object):
                 raise AssertionError("Invalid body data read: %r != %r" % (
                                                     line, body[:len(line)]))
             body = body[len(line):]
-        if len(body):
+        if body:
             raise AssertionError("Failed to read entire body: %r" % body)
         data = req.body.readlines(sizes())
         if data:
@@ -207,7 +207,7 @@ class request(object):
                 raise AssertionError("Invalid body data read: %r != %r" % (
                                                     line, body[:len(line)]))
             body = body[len(line):]
-        if len(body):
+        if body:
             raise AssertionError("Failed to read entire body: %r" % body)
         try:
             data = six.next(iter(req.body))
@@ -254,7 +254,7 @@ class request(object):
         p = RequestParser(cfg, sender())
         for req in p:
             self.same(req, sizer, matcher, cases.pop(0))
-        assert len(cases) == 0
+        assert not cases
 
     def same(self, req, sizer, matcher, exp):
         assert req.method == exp["method"]

--- a/tox.ini
+++ b/tox.ini
@@ -15,5 +15,4 @@ deps =
 commands = prospector
 deps =
   ; TODO: See https://github.com/landscapeio/prospector/pull/205
-  pylint<1.7
   prospector


### PR DESCRIPTION
This is a much better version of #1519 and also supersedes #1516. Commits are now better separated based on the category of fault they're fixing. There are no `# pylint` comments. More categories are unilaterally disabled in the prospector configuration as there is no way in the prospector configuration to disable a category for a specific file.

Fixes #1515 and #1518.