### PR TITLE
Enable pycodestyle in prospector CI

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -17,7 +17,19 @@ ignore-paths:
   - tests/test_gaiohttp.py  # TODO: We are going to remove this worker.
 
 pep8:
-  run: false
+  enable:
+    - E127
+    - E128
+    - E262
+    - E265
+    - E266
+    - E301
+    - E302
+    - E303
+    - W291
+    - W293
+  disable:
+    - E129
 
 pyflakes:
   run: false

--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -14,6 +14,7 @@ from gunicorn.arbiter import Arbiter
 from gunicorn.config import Config, get_default_config_file
 from gunicorn import debug
 
+
 class BaseApplication(object):
     """
     An application interface for configuring and loading

--- a/gunicorn/app/pasterapp.py
+++ b/gunicorn/app/pasterapp.py
@@ -65,15 +65,16 @@ def paste_config(gconfig, config_url, relative_to, global_conf=None):
 
 
 def load_pasteapp(config_url, relative_to, global_conf=None):
-    return loadapp(config_url, relative_to=relative_to,
-            global_conf=global_conf)
+    return loadapp(config_url,
+                   relative_to=relative_to, global_conf=global_conf)
+
 
 class PasterBaseApplication(Application):
     gcfg = None
 
     def app_config(self):
         return paste_config(self.cfg, self.cfgurl, self.relpath,
-                global_conf=self.gcfg)
+                            global_conf=self.gcfg)
 
     def load_config(self):
         super(PasterBaseApplication, self).load_config()

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -573,7 +573,7 @@ class Arbiter(object):
         # Do not inherit the temporary files of other workers
         for sibling in self.WORKERS.values():
             sibling.tmp.close()
-        
+
         # Process Child
         worker.pid = os.getpid()
         try:
@@ -602,7 +602,7 @@ class Arbiter(object):
                 self.cfg.worker_exit(self, worker)
             except:
                 self.log.warning("Exception during worker exit:\n%s",
-                                  traceback.format_exc())
+                                 traceback.format_exc())
 
     def spawn_workers(self):
         """\

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -84,9 +84,9 @@ class Config(object):
         }
         parser = argparse.ArgumentParser(**kwargs)
         parser.add_argument("-v", "--version",
-                action="version", default=argparse.SUPPRESS,
-                version="%(prog)s (version " + __version__ + ")\n",
-                help="show program's version number and exit")
+                            action="version", default=argparse.SUPPRESS,
+                            version="%(prog)s (version " + __version__ + ")\n",
+                            help="show program's version number and exit")
         parser.add_argument("args", nargs="*", help=argparse.SUPPRESS)
 
         keys = sorted(self.settings, key=self.settings.__getitem__)
@@ -99,7 +99,7 @@ class Config(object):
     def worker_class_str(self):
         uri = self.settings['worker_class'].get()
 
-        ## are we using a threaded worker?
+        # are we using a threaded worker?
         is_sync = uri.endswith('SyncWorker') or uri == 'sync'
         if is_sync and self.threads > 1:
             return "threads"
@@ -109,7 +109,7 @@ class Config(object):
     def worker_class(self):
         uri = self.settings['worker_class'].get()
 
-        ## are we using a threaded worker?
+        # are we using a threaded worker?
         is_sync = uri.endswith('SyncWorker') or uri == 'sync'
         if is_sync and self.threads > 1:
             uri = "gunicorn.workers.gthread.ThreadWorker"
@@ -409,7 +409,7 @@ def validate_callable(arity):
                 raise TypeError(str(e))
             except AttributeError:
                 raise TypeError("Can not load '%s' from '%s'"
-                    "" % (obj_name, mod_name))
+                                "" % (obj_name, mod_name))
         if not six.callable(val):
             raise TypeError("Value is not six.callable: %s" % val)
         if arity != -1 and arity != _compat.get_arity(val):
@@ -495,7 +495,7 @@ def validate_reload_engine(val):
 
 def get_default_config_file():
     config_path = os.path.join(os.path.abspath(os.getcwd()),
-            'gunicorn.conf.py')
+                               'gunicorn.conf.py')
     if os.path.exists(config_path):
         return config_path
     return None
@@ -520,6 +520,7 @@ class ConfigFile(Setting):
            Loading the config from a Python module requires the ``python:``
            prefix.
         """
+
 
 class Bind(Setting):
     name = "bind"
@@ -623,6 +624,7 @@ class WorkerClass(Setting):
            :ref:`asyncio-workers` for more information on how to use it.
         """
 
+
 class WorkerThreads(Setting):
     name = "threads"
     section = "Worker Processes"
@@ -643,7 +645,7 @@ class WorkerThreads(Setting):
         If it is not defined, the default is ``1``.
 
         This setting only affects the Gthread worker type.
-        
+
         .. note::
            If you try to use the ``sync`` worker type and set the ``threads``
            setting to more than 1, the ``gthread`` worker type will be used
@@ -979,6 +981,7 @@ class Daemon(Setting):
         background.
         """
 
+
 class Env(Setting):
     name = "raw_env"
     action = "append"
@@ -1011,6 +1014,7 @@ class Pidfile(Setting):
 
         If not set, no PID file will be written.
         """
+
 
 class WorkerTmpDir(Setting):
     name = "worker_tmp_dir"
@@ -1064,6 +1068,7 @@ class Group(Setting):
         retrieved with a call to ``pwd.getgrnam(value)`` or ``None`` to not
         change the worker processes group.
         """
+
 
 class Umask(Setting):
     name = "umask"
@@ -1177,6 +1182,7 @@ class AccessLog(Setting):
 
         ``'-'`` means log to stdout.
         """
+
 
 class DisableRedirectAccessToSyslog(Setting):
     name = "disable_redirect_access_to_syslog"
@@ -1437,6 +1443,7 @@ class StatsdHost(Setting):
     .. versionadded:: 19.1
     """
 
+
 class StatsdPrefix(Setting):
     name = "statsd_prefix"
     section = "Logging"
@@ -1612,6 +1619,7 @@ class PostWorkerInit(Setting):
         Worker.
         """
 
+
 class WorkerInt(Setting):
     name = "worker_int"
     section = "Server Hooks"
@@ -1755,6 +1763,7 @@ class NumWorkersChanged(Setting):
         be ``None``.
         """
 
+
 class OnExit(Setting):
     name = "on_exit"
     section = "Server Hooks"
@@ -1835,6 +1844,7 @@ class CertFile(Setting):
     SSL certificate file
     """
 
+
 class SSLVersion(Setting):
     name = "ssl_version"
     section = "SSL"
@@ -1849,6 +1859,7 @@ class SSLVersion(Setting):
        ``ssl.PROTOCOL_SSLv23``.
     """
 
+
 class CertReqs(Setting):
     name = "cert_reqs"
     section = "SSL"
@@ -1858,6 +1869,7 @@ class CertReqs(Setting):
     desc = """\
     Whether client certificate is required (see stdlib ssl module's)
     """
+
 
 class CACerts(Setting):
     name = "ca_certs"
@@ -1870,6 +1882,7 @@ class CACerts(Setting):
     CA certificates file
     """
 
+
 class SuppressRaggedEOFs(Setting):
     name = "suppress_ragged_eofs"
     section = "SSL"
@@ -1880,6 +1893,7 @@ class SuppressRaggedEOFs(Setting):
     desc = """\
     Suppress ragged EOFs (see stdlib ssl module's)
     """
+
 
 class DoHandshakeOnConnect(Setting):
     name = "do_handshake_on_connect"

--- a/gunicorn/errors.py
+++ b/gunicorn/errors.py
@@ -4,7 +4,7 @@
 # See the NOTICE for more information.
 
 
-# we inherit from BaseException here to make sure to not be caucght 
+# we inherit from BaseException here to make sure to not be caucght
 # at application level
 class HaltServer(BaseException):
     def __init__(self, reason, exit_status=1):

--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -35,7 +35,7 @@ SYSLOG_FACILITIES = {
         "lpr":      6,
         "mail":     2,
         "news":     7,
-        "security": 4,  #  DEPRECATED
+        "security": 4,  #  DEPRECATED # noqa
         "syslog":   5,
         "user":     1,
         "uucp":     8,
@@ -218,8 +218,10 @@ class Logger(object):
 
         # set gunicorn.access handler
         if cfg.accesslog is not None:
-            self._set_handler(self.access_log, cfg.accesslog,
-                fmt=logging.Formatter(self.access_fmt), stream=sys.stdout)
+            self._set_handler(
+                self.access_log, cfg.accesslog,
+                fmt=logging.Formatter(self.access_fmt), stream=sys.stdout
+            )
 
         # set syslog handler
         if cfg.syslog:
@@ -293,7 +295,8 @@ class Logger(object):
             'u': self._get_user(environ) or '-',
             't': self.now(),
             'r': "%s %s %s" % (environ['REQUEST_METHOD'],
-                environ['RAW_URI'], environ["SERVER_PROTOCOL"]),
+                               environ['RAW_URI'],
+                               environ["SERVER_PROTOCOL"]),
             's': status,
             'm': environ.get('REQUEST_METHOD'),
             'U': environ.get('PATH_INFO'),
@@ -345,8 +348,9 @@ class Logger(object):
         # wrap atoms:
         # - make sure atoms will be test case insensitively
         # - if atom doesn't exist replace it by '-'
-        safe_atoms = self.atoms_wrapper_class(self.atoms(resp, req, environ,
-            request_time))
+        safe_atoms = self.atoms_wrapper_class(
+            self.atoms(resp, req, environ, request_time)
+        )
 
         try:
             self.access_log.info(self.cfg.access_log_format, safe_atoms)
@@ -369,7 +373,6 @@ class Logger(object):
                 os.dup2(self.logfile.fileno(), sys.stdout.fileno())
                 os.dup2(self.logfile.fileno(), sys.stderr.fileno())
 
-
         for log in loggers():
             for handler in log.handlers:
                 if isinstance(handler, logging.FileHandler):
@@ -378,7 +381,7 @@ class Logger(object):
                         if handler.stream:
                             handler.stream.close()
                             handler.stream = open(handler.baseFilename,
-                                    handler.mode)
+                                                  handler.mode)
                     finally:
                         handler.release()
 
@@ -445,13 +448,14 @@ class Logger(object):
 
         # finally setup the syslog handler
         if sys.version_info >= (2, 7):
-            h = logging.handlers.SysLogHandler(address=addr,
-                    facility=facility, socktype=socktype)
+            h = logging.handlers.SysLogHandler(
+                    address=addr, facility=facility, socktype=socktype
+                )
         else:
             # socktype is only supported in 2.7 and sup
             # fix issue #541
             h = logging.handlers.SysLogHandler(address=addr,
-                    facility=facility)
+                                               facility=facility)
 
         h.setFormatter(fmt)
         h._gunicorn = True

--- a/gunicorn/http/_sendfile.py
+++ b/gunicorn/http/_sendfile.py
@@ -56,8 +56,10 @@ def sendfile(fdout, fdin, offset, nbytes):
         return _sbytes.value
 
     else:
-        _sendfile.argtypes = [ctypes.c_int, ctypes.c_int,
-                ctypes.POINTER(ctypes.c_uint64), ctypes.c_size_t]
+        _sendfile.argtypes = [
+            ctypes.c_int, ctypes.c_int,
+            ctypes.POINTER(ctypes.c_uint64), ctypes.c_size_t,
+        ]
 
         _offset = ctypes.c_uint64(offset)
         sent = _sendfile(fdout, fdin, _offset, nbytes)

--- a/gunicorn/http/body.py
+++ b/gunicorn/http/body.py
@@ -3,8 +3,9 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
-from gunicorn.http.errors import (NoMoreData, ChunkMissingTerminator,
-        InvalidChunkSize)
+from gunicorn.http.errors import (
+    NoMoreData, ChunkMissingTerminator, InvalidChunkSize,
+)
 from gunicorn import six
 
 

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -10,9 +10,11 @@ from errno import ENOTCONN
 from gunicorn._compat import bytes_to_str
 from gunicorn.http.unreader import SocketUnreader
 from gunicorn.http.body import ChunkedReader, LengthReader, EOFReader, Body
-from gunicorn.http.errors import (InvalidHeader, InvalidHeaderName, NoMoreData,
+from gunicorn.http.errors import (
+    InvalidHeader, InvalidHeaderName, NoMoreData,
     InvalidRequestLine, InvalidRequestMethod, InvalidHTTPVersion,
-    LimitRequestLine, LimitRequestHeaders)
+    LimitRequestLine, LimitRequestHeaders,
+)
 from gunicorn.http.errors import InvalidProxyLine, ForbiddenProxyRequest
 from gunicorn.six import BytesIO
 from gunicorn._compat import urlsplit
@@ -86,7 +88,7 @@ class Message(object):
                 header_length += len(curr)
                 if header_length > self.limit_request_field_size > 0:
                     raise LimitRequestHeaders("limit request headers "
-                            + "fields size")
+                                              "fields size")
                 value.append(curr)
             value = ''.join(value).rstrip()
 

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -137,8 +137,9 @@ def create(req, sock, client, server, cfg):
             # handle expect
             if hdr_value.lower() == "100-continue":
                 sock.send(b"HTTP/1.1 100 Continue\r\n\r\n")
-        elif secure_headers and (hdr_name in secure_headers and
-              hdr_value == secure_headers[hdr_name]):
+        elif (secure_headers
+              and hdr_name in secure_headers
+              and hdr_value == secure_headers[hdr_name]):
             url_scheme = "https"
         elif hdr_name == 'HOST':
             host = hdr_value
@@ -318,7 +319,7 @@ class Response(object):
 
         headers = [
             "HTTP/%s.%s %s\r\n" % (self.req.version[0],
-                self.req.version[1], self.status),
+                                   self.req.version[1], self.status),
             "Server: %s\r\n" % self.version,
             "Date: %s\r\n" % util.http_date(),
             "Connection: %s\r\n" % connection

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -20,6 +20,7 @@ GAUGE_TYPE = "gauge"
 COUNTER_TYPE = "counter"
 HISTOGRAM_TYPE = "histogram"
 
+
 class Statsd(Logger):
     """statsD-based instrumentation, that passes as a logger
     """

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -92,7 +92,7 @@ relative import to an absolute import.
 
 
 def load_class(uri, default="gunicorn.workers.sync.SyncWorker",
-        section="gunicorn.workers"):
+               section="gunicorn.workers"):
     if inspect.isclass(uri):
         return uri
     if uri.startswith("egg:"):
@@ -122,8 +122,9 @@ def load_class(uri, default="gunicorn.workers.sync.SyncWorker",
                     break
 
                 try:
-                    return pkg_resources.load_entry_point("gunicorn",
-                                section, uri)
+                    return pkg_resources.load_entry_point(
+                        "gunicorn", section, uri
+                    )
                 except:
                     exc = traceback.format_exc()
                     msg = "class uri %r invalid or not found: \n\n[%s]"
@@ -249,7 +250,7 @@ def parse_address(netloc, default_port=8000):
     else:
         host = netloc.lower()
 
-    #get port
+    # get port
     netloc = netloc.split(']')[-1]
     if ":" in netloc:
         port = netloc.split(':', 1)[1]
@@ -505,6 +506,7 @@ def to_bytestring(value, encoding="utf8"):
         raise TypeError('%r is not a string' % value)
 
     return value.encode(encoding)
+
 
 def has_fileno(obj):
     if not hasattr(obj, "fileno"):

--- a/gunicorn/workers/async.py
+++ b/gunicorn/workers/async.py
@@ -93,7 +93,7 @@ class AsyncWorker(base.Worker):
         try:
             self.cfg.pre_request(self, req)
             resp, environ = wsgi.create(req, sock, addr,
-                    listener_name, self.cfg)
+                                        listener_name, self.cfg)
             environ["wsgi.multithread"] = True
             self.nr += 1
             if self.alive and self.nr >= self.max_requests:

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -27,8 +27,9 @@ from gunicorn.six import MAXSIZE
 
 class Worker(object):
 
-    SIGNALS = [getattr(signal, "SIG%s" % x)
-            for x in "ABRT HUP QUIT INT TERM USR1 USR2 WINCH CHLD".split()]
+    SIGNALS = [getattr(signal, "SIG%s" % x) for x in (
+                   "ABRT HUP QUIT INT TERM USR1 USR2 WINCH CHLD".split()
+               )]
 
     PIPE = []
 
@@ -197,11 +198,13 @@ class Worker(object):
     def handle_error(self, req, client, addr, exc):
         request_start = datetime.now()
         addr = addr or ('', -1)  # unix socket case
-        if isinstance(exc, (InvalidRequestLine, InvalidRequestMethod,
+        if isinstance(exc, (
+                InvalidRequestLine, InvalidRequestMethod,
                 InvalidHTTPVersion, InvalidHeader, InvalidHeaderName,
                 LimitRequestLine, LimitRequestHeaders,
                 InvalidProxyLine, ForbiddenProxyRequest,
-                SSLError)):
+                SSLError,
+            )):
 
             status_int = 400
             reason = "Bad Request"

--- a/gunicorn/workers/geventlet.py
+++ b/gunicorn/workers/geventlet.py
@@ -26,6 +26,7 @@ import greenlet
 from gunicorn.http.wsgi import sendfile as o_sendfile
 from gunicorn.workers.async import AsyncWorker
 
+
 def _eventlet_sendfile(fdout, fdin, offset, nbytes):
     while True:
         try:

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -32,6 +32,7 @@ from gunicorn.http.wsgi import sendfile as o_sendfile
 
 VERSION = "gevent/%s gunicorn/%s" % (gevent.__version__, gunicorn.__version__)
 
+
 def _gevent_sendfile(fdout, fdin, offset, nbytes):
     while True:
         try:
@@ -41,6 +42,7 @@ def _gevent_sendfile(fdout, fdin, offset, nbytes):
                 wait_write(fdout)
             else:
                 raise
+
 
 def patch_sendfile():
     from gunicorn.http import wsgi
@@ -72,10 +74,10 @@ class GeventWorker(AsyncWorker):
         for s in self.sockets:
             if sys.version_info[0] == 3:
                 sockets.append(socket(s.FAMILY, _socket.SOCK_STREAM,
-                    fileno=s.sock.fileno()))
+                                      fileno=s.sock.fileno()))
             else:
                 sockets.append(socket(s.FAMILY, _socket.SOCK_STREAM,
-                    _sock=s))
+                                      _sock=s))
         self.sockets = sockets
 
     def notify(self):
@@ -178,8 +180,8 @@ class GeventWorker(AsyncWorker):
             import gevent.core
             gevent.core.reinit()
 
-            #gevent 0.13 and older doesn't reinitialize dns for us after forking
-            #here's the workaround
+            # gevent 0.13 and older doesn't reinitialize dns for us after forking
+            # here's the workaround
             gevent.core.dns_shutdown(fail_requests=1)
             gevent.core.dns_init()
             super(GeventWorker, self).init_process()

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -62,7 +62,7 @@ class TConn(object):
             # wrap the socket if needed
             if self.cfg.is_ssl:
                 self.sock = ssl.wrap_socket(self.sock, server_side=True,
-                        **self.cfg.ssl_options)
+                                            **self.cfg.ssl_options)
 
             # initialize the parser
             self.parser = http.RequestParser(self.cfg, self.sock)
@@ -100,7 +100,7 @@ class ThreadWorker(base.Worker):
 
         if max_keepalived <= 0 and cfg.keepalive:
             log.warning("No keepalived connections can be handled. " +
-                    "Check the number of worker connections and threads.")
+                        "Check the number of worker connections and threads.")
 
     def init_process(self):
         self.tpool = futures.ThreadPoolExecutor(max_workers=self.cfg.threads)
@@ -136,8 +136,8 @@ class ThreadWorker(base.Worker):
             # enqueue the job
             self.enqueue_req(conn)
         except EnvironmentError as e:
-            if e.errno not in (errno.EAGAIN,
-                    errno.ECONNABORTED, errno.EWOULDBLOCK):
+            if e.errno not in (errno.EAGAIN, errno.ECONNABORTED,
+                               errno.EWOULDBLOCK):
                 raise
 
     def reuse_connection(self, conn, client):
@@ -217,11 +217,11 @@ class ThreadWorker(base.Worker):
 
                 # check (but do not wait) for finished requests
                 result = futures.wait(self.futures, timeout=0,
-                        return_when=futures.FIRST_COMPLETED)
+                                      return_when=futures.FIRST_COMPLETED)
             else:
                 # wait for a request to finish
                 result = futures.wait(self.futures, timeout=1.0,
-                        return_when=futures.FIRST_COMPLETED)
+                                      return_when=futures.FIRST_COMPLETED)
 
             # clean up finished requests
             for fut in result.done:
@@ -262,7 +262,7 @@ class ThreadWorker(base.Worker):
 
                     # add the socket to the event loop
                     self.poller.register(conn.sock, selectors.EVENT_READ,
-                            partial(self.reuse_connection, conn))
+                                         partial(self.reuse_connection, conn))
             else:
                 self.nr_conns -= 1
                 conn.close()
@@ -317,7 +317,7 @@ class ThreadWorker(base.Worker):
             self.cfg.pre_request(self, req)
             request_start = datetime.now()
             resp, environ = wsgi.create(req, conn.sock, conn.client,
-                    conn.server, self.cfg)
+                                        conn.server, self.cfg)
             environ["wsgi.multithread"] = True
             self.nr += 1
             if self.alive and self.nr >= self.max_requests:

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -18,8 +18,10 @@ import gunicorn.util as util
 import gunicorn.workers.base as base
 from gunicorn import six
 
+
 class StopWaiting(Exception):
     """ exception raised to stop waiting for a connnection """
+
 
 class SyncWorker(base.Worker):
 
@@ -73,7 +75,7 @@ class SyncWorker(base.Worker):
 
             except EnvironmentError as e:
                 if e.errno not in (errno.EAGAIN, errno.ECONNABORTED,
-                        errno.EWOULDBLOCK):
+                                   errno.EWOULDBLOCK):
                     raise
 
             if not self.is_parent_alive():
@@ -102,7 +104,7 @@ class SyncWorker(base.Worker):
                         self.accept(listener)
                     except EnvironmentError as e:
                         if e.errno not in (errno.EAGAIN, errno.ECONNABORTED,
-                                errno.EWOULDBLOCK):
+                                           errno.EWOULDBLOCK):
                             raise
 
             if not self.is_parent_alive():
@@ -128,7 +130,7 @@ class SyncWorker(base.Worker):
         try:
             if self.cfg.is_ssl:
                 client = ssl.wrap_socket(client, server_side=True,
-                    **self.cfg.ssl_options)
+                                         **self.cfg.ssl_options)
 
             parser = http.RequestParser(self.cfg, client)
             req = six.next(parser)
@@ -164,7 +166,7 @@ class SyncWorker(base.Worker):
             self.cfg.pre_request(self, req)
             request_start = datetime.now()
             resp, environ = wsgi.create(req, client, addr,
-                    listener.getsockname(), self.cfg)
+                                        listener.getsockname(), self.cfg)
             # Force the connection closed until someone shows
             # a buffering proxy that supports Keep-Alive to
             # the backend.


### PR DESCRIPTION
This PR enables pycodestyle in lint tox through prospector. The version of pycodestyle is exactly 2.0.0 due to the constraints from prospector while the latest is [2.3.1](https://pypi.python.org/pypi/pycodestyle/2.3.1).

Starts with the following lints:

- E127
- E128
- E262
- E265
- E266
- E301
- E302
- E303
- W291
- W293

In this PR the following lints are disabled:

- E129

Closes #1599

### Tests

- Failed before fixing errors/warnings: https://travis-ci.org/tnir/gunicorn/jobs/276449817
- Passed after fixing errors/warnings: https://travis-ci.org/tnir/gunicorn/jobs/276451030