### PR TITLE
Add restructuredtext_lint to test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ matrix:
       env: TOXENV=py38-dev
       dist: xenial
       sudo: true
+    - python: 3.7
+      env: TOXENV=docs-lint
+      dist: xenial
+      sudo: true
   allow_failures:
     - env: TOXENV=py38-dev
 install: pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -27,3 +27,15 @@ commands =
     tests/test_valid_requests.py
 deps =
   pylint
+
+[testenv:docs-lint]
+whitelist_externals =
+  rst-lint
+  bash
+  grep
+deps =
+  restructuredtext_lint
+  pygments
+commands =
+  rst-lint README.rst docs/README.rst
+  bash -c "(set -o pipefail; rst-lint --encoding utf-8 docs/source/*.rst | grep -v 'Unknown interpreted text role\|Unknown directive type'); test $? == 1"


### PR DESCRIPTION
To save time to fix docs formatting (#1592, #1597), add [restructuredtext_lint](https://github.com/twolfson/restructuredtext-lint) to test.

At this moment there's no way to ignore extended directives and roles for Sphinx in restructuredtext_lint CLI and so this PR includes a workaround to skip the following errors:

```
   2 ERROR Unknown directive type "highlight".
   2 ERROR Unknown directive type "literalinclude".
   2 ERROR Unknown directive type "toctree".
  14 ERROR Unknown directive type "versionadded".
   7 ERROR Unknown directive type "versionchanged".
   1 ERROR Unknown interpreted text role "class".
   6 ERROR Unknown interpreted text role "doc".
 148 ERROR Unknown interpreted text role "issue".
   2 ERROR Unknown interpreted text role "pr".
  21 ERROR Unknown interpreted text role "ref".
```

Blocked #1597 

Closes #1596