### PR TITLE
Document selection of 'gthread' worker if sync && threads > 1

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -652,6 +652,11 @@ class WorkerThreads(Setting):
         If it is not defined, the default is ``1``.
 
         This setting only affects the Gthread worker type.
+        
+        .. note::
+           If you try to use the ``sync`` worker type and set the ``threads``
+           setting to more than 1, the ``gthread`` worker type will be used
+           instead.
         """
 
 


### PR DESCRIPTION
The current documentation makes a reader believe that the setting is ignored if the worker type is not Gthread. That is not the case since if the worker is `sync`, a `threads` setting of > 1 sets the worker type to `gthread`.

I know this was probably done to support running gunicorn as `gunicorn --threads=4` and actually have threads even though the default worker is `sync`, but it can be confusing if running `gunicorn --worker-class sync --threads 4` and expecting the parameter will be ignored.