### PR TITLE
workers.base: Log 500 error message

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -11,7 +11,6 @@ import select
 import signal
 import sys
 import time
-import traceback
 
 from gunicorn.errors import HaltServer, AppImportError
 from gunicorn.pidfile import Pidfile
@@ -590,8 +589,8 @@ class Arbiter(object):
             print("%s" % e, file=sys.stderr)
             sys.stderr.flush()
             sys.exit(self.APP_LOAD_ERROR)
-        except:
-            self.log.exception("Exception in worker process")
+        except Exception as e:
+            self.log.exception("Exception in worker process", exc_info=e)
             if not worker.booted:
                 sys.exit(self.WORKER_BOOT_ERROR)
             sys.exit(-1)
@@ -600,9 +599,8 @@ class Arbiter(object):
             try:
                 worker.tmp.close()
                 self.cfg.worker_exit(self, worker)
-            except:
-                self.log.warning("Exception during worker exit:\n%s",
-                                  traceback.format_exc())
+            except Exception as e:
+                self.log.warning("Exception during worker exit", exc_info=e)
 
     def spawn_workers(self):
         """\

--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -18,7 +18,6 @@ import os
 import socket
 import sys
 import threading
-import traceback
 
 from gunicorn import util
 from gunicorn.six import PY3, string_types
@@ -350,8 +349,8 @@ class Logger(object):
 
         try:
             self.access_log.info(self.cfg.access_log_format, safe_atoms)
-        except:
-            self.error(traceback.format_exc())
+        except Exception as error:
+            self.error('access logging failed', exc_info=error)
 
     def now(self):
         """ return date in Apache Common Log Format """

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -66,7 +66,7 @@ class BaseSocket(object):
         try:
             self.sock.close()
         except socket.error as e:
-            self.log.info("Error while closing socket %s", str(e))
+            self.log.info("Error while closing socket", exc_info=e)
 
         self.sock = None
 

--- a/gunicorn/workers/_gaiohttp.py
+++ b/gunicorn/workers/_gaiohttp.py
@@ -82,8 +82,8 @@ class AiohttpWorker(base.Worker):
         try:
             if hasattr(self.wsgi, 'close'):
                 yield from self.wsgi.close()
-        except:
-            self.log.exception('Process shutdown exception')
+        except Exception as e:
+            self.log.exception('Process shutdown exception', exc_info=e)
 
     @asyncio.coroutine
     def _run(self):

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -139,7 +139,7 @@ class Worker(object):
             if self.cfg.reload == 'off':
                 raise
 
-            self.log.exception(e)
+            self.log.exception(e, exec_info=e)
 
             # fix from PR #1228
             # storing the traceback into exc_tb will create a circular reference.
@@ -235,7 +235,10 @@ class Worker(object):
             self.log.debug(msg.format(ip=addr[0], error=str(exc)))
         else:
             if hasattr(req, "uri"):
-                self.log.exception("Error handling request %s", req.uri)
+                self.log.exception("Error handling request %s", req.uri, exc_info=exc)
+            else:
+                self.log.exception("Error handling request", exc_info=exc)
+
             status_int = 500
             reason = "Internal Server Error"
             mesg = ""
@@ -252,8 +255,8 @@ class Worker(object):
 
         try:
             util.write_error(client, status_int, reason, mesg)
-        except:
-            self.log.debug("Failed to send error message.")
+        except Exception as error:
+            self.log.debug("Failed to send error message", exc_info=error)
 
     def handle_winch(self, sig, fname):
         # Ignore SIGWINCH in worker. Fixes a crash on OpenBSD.

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -134,15 +134,14 @@ class SyncWorker(base.Worker):
             req = six.next(parser)
             self.handle_request(listener, req, client, addr)
         except http.errors.NoMoreData as e:
-            self.log.debug("Ignored premature client disconnection. %s", e)
+            self.log.debug("Ignored premature client disconnection", exc_info=e)
         except StopIteration as e:
-            self.log.debug("Closing connection. %s", e)
+            self.log.debug("Closing connection", exc_info=e)
         except ssl.SSLError as e:
             if e.args[0] == ssl.SSL_ERROR_EOF:
                 self.log.debug("ssl connection closed")
                 client.close()
             else:
-                self.log.debug("Error processing SSL request.")
                 self.handle_error(req, client, addr, e)
         except EnvironmentError as e:
             if e.errno not in (errno.EPIPE, errno.ECONNRESET):
@@ -189,11 +188,11 @@ class SyncWorker(base.Worker):
         except EnvironmentError:
             # pass to next try-except level
             six.reraise(*sys.exc_info())
-        except Exception:
+        except Exception as error:
             if resp and resp.headers_sent:
                 # If the requests have already been sent, we should close the
                 # connection to indicate the error.
-                self.log.exception("Error handling request")
+                self.log.exception("Error handling request", exc_info=error)
                 try:
                     client.shutdown(socket.SHUT_RDWR)
                     client.close()
@@ -204,5 +203,5 @@ class SyncWorker(base.Worker):
         finally:
             try:
                 self.cfg.post_request(self, req, environ, resp)
-            except Exception:
-                self.log.exception("Exception in post_request hook")
+            except Exception as error:
+                self.log.exception("Exception in post_request hook", exc_info=error)


### PR DESCRIPTION
This makes it a bit easier to debug than just logging the fact that there was an exception.  Also restore logging in the URI-less case, since that was broken in 79011d0c (#1071) but not restored in 1ccebab7 (#1231).