### PR TITLE
Check all the worker pids instead of every child.

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -508,7 +508,7 @@ class Arbiter(object):
         """\
         Reap workers to avoid zombie processes
         """
-        for pid in tuple(self.WORKERS):
+        for pid in self.WORKERS.keys():
             try:
                 wpid, status = os.waitpid(pid, os.WNOHANG)
                 if self.reexec_pid == wpid:

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -511,8 +511,6 @@ class Arbiter(object):
         for pid in tuple(self.WORKERS):
             try:
                 wpid, status = os.waitpid(pid, os.WNOHANG)
-                if not wpid:
-                    continue
                 if self.reexec_pid == wpid:
                     self.reexec_pid = 0
                 else:

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -508,11 +508,11 @@ class Arbiter(object):
         """\
         Reap workers to avoid zombie processes
         """
-        try:
-            while True:
-                wpid, status = os.waitpid(-1, os.WNOHANG)
+        for pid, _ in self.WORKERS.items():
+            try:
+                wpid, status = os.waitpid(pid, os.WNOHANG)
                 if not wpid:
-                    break
+                    continue
                 if self.reexec_pid == wpid:
                     self.reexec_pid = 0
                 else:
@@ -532,9 +532,9 @@ class Arbiter(object):
                         continue
                     worker.tmp.close()
                     self.cfg.child_exit(self, worker)
-        except OSError as e:
-            if e.errno != errno.ECHILD:
-                raise
+            except OSError as e:
+                if e.errno != errno.ECHILD:
+                    raise
 
     def manage_workers(self):
         """\

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -508,7 +508,7 @@ class Arbiter(object):
         """\
         Reap workers to avoid zombie processes
         """
-        for pid, _ in self.WORKERS.items():
+        for pid in tuple(self.WORKERS):
             try:
                 wpid, status = os.waitpid(pid, os.WNOHANG)
                 if not wpid:

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -10,6 +10,8 @@ try:
 except ImportError:
     import mock
 
+import pytest
+
 import gunicorn.app.base
 import gunicorn.arbiter
 
@@ -159,7 +161,9 @@ def test_arbiter_reap_workers_with_unexpected_exception(mock_os_waitpid):
     arbiter.cfg.settings['child_exit'] = mock.Mock()
     mock_worker = mock.Mock()
     arbiter.WORKERS = {42: mock_worker}
-    self.assertRaises(OSError, arbiter.reap_workers)
+    with pytest.raises(OSError) as excinfo:
+        arbiter.reap_workers()
+    assert excinfo.errno == 11
 
 
 class PreloadedAppWithEnvSettings(DummyApplication):

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -141,7 +141,17 @@ def test_arbiter_reap_workers(mock_os_waitpid):
     mock_worker.tmp.close.assert_called_with()
     arbiter.cfg.child_exit.assert_called_with(arbiter, mock_worker)
 
-    
+
+@mock.patch('os.waitpid')
+def test_arbiter_reap_workers_with_waitpid_exception(mock_os_waitpid):
+    mock_os_waitpid.side_effect = [lambda : OSError(10, "No child processes")]
+    arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
+    arbiter.cfg.settings['child_exit'] = mock.Mock()
+    mock_worker = mock.Mock()
+    arbiter.WORKERS = {42: mock_worker}
+    arbiter.reap_workers()
+
+
 class PreloadedAppWithEnvSettings(DummyApplication):
     """
     Simple application that makes use of the 'preload' feature to

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -152,6 +152,16 @@ def test_arbiter_reap_workers_with_waitpid_exception(mock_os_waitpid):
     arbiter.reap_workers()
 
 
+@mock.patch('os.waitpid')
+def test_arbiter_reap_workers_with_unexpected_exception(mock_os_waitpid):
+    mock_os_waitpid.side_effect = OSError(11, "Any other error")
+    arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
+    arbiter.cfg.settings['child_exit'] = mock.Mock()
+    mock_worker = mock.Mock()
+    arbiter.WORKERS = {42: mock_worker}
+    self.assertRaises(OSError, arbiter.reap_workers)
+
+
 class PreloadedAppWithEnvSettings(DummyApplication):
     """
     Simple application that makes use of the 'preload' feature to

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -163,7 +163,7 @@ def test_arbiter_reap_workers_with_unexpected_exception(mock_os_waitpid):
     arbiter.WORKERS = {42: mock_worker}
     with pytest.raises(OSError) as excinfo:
         arbiter.reap_workers()
-    assert excinfo.errno == 11
+    assert excinfo.value.errno == 11
 
 
 class PreloadedAppWithEnvSettings(DummyApplication):

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -132,7 +132,7 @@ def test_arbiter_calls_worker_exit(mock_os_fork):
 
 @mock.patch('os.waitpid')
 def test_arbiter_reap_workers(mock_os_waitpid):
-    mock_os_waitpid.side_effect = [(42, 0), (0, 0)]
+    mock_os_waitpid.side_effect = [(42, 0)]
     arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
     arbiter.cfg.settings['child_exit'] = mock.Mock()
     mock_worker = mock.Mock()
@@ -141,7 +141,7 @@ def test_arbiter_reap_workers(mock_os_waitpid):
     mock_worker.tmp.close.assert_called_with()
     arbiter.cfg.child_exit.assert_called_with(arbiter, mock_worker)
 
-
+    
 class PreloadedAppWithEnvSettings(DummyApplication):
     """
     Simple application that makes use of the 'preload' feature to

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -144,7 +144,7 @@ def test_arbiter_reap_workers(mock_os_waitpid):
 
 @mock.patch('os.waitpid')
 def test_arbiter_reap_workers_with_waitpid_exception(mock_os_waitpid):
-    mock_os_waitpid.side_effect = [lambda : OSError(10, "No child processes")]
+    mock_os_waitpid.side_effect = OSError(10, "No child processes")
     arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
     arbiter.cfg.settings['child_exit'] = mock.Mock()
     mock_worker = mock.Mock()


### PR DESCRIPTION
This solves a problem where this wait is triggered by something done on a child process launched by a third-party library which we use when setting up workers.

This seems to be a reasonable fix, we only need to wait on the pids of the workers, and not any other arbitrary child pid.