### PR TITLE
new --reload-extra-file option

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -368,6 +368,14 @@ def validate_string(val):
     return val.strip()
 
 
+def validate_file_exists(val):
+    if val is None:
+        return None
+    if not os.path.exists(val):
+        raise ValueError("File %s does not exists." % val)
+    return val
+
+
 def validate_list_string(val):
     if not val:
         return []
@@ -377,6 +385,10 @@ def validate_list_string(val):
         val = [val]
 
     return [validate_string(v) for v in val]
+
+
+def validate_list_of_existing_files(val):
+    return [validate_file_exists(v) for v in validate_list_string(val)]
 
 
 def validate_string_to_list(val):
@@ -854,6 +866,20 @@ class ReloadEngine(Setting):
         * 'inotify' (requires inotify)
 
         .. versionadded:: 19.7
+        """
+
+
+class ReloadExtraFiles(Setting):
+    name = "reload_extra_files"
+    action = "append"
+    section = "Debugging"
+    cli = ["--reload-extra-file"]
+    meta = "FILES"
+    validator = validate_list_of_existing_files
+    default = []
+    desc = """\
+        Extends --reload option to also watch and reload on additional files
+        (e.g., templates, configurations, specifications, etc.).
         """
 
 

--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -81,6 +81,9 @@ if has_inotify:
             self._dirs = set()
             self._watcher = Inotify()
 
+            for extra_file in extra_files:
+                self.add_extra_file(extra_file)
+
         def add_extra_file(self, filename):
             dirname = os.path.dirname(filename)
 

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -120,7 +120,8 @@ class Worker(object):
                 sys.exit(0)
 
             reloader_cls = reloader_engines[self.cfg.reload_engine]
-            self.reloader = reloader_cls(callback=changed)
+            self.reloader = reloader_cls(extra_files=self.cfg.reload_extra_files,
+                                         callback=changed)
             self.reloader.start()
 
         self.load_wsgi()


### PR DESCRIPTION
I quickly added an option which is implemented but not exposed in the command line.
Would something like this be excepted? If yes I'll add the documentation for the command line option.

/cc @tilgovi (author of ``gunicorn/reloader.py``)

