### PR TITLE
Let Errno 92 pass (support windows Linux Subsystem)

### DIFF
--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -43,7 +43,7 @@ class BaseSocket(object):
             try:
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
             except socket.error as err:
-                if err.errno not in (errno.ENOPROTOOPT, errno.EINVAL):
+                if err.errno not in (errno.ENOPROTOOPT, errno.EINVAL, 92):
                     raise
         if not bound:
             self.bind(sock)


### PR DESCRIPTION
When running gunicorn in a windows Linux Subsystem I get this error. 

    16:21:30 web.1   |     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
    16:21:30 web.1   | OSError: [Errno 92] Protocol not available

This fix in this pull request mirrors the way they fixed the bug in eventlet. https://github.com/eventlet/eventlet/issues/418
