### PR TITLE
Separate Instrumentation and Logging

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -170,3 +170,4 @@ Ryan Peck <ryan@rypeck.com>
 Alex Conrad <alexandre.conrad@gmail.com>
 Nik Nyby <nnyby@columbia.edu>
 Ed Morley <edmorley@users.noreply.github.com>
+Yohei Kusakabe <yoheikusakabe@gmail.com>

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -15,7 +15,7 @@ import traceback
 
 from gunicorn.errors import HaltServer, AppImportError
 from gunicorn.pidfile import Pidfile
-from gunicorn import sock, systemd, util
+from gunicorn import sock, systemd, util, glogging
 
 from gunicorn import __version__, SERVER_SOFTWARE
 
@@ -92,6 +92,8 @@ class Arbiter(object):
         self.cfg = app.cfg
 
         if self.log is None:
+            if self.cfg.instrumentation_classes:
+                self.log = glogging.add_instrumentation(self.cfg)
             self.log = self.cfg.logger_class(app.cfg)
 
         # reopen files

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -161,12 +161,6 @@ class Config(object):
             # support the default
             uri = LoggerClass.default
 
-        # if default logger is in use, and statsd is on, automagically switch
-        # to the statsd logger
-        if uri == LoggerClass.default:
-            if 'statsd_host' in self.settings and self.settings['statsd_host'].value is not None:
-                uri = "gunicorn.instrument.statsd.Statsd"
-
         logger_class = util.load_class(
             uri,
             default="gunicorn.glogging.Logger",
@@ -175,6 +169,18 @@ class Config(object):
         if hasattr(logger_class, "install"):
             logger_class.install()
         return logger_class
+
+    @property
+    def instrumentation_classes(self):
+        inst_class_uris = []
+        inst_classes = []
+        if 'statsd_host' in self.settings and self.settings['statsd_host'].value is not None:
+            inst_class_uris.append("gunicorn.instrument.statsd.Statsd")
+
+        for uri in inst_class_uris:
+            inst_classes.append(util.load_class(uri))
+
+        return inst_classes
 
     @property
     def is_ssl(self):

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -4,12 +4,11 @@
 # See the NOTICE for more information.
 
 "Bare-bones implementation of statsD's protocol, client-side"
-
+from __future__ import print_function
+import sys
 import socket
-import logging
 from re import sub
 
-from gunicorn.glogging import Logger
 from gunicorn import six
 
 # Instrumentation constants
@@ -20,77 +19,72 @@ GAUGE_TYPE = "gauge"
 COUNTER_TYPE = "counter"
 HISTOGRAM_TYPE = "histogram"
 
-class Statsd(Logger):
-    """statsD-based instrumentation, that passes as a logger
+
+class Statsd(object):
+    """
+    Statsd instrumentation.
+    Logging methods (critical, error, warning, exception, info, debug, log,
+    access) will get wrapped in glogging._wrap_log_method by
+    glogging.add_inst_methods, receiving logger and arguments.
     """
     def __init__(self, cfg):
         """host, port: statsD server
         """
-        Logger.__init__(self, cfg)
         self.prefix = sub(r"^(.+[^.]+)\.*$", "\g<1>.", cfg.statsd_prefix)
         try:
             host, port = cfg.statsd_host
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             self.sock.connect((host, int(port)))
-        except Exception:
+        except Exception as e:
             self.sock = None
+            if sys.stderr:
+                print("Error initializing statsd connection: %s" % str(e), file=sys.stderr)
+                sys.stderr.flush()
 
     # Log errors and warnings
-    def critical(self, msg, *args, **kwargs):
-        Logger.critical(self, msg, *args, **kwargs)
+    def critical(self, *args, **kwargs):
         self.increment("gunicorn.log.critical", 1)
 
-    def error(self, msg, *args, **kwargs):
-        Logger.error(self, msg, *args, **kwargs)
+    def error(self, *args, **kwargs):
         self.increment("gunicorn.log.error", 1)
 
-    def warning(self, msg, *args, **kwargs):
-        Logger.warning(self, msg, *args, **kwargs)
+    def warning(self, *args, **kwargs):
         self.increment("gunicorn.log.warning", 1)
 
-    def exception(self, msg, *args, **kwargs):
-        Logger.exception(self, msg, *args, **kwargs)
+    def exception(self, *args, **kwargs):
         self.increment("gunicorn.log.exception", 1)
 
     # Special treatement for info, the most common log level
-    def info(self, msg, *args, **kwargs):
-        self.log(logging.INFO, msg, *args, **kwargs)
+    def info(self, *args,  **kwargs):
+        self.log(*args, **kwargs)
 
     # skip the run-of-the-mill logs
-    def debug(self, msg, *args, **kwargs):
-        self.log(logging.DEBUG, msg, *args, **kwargs)
+    def debug(self, *args, **kwargs):
+        self.log(*args, **kwargs)
 
-    def log(self, lvl, msg, *args, **kwargs):
+    def log(self, *args, **kwargs):
         """Log a given statistic if metric, value and type are present
         """
-        try:
-            extra = kwargs.get("extra", None)
-            if extra is not None:
-                metric = extra.get(METRIC_VAR, None)
-                value = extra.get(VALUE_VAR, None)
-                typ = extra.get(MTYPE_VAR, None)
-                if metric and value and typ:
-                    if typ == GAUGE_TYPE:
-                        self.gauge(metric, value)
-                    elif typ == COUNTER_TYPE:
-                        self.increment(metric, value)
-                    elif typ == HISTOGRAM_TYPE:
-                        self.histogram(metric, value)
-                    else:
-                        pass
-
-            # Log to parent logger only if there is something to say
-            if msg:
-                Logger.log(self, lvl, msg, *args, **kwargs)
-        except Exception:
-            Logger.warning(self, "Failed to log to statsd", exc_info=True)
+        extra = kwargs.get("extra", None)
+        if extra is not None:
+            metric = extra.get(METRIC_VAR, None)
+            value = extra.get(VALUE_VAR, None)
+            typ = extra.get(MTYPE_VAR, None)
+            if metric and value and typ:
+                if typ == GAUGE_TYPE:
+                    self.gauge(metric, value)
+                elif typ == COUNTER_TYPE:
+                    self.increment(metric, value)
+                elif typ == HISTOGRAM_TYPE:
+                    self.histogram(metric, value)
+                else:
+                    pass
 
     # access logging
-    def access(self, resp, req, environ, request_time):
+    def access(self, logger, resp, req, environ, request_time):
         """Measure request duration
         request_time is a datetime.timedelta
         """
-        Logger.access(self, resp, req, environ, request_time)
         duration_in_ms = request_time.seconds * 1000 + float(request_time.microseconds) / 10 ** 3
         status = resp.status
         if isinstance(status, str):
@@ -119,5 +113,10 @@ class Statsd(Logger):
                 msg = msg.encode("ascii")
             if self.sock:
                 self.sock.send(msg)
-        except Exception:
-            Logger.warning(self, "Error sending message to statsd", exc_info=True)
+            elif sys.stderr:
+                print("Statsd connection is not initialized", file=sys.stderr)
+                sys.stderr.flush()
+        except Exception as e:
+            if sys.stderr:
+                print("Error sending message to statsd: %s" % str(e), file=sys.stderr)
+                sys.stderr.flush()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -302,11 +302,10 @@ def test_nworkers_changed():
     assert c.nworkers_changed(1, 2, 3) == 3
 
 
-def test_statsd_changes_logger():
+def test_instrumentation_class_statsd():
     c = config.Config()
-    assert c.logger_class == glogging.Logger
     c.set('statsd_host', 'localhost:12345')
-    assert c.logger_class == statsd.Statsd
+    assert c.instrumentation_classes[0] == statsd.Statsd
 
 
 class MyLogger(glogging.Logger):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,7 +1,9 @@
 import datetime
+import logging
 
 from gunicorn.config import Config
-from gunicorn.glogging import Logger
+from gunicorn.glogging import Logger, add_instrumentation
+from gunicorn.six import StringIO
 
 from support import SimpleNamespace
 
@@ -46,3 +48,35 @@ def test_get_username_from_basic_auth_header():
     logger = Logger(Config())
     atoms = logger.atoms(response, request, environ, datetime.timedelta(seconds=1))
     assert atoms['u'] == 'brk0v'
+
+
+class ConfigMock(Config):
+    def __init__(self, sio):
+        Config.__init__(self)
+        self.sio = sio
+
+    @property
+    def instrumentation_classes(self):
+        return [InstrumentationMock]
+
+
+class InstrumentationMock(object):
+    def __init__(self, cfg):
+        self.cfg = cfg
+        self.sio = cfg.sio
+
+    def info(self, *args, **kwargs):
+        self.sio.write('instrumentation-called')
+
+
+def test_add_inst_methods():
+    sio = StringIO()
+    c = ConfigMock(sio)
+    add_instrumentation(c)
+    logger = Logger(c)
+
+    logger.error_log.addHandler(logging.StreamHandler(sio))
+
+    logger.info('logger-info-called')
+    assert sio.getvalue() == "logger-info-called\ninstrumentation-called"
+

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -4,8 +4,10 @@ import logging
 import tempfile
 import shutil
 import os
+import mock
 
 from gunicorn.config import Config
+from gunicorn.glogging import Logger, add_inst_methods
 from gunicorn.instrument.statsd import Statsd
 from gunicorn.six import StringIO
 
@@ -48,88 +50,137 @@ class MockSocket(object):
         self.msgs = []
 
 
-def test_statsd_fail():
-    "UDP socket fails"
-    logger = Statsd(Config())
-    logger.sock = MockSocket(True)
-    logger.info("No impact on logging")
-    logger.debug("No impact on logging")
-    logger.critical("No impact on logging")
-    logger.error("No impact on logging")
-    logger.warning("No impact on logging")
-    logger.exception("No impact on logging")
+@mock.patch('time.strftime', return_value='01/Jan/2017:00:00:00 +0800')
+def test_instrument(time_mock):
+    c = Config()
+    c.set('statsd_host', 'localhost:12345')
+    c.set('accesslog', '-')
+    statsd = Statsd(c)
+    statsd.sock = MockSocket(False)
+    add_inst_methods(Logger, statsd)
+    logger = Logger(c)
 
-
-def test_instrument():
-    logger = Statsd(Config())
     # Capture logged messages
     sio = StringIO()
-    logger.error_log.addHandler(logging.StreamHandler(sio))
-    logger.sock = MockSocket(False)
+    logger.error_log.handlers = [logging.StreamHandler(sio)]
+    logger.access_log.handlers = [logging.StreamHandler(sio)]
 
     # Regular message
     logger.info("Blah", extra={"mtype": "gauge", "metric": "gunicorn.test", "value": 666})
-    assert logger.sock.msgs[0] == b"gunicorn.test:666|g"
+    assert statsd.sock.msgs[0] == b"gunicorn.test:666|g"
     assert sio.getvalue() == "Blah\n"
-    logger.sock.reset()
+    statsd.sock.reset()
 
-    # Only metrics, no logging
+    # Empty message
     logger.info("", extra={"mtype": "gauge", "metric": "gunicorn.test", "value": 666})
-    assert logger.sock.msgs[0] == b"gunicorn.test:666|g"
-    assert sio.getvalue() == "Blah\n"  # log is unchanged
-    logger.sock.reset()
+    assert statsd.sock.msgs[0] == b"gunicorn.test:666|g"
+    assert sio.getvalue() == "Blah\n\n"  # Empty line is added from Logger.info
+    statsd.sock.reset()
 
-    # Debug logging also supports metrics
+    # Debug with logger level: info (default)
     logger.debug("", extra={"mtype": "gauge", "metric": "gunicorn.debug", "value": 667})
-    assert logger.sock.msgs[0] == b"gunicorn.debug:667|g"
-    assert sio.getvalue() == "Blah\n"  # log is unchanged
-    logger.sock.reset()
+    assert statsd.sock.msgs[0] == b"gunicorn.debug:667|g"
+    assert sio.getvalue() == "Blah\n\n"  # Logging doesn't happen, but statsd still gets called
+    statsd.sock.reset()
 
+    # Critical
     logger.critical("Boom")
-    assert logger.sock.msgs[0] == b"gunicorn.log.critical:1|c|@1.0"
-    logger.sock.reset()
+    assert statsd.sock.msgs[0] == b"gunicorn.log.critical:1|c|@1.0"
+    assert sio.getvalue() == "Blah\n\nBoom\n"
+    statsd.sock.reset()
 
-    logger.access(SimpleNamespace(status="200 OK"), None, {}, timedelta(seconds=7))
-    assert logger.sock.msgs[0] == b"gunicorn.request.duration:7000.0|ms"
-    assert logger.sock.msgs[1] == b"gunicorn.requests:1|c|@1.0"
-    assert logger.sock.msgs[2] == b"gunicorn.request.status.200:1|c|@1.0"
+    # Exception
+    logger.exception("Exception")
+    assert statsd.sock.msgs[0] == b"gunicorn.log.exception:1|c|@1.0"
+    assert sio.getvalue() == "Blah\n\nBoom\nException\nNone\n"  # Exception adds exc_info (in this case None)
+    statsd.sock.reset()
+
+    # Access logging
+    environ = {
+        'REQUEST_METHOD': 'GET', 'RAW_URI': '/my/path?foo=bar',
+        'PATH_INFO': '/my/path', 'QUERY_STRING': 'foo=bar',
+        'SERVER_PROTOCOL': 'HTTP/1.1'
+    }
+    logger.access(SimpleNamespace(status="200 OK", headers=()), SimpleNamespace(headers=()), environ,
+                  timedelta(seconds=7))
+    assert statsd.sock.msgs[0] == b"gunicorn.request.duration:7000.0|ms"
+    assert statsd.sock.msgs[1] == b"gunicorn.requests:1|c|@1.0"
+    assert statsd.sock.msgs[2] == b"gunicorn.request.status.200:1|c|@1.0"
+    assert sio.getvalue() == ('Blah\n\nBoom\nException\nNone\n'
+                              '- - - 01/Jan/2017:00:00:00 +0800 "GET /my/path?foo=bar HTTP/1.1" 200 - "-" "-"\n')
 
 
 def test_prefix():
     c = Config()
+    c.set('statsd_host', 'localhost:12345')
     c.set("statsd_prefix", "test.")
-    logger = Statsd(c)
-    logger.sock = MockSocket(False)
+    statsd = Statsd(c)
+    statsd.sock = MockSocket(False)
+    add_inst_methods(Logger, statsd)
+    logger = Logger(c)
 
     logger.info("Blah", extra={"mtype": "gauge", "metric": "gunicorn.test", "value": 666})
-    assert logger.sock.msgs[0] == b"test.gunicorn.test:666|g"
+    assert statsd.sock.msgs[0] == b"test.gunicorn.test:666|g"
 
 
 def test_prefix_no_dot():
     c = Config()
+    c.set('statsd_host', 'localhost:12345')
     c.set("statsd_prefix", "test")
-    logger = Statsd(c)
-    logger.sock = MockSocket(False)
+    statsd = Statsd(c)
+    statsd.sock = MockSocket(False)
+    add_inst_methods(Logger, statsd)
+    logger = Logger(c)
 
     logger.info("Blah", extra={"mtype": "gauge", "metric": "gunicorn.test", "value": 666})
-    assert logger.sock.msgs[0] == b"test.gunicorn.test:666|g"
+    assert statsd.sock.msgs[0] == b"test.gunicorn.test:666|g"
 
 
 def test_prefix_multiple_dots():
     c = Config()
+    c.set('statsd_host', 'localhost:12345')
     c.set("statsd_prefix", "test...")
-    logger = Statsd(c)
-    logger.sock = MockSocket(False)
+    statsd = Statsd(c)
+    statsd.sock = MockSocket(False)
+    add_inst_methods(Logger, statsd)
+    logger = Logger(c)
 
     logger.info("Blah", extra={"mtype": "gauge", "metric": "gunicorn.test", "value": 666})
-    assert logger.sock.msgs[0] == b"test.gunicorn.test:666|g"
+    assert statsd.sock.msgs[0] == b"test.gunicorn.test:666|g"
 
 
 def test_prefix_nested():
     c = Config()
+    c.set('statsd_host', 'localhost:12345')
     c.set("statsd_prefix", "test.asdf.")
-    logger = Statsd(c)
-    logger.sock = MockSocket(False)
+    statsd = Statsd(c)
+    statsd.sock = MockSocket(False)
+    add_inst_methods(Logger, statsd)
+    logger = Logger(c)
 
     logger.info("Blah", extra={"mtype": "gauge", "metric": "gunicorn.test", "value": 666})
-    assert logger.sock.msgs[0] == b"test.asdf.gunicorn.test:666|g"
+    assert statsd.sock.msgs[0] == b"test.asdf.gunicorn.test:666|g"
+
+
+def test_statsd_fail():
+    "UDP socket fails"
+    c = Config()
+    c.set('statsd_host', 'localhost:12345')
+    statsd = Statsd(c)
+    statsd.sock = MockSocket(True)
+    add_inst_methods(Logger, statsd)
+    logger = Logger(c)
+
+    sio = StringIO()
+    logger.error_log.handlers = [logging.StreamHandler(sio)]
+
+    logger.info("test-info")
+    assert sio.getvalue() == "test-info\n"
+    logger.critical("test-critical")
+    assert sio.getvalue() == "test-info\ntest-critical\n"
+    logger.error("test-error")
+    assert sio.getvalue() == "test-info\ntest-critical\ntest-error\n"
+    logger.warning("test-warning")
+    assert sio.getvalue() == "test-info\ntest-critical\ntest-error\ntest-warning\n"
+    logger.exception("test-exception")
+    assert sio.getvalue() == "test-info\ntest-critical\ntest-error\ntest-warning\ntest-exception\nNone\n"


### PR DESCRIPTION
Proposed fix for #1564 on separation of instrumentation from logging by dynamically wrapping instrumentation methods and logging methods.
This allows multiple instrumentation possible if desired, loading from newly added config property, `instrumentation_classes`.