### PR TITLE
Update Debian installation instructions

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -71,18 +71,39 @@ advantages:
   rolled back in case of incompatibility. The package can also be purged
   entirely from the system in seconds.
 
-stable ("jessie")
------------------
+stable ("stretch")
+------------------
 
-The version of Gunicorn in the Debian_ "stable" distribution is 19.0 (June
-2014). You can install it using::
+The version of Gunicorn in the Debian_ "stable" distribution is 19.6.0 (June
+2017). You can install it using::
 
     $ sudo apt-get install gunicorn
 
 You can also use the most recent version by using `Debian Backports`_.
 First, copy the following line to your ``/etc/apt/sources.list``::
 
-    deb http://backports.debian.org/debian-backports jessie-backports main
+    deb http://ftp.debian.org/debian stretch-backports main
+
+Then, update your local package lists::
+
+    $ sudo apt-get update
+
+You can then install the latest version using::
+
+    $ sudo apt-get -t stretch-backports install gunicorn
+
+oldstable ("jessie")
+--------------------
+
+The version of Gunicorn in the Debian_ "oldstable" distribution is 19.0 (June
+2014). you can install it using::
+
+    $ sudo apt-get install gunicorn
+
+You can also use the most recent version by using `Debian Backports`_.
+First, copy the following line to your ``/etc/apt/sources.list``::
+
+    deb http://ftp.debian.org/debian jessie-backports main
 
 Then, update your local package lists::
 
@@ -92,31 +113,10 @@ You can then install the latest version using::
 
     $ sudo apt-get -t jessie-backports install gunicorn
 
-oldstable ("wheezy")
---------------------
+Testing ("buster") / Unstable ("sid")
+-------------------------------------
 
-The version of Gunicorn in the Debian_ "oldstable" distribution is 0.14.5 (June
-2012). you can install it using::
-
-    $ sudo apt-get install gunicorn
-
-You can also use the most recent version by using `Debian Backports`_.
-First, copy the following line to your ``/etc/apt/sources.list``::
-
-    deb http://backports.debian.org/debian-backports wheezy-backports main
-
-Then, update your local package lists::
-
-    $ sudo apt-get update
-
-You can then install the latest version using::
-
-    $ sudo apt-get -t wheezy-backports install gunicorn
-
-Testing ("stretch") / Unstable ("sid")
---------------------------------------
-
-"stretch" and "sid" contain the latest released version of Gunicorn. You can
+"buster" and "sid" contain the latest released version of Gunicorn. You can
 install it in the usual way::
 
     $ sudo apt-get install gunicorn


### PR DESCRIPTION
Update Debian installation instructions as two years passed after #1112 and 'stretch' Debian 9 was released.