### PR TITLE
Update docs links

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -7,7 +7,7 @@ Requirements
 To generate documentation you need to install:
 
  - Python >= 2.5
- - Sphinx (http://sphinx.pocoo.org/)
+ - Sphinx (http://sphinx-doc.org/)
 
 
 Generate html

--- a/docs/source/2010-news.rst
+++ b/docs/source/2010-news.rst
@@ -204,8 +204,8 @@ Changelog - 2010
 * Allow multiple keys in request and response headers
 
 .. _Tornado: http://www.tornadoweb.org/
-.. _`PEP 333`: http://www.python.org/dev/peps/pep-0333/
-.. _Eventlet: http://eventlet.net
-.. _Gevent: http://gevent.org
-.. _OpenBSD: http://openbsd.org
-.. _Websockets: http://dev.w3.org/html5/websockets/
+.. _`PEP 333`: https://www.python.org/dev/peps/pep-0333/
+.. _Eventlet: http://eventlet.net/
+.. _Gevent: http://www.gevent.org/
+.. _OpenBSD: https://www.openbsd.org/
+.. _Websockets: https://html.spec.whatwg.org/multipage/web-sockets.html

--- a/docs/source/configure.rst
+++ b/docs/source/configure.rst
@@ -77,7 +77,7 @@ settings. If you have ideas for providing settings to WSGI applications or
 pulling information from Django's settings.py feel free to open an issue_ to
 let us know.
 
-.. _issue: http://github.com/benoitc/gunicorn/issues
+.. _issue: https://github.com/benoitc/gunicorn/issues
 
 Paster Applications
 -------------------

--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -331,4 +331,4 @@ utility::
 .. _`logging configuration file`: https://github.com/benoitc/gunicorn/blob/master/examples/logging.conf
 .. _Virtualenv: http://pypi.python.org/pypi/virtualenv
 .. _Systemd: http://www.freedesktop.org/wiki/Software/systemd
-.. _Gaffer <https://gaffer.readthedocs.io/en/latest/index.html>:
+.. _Gaffer: https://gaffer.readthedocs.io/

--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -320,15 +320,15 @@ utility::
    Gunicorn error log is here to log errors from Gunicorn, not from another
    application.
 
-.. _Nginx: http://www.nginx.org
+.. _Nginx: https://nginx.org/
 .. _Hey: https://github.com/rakyll/hey
-.. _`example configuration`: http://github.com/benoitc/gunicorn/blob/master/examples/nginx.conf
+.. _`example configuration`: https://github.com/benoitc/gunicorn/blob/master/examples/nginx.conf
 .. _runit: http://smarden.org/runit/
-.. _`example service`: http://github.com/benoitc/gunicorn/blob/master/examples/gunicorn_rc
-.. _Supervisor: http://supervisord.org
-.. _`simple configuration`: http://github.com/benoitc/gunicorn/blob/master/examples/supervisor.conf
+.. _`example service`: https://github.com/benoitc/gunicorn/blob/master/examples/gunicorn_rc
+.. _Supervisor: http://supervisord.org/
+.. _`simple configuration`: https://github.com/benoitc/gunicorn/blob/master/examples/supervisor.conf
 .. _`configuration documentation`: http://docs.gunicorn.org/en/latest/settings.html#logging
 .. _`logging configuration file`: https://github.com/benoitc/gunicorn/blob/master/examples/logging.conf
-.. _Virtualenv: http://pypi.python.org/pypi/virtualenv
-.. _Systemd: http://www.freedesktop.org/wiki/Software/systemd
+.. _Virtualenv: https://pypi.python.org/pypi/virtualenv
+.. _Systemd: https://www.freedesktop.org/wiki/Software/systemd/
 .. _Gaffer: https://gaffer.readthedocs.io/

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -134,7 +134,7 @@ code in the master process).
    feature.
 
 .. _Greenlets: https://github.com/python-greenlet/greenlet
-.. _Eventlet: http://eventlet.net
-.. _Gevent: http://gevent.org
+.. _Eventlet: http://eventlet.net/
+.. _Gevent: http://www.gevent.org/
 .. _Hey: https://github.com/rakyll/hey
 .. _aiohttp: https://github.com/KeepSafe/aiohttp

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -52,7 +52,7 @@ handle unbuffered requests (ie, serving requests directly from the internet)
 you should use one of the async workers.
 
 .. _Hey: https://github.com/rakyll/hey
-.. _setproctitle: http://pypi.python.org/pypi/setproctitle
+.. _setproctitle: https://pypi.python.org/pypi/setproctitle
 .. _proc_name: settings.html#proc-name
 
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -134,8 +134,8 @@ you can install it in the usual way::
 
 .. _`design docs`: design.html
 .. _Eventlet: http://eventlet.net
-.. _Gevent: http://gevent.org
-.. _libevent: http://monkey.org/~provos/libevent
-.. _Debian: http://www.debian.org/
-.. _`Debian Backports`: http://backports.debian.org/
-.. _Ubuntu: http://www.ubuntu.com/
+.. _Gevent: http://www.gevent.org/
+.. _libevent: http://libevent.org/
+.. _Debian: https://www.debian.org/
+.. _`Debian Backports`: https://backports.debian.org/
+.. _Ubuntu: https://www.ubuntu.com/

--- a/docs/source/instrumentation.rst
+++ b/docs/source/instrumentation.rst
@@ -30,4 +30,4 @@ all requests. The following metrics are generated:
 * ``gunicorn.log.warning``: rate of warning log messages
 * ``gunicorn.log.exception``: rate of exceptional log messages
 
-.. _statsD: http://github.com/etsy/statsd
+.. _statsD: https://github.com/etsy/statsd

--- a/docs/source/run.rst
+++ b/docs/source/run.rst
@@ -71,7 +71,7 @@ Settings can be specified by using environment variable
 
 See :ref:`configuration` and :ref:`settings` for detailed usage.
 
-.. _setproctitle: http://pypi.python.org/pypi/setproctitle/
+.. _setproctitle: https://pypi.python.org/pypi/setproctitle
 
 Integration
 ===========


### PR DESCRIPTION
- Fix dead link to Gaffer in docs
- Update links to reduce HTTP redirects (e.g. http->https, with/without www subdomains, trailing slashes)
