### PR TITLE
faq: Fix --log-file → --error-logfile

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -107,8 +107,8 @@ Why I don't see any logs in the console?
 ----------------------------------------
 
 In version R19, Gunicorn doesn't log by default in the console.
-To watch the logs in the console you need to use the option ``--log-file=-``.
-In version R20, Gunicorn logs to the console by default again.
+To watch the logs in the console you need to use the option ``--error-logfile=-``.
+In version R19.2, Gunicorn logs to the console by default again.
 
 Kernel Parameters
 =================


### PR DESCRIPTION
The option rename is from 66f7271c.

Also fix the version for console restoration from 7be15d63 (#892).  7be15d63 didn't know which release it would end up in, but it turned out to be 19.2:

```
$ git describe --contains 7be15d633
19.2~74^2
```

Fixes #1294.