### PR TITLE
TCP RST is sent if application does not consume all posted data

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -159,6 +159,7 @@ Sébastien Fievet <zyegfryed@gmail.com>
 TedWantsMore <TedWantsMore@gmx.com>
 Thomas Grainger <tagrain@gmail.com>
 Thomas Steinacher <tom@eggdrop.ch>
+Toshihito Kikuchi <k.toshihito@yahoo.de>
 Travis Cline <travis.cline@gmail.com>
 Travis Swicegood <development@domain51.com>
 Trey Long <trey@ktrl.com>

--- a/gunicorn/http/body.py
+++ b/gunicorn/http/body.py
@@ -257,3 +257,12 @@ class Body(object):
                 line, data = data[:pos + 1], data[pos + 1:]
                 ret.append(line)
         return ret
+
+    def discard(self):
+        discarded_len = 0
+        bytes_read = six.MAXSIZE
+        while bytes_read > 0:
+            data = self.reader.read(1024)
+            bytes_read = len(data)
+            discarded_len += bytes_read
+        return discarded_len


### PR DESCRIPTION
If we receive POST but WSGI application does not consume all posted data from
the stream, we just close the socket, resulting in an abortive session close
with TCP RST without graceful finish.

![rst](https://user-images.githubusercontent.com/1780142/32930480-d2b2d2a8-cb13-11e7-9c0b-e30c9005b1aa.png)

This was observed when HTTP POST was sent via XHR over HTTPS.  If this happens,
Chrome displays ERR_CONNECTION_RESET and we cannot see response payload.

<img width="359" alt="chrome" src="https://user-images.githubusercontent.com/1780142/32930458-aa314418-cb13-11e7-9242-0b526e2c4153.png">

The proposed fix is to discard data in the body before closing the socket as
Eventlet does in `HttpProtocol.handle_one_request`.