### PR TITLE
Avoid needlessly triggering true return from issetugid on MacOSX

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -161,7 +161,7 @@ def set_owner_process(uid, gid, initgroups=False):
 
         if initgroups:
             os.initgroups(username, gid)
-        else:
+        elif gid != os.getgid():
             os.setgid(gid)
 
     if uid:


### PR DESCRIPTION
On MacOSX (tested on Sierra 10.12) setgid(getgid()) causes subsequent calls to issetugid to return true, even though the operation is a no-op.  Kerberos examines issetugid on OSX and ignores KRB5_KTNAME on true.  This makes it impossible to use gunicorn in a kerberos enabled app that relies on keytabs.