### PR TITLE
Add extras_require for various worker types

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -33,12 +33,12 @@ want to consider one of the alternate worker types.
 
 ::
 
-    $ pip install greenlet  # Required for both
-    $ pip install eventlet  # For eventlet workers
-    $ pip install gevent    # For gevent workers
+    $ pip install gunicorn[eventlet]  # For eventlet workers
+    $ pip install gunicorn[gevent]    # For gevent workers
 
 .. note::
-    If installing ``greenlet`` fails you probably need to install
+    Both require ``greenlet``, which should get installed automatically,
+    If its installation fails, you probably need to install
     the Python headers. These headers are available in most package
     managers. On Ubuntu the package name for ``apt-get`` is
     ``python-dev``.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -33,8 +33,11 @@ want to consider one of the alternate worker types.
 
 ::
 
-    $ pip install gunicorn[eventlet]  # For eventlet workers
-    $ pip install gunicorn[gevent]    # For gevent workers
+    $ pip install greenlet            # Required for both
+    $ pip install eventlet            # For eventlet workers
+    $ pip install gunicorn[eventlet]  # Or, using extra
+    $ pip install gevent              # For gevent workers
+    $ pip install gunicorn[gevent]    # Or, using extra
 
 .. note::
     Both require ``greenlet``, which should get installed automatically,

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -119,10 +119,12 @@ you might want to choose one of the other worker classes.
 A string referring to one of the following bundled classes:
 
 * ``sync``
-* ``eventlet`` - Requires eventlet >= 0.9.7
-* ``gevent``   - Requires gevent >= 0.13
-* ``tornado``  - Requires tornado >= 0.2
-* ``gthread``  - Python 2 requires the futures package to be installed
+* ``eventlet`` - Requires eventlet >= 0.9.7 (or install using
+  gunicorn[eventlet])
+* ``gevent``   - Requires gevent >= 0.13 (or install using gunicorn[gevent])
+* ``tornado``  - Requires tornado >= 0.2 (or install using gunicorn[tornado])
+* ``gthread``  - Python 2 requires the futures package to be installed (or
+  install using gunicorn[gthread])
 * ``gaiohttp`` - Deprecated.
 
 Optionally, you can provide your own worker by giving Gunicorn a

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -115,16 +115,19 @@ The type of workers to use.
 The default class (``sync``) should handle most "normal" types of
 workloads. You'll want to read :doc:`design` for information on when
 you might want to choose one of the other worker classes. Required
-libraries may be installed using setuptools' extra_require feature.
+libraries may be installed using setuptools' ``extra_require`` feature.
 
 A string referring to one of the following bundled classes:
 
 * ``sync``
-* ``eventlet`` - Requires eventlet >= 0.9.7 (extra gunicorn[eventlet])
-* ``gevent``   - Requires gevent >= 0.13 (extra gunicorn[gevent])
-* ``tornado``  - Requires tornado >= 0.2 (extra gunicorn[tornado])
+* ``eventlet`` - Requires eventlet >= 0.9.7 (or install it via 
+  ``pip install gunicorn[eventlet]``)
+* ``gevent``   - Requires gevent >= 0.13 (or install it via 
+  ``pip install gunicorn[gevent]``)
+* ``tornado``  - Requires tornado >= 0.2 (or install it via 
+  ``pip install gunicorn[tornado]``)
 * ``gthread``  - Python 2 requires the futures package to be installed
-  (extra gunicorn[gthread])
+  (or install it via ``pip install gunicorn[gthread]``)
 * ``gaiohttp`` - Deprecated.
 
 Optionally, you can provide your own worker by giving Gunicorn a

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -119,12 +119,10 @@ you might want to choose one of the other worker classes.
 A string referring to one of the following bundled classes:
 
 * ``sync``
-* ``eventlet`` - Requires eventlet >= 0.9.7 (or install using
-  gunicorn[eventlet])
-* ``gevent``   - Requires gevent >= 0.13 (or install using gunicorn[gevent])
-* ``tornado``  - Requires tornado >= 0.2 (or install using gunicorn[tornado])
-* ``gthread``  - Python 2 requires the futures package to be installed (or
-  install using gunicorn[gthread])
+* ``eventlet`` - Requires eventlet >= 0.9.7
+* ``gevent``   - Requires gevent >= 0.13
+* ``tornado``  - Requires tornado >= 0.2
+* ``gthread``  - Python 2 requires the futures package to be installed
 * ``gaiohttp`` - Deprecated.
 
 Optionally, you can provide your own worker by giving Gunicorn a

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -114,15 +114,17 @@ The type of workers to use.
 
 The default class (``sync``) should handle most "normal" types of
 workloads. You'll want to read :doc:`design` for information on when
-you might want to choose one of the other worker classes.
+you might want to choose one of the other worker classes. Required
+libraries may be installed using setuptools' extra_require feature.
 
 A string referring to one of the following bundled classes:
 
 * ``sync``
-* ``eventlet`` - Requires eventlet >= 0.9.7
-* ``gevent``   - Requires gevent >= 0.13
-* ``tornado``  - Requires tornado >= 0.2
+* ``eventlet`` - Requires eventlet >= 0.9.7 (extra gunicorn[eventlet])
+* ``gevent``   - Requires gevent >= 0.13 (extra gunicorn[gevent])
+* ``tornado``  - Requires tornado >= 0.2 (extra gunicorn[tornado])
 * ``gthread``  - Python 2 requires the futures package to be installed
+  (extra gunicorn[gthread])
 * ``gaiohttp`` - Deprecated.
 
 Optionally, you can provide your own worker by giving Gunicorn a

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -605,15 +605,17 @@ class WorkerClass(Setting):
 
         The default class (``sync``) should handle most "normal" types of
         workloads. You'll want to read :doc:`design` for information on when
-        you might want to choose one of the other worker classes.
+        you might want to choose one of the other worker classes. Required
+        libraries may be installed using setuptools' extra_require feature.
 
         A string referring to one of the following bundled classes:
 
         * ``sync``
-        * ``eventlet`` - Requires eventlet >= 0.9.7
-        * ``gevent``   - Requires gevent >= 0.13
-        * ``tornado``  - Requires tornado >= 0.2
+        * ``eventlet`` - Requires eventlet >= 0.9.7 (extra gunicorn[eventlet])
+        * ``gevent``   - Requires gevent >= 0.13 (extra gunicorn[gevent])
+        * ``tornado``  - Requires tornado >= 0.2 (extra gunicorn[tornado])
         * ``gthread``  - Python 2 requires the futures package to be installed
+          (extra gunicorn[gthread])
         * ``gaiohttp`` - Deprecated.
 
         Optionally, you can provide your own worker by giving Gunicorn a

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -606,16 +606,19 @@ class WorkerClass(Setting):
         The default class (``sync``) should handle most "normal" types of
         workloads. You'll want to read :doc:`design` for information on when
         you might want to choose one of the other worker classes. Required
-        libraries may be installed using setuptools' extra_require feature.
+        libraries may be installed using setuptools' ``extra_require`` feature.
 
         A string referring to one of the following bundled classes:
 
         * ``sync``
-        * ``eventlet`` - Requires eventlet >= 0.9.7 (extra gunicorn[eventlet])
-        * ``gevent``   - Requires gevent >= 0.13 (extra gunicorn[gevent])
-        * ``tornado``  - Requires tornado >= 0.2 (extra gunicorn[tornado])
+        * ``eventlet`` - Requires eventlet >= 0.9.7 (or install it via 
+          ``pip install gunicorn[eventlet]``)
+        * ``gevent``   - Requires gevent >= 0.13 (or install it via 
+          ``pip install gunicorn[gevent]``)
+        * ``tornado``  - Requires tornado >= 0.2 (or install it via 
+          ``pip install gunicorn[tornado]``)
         * ``gthread``  - Python 2 requires the futures package to be installed
-          (extra gunicorn[gthread])
+          (or install it via ``pip install gunicorn[gthread]``)
         * ``gaiohttp`` - Deprecated.
 
         Optionally, you can provide your own worker by giving Gunicorn a

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,16 @@ class PyTestCommand(TestCommand):
         errno = pytest.main(self.test_args)
         sys.exit(errno)
 
+
+extra_require = {
+    'gevent':  ["gevent>=0.13"],
+    'eventlet': ["eventlet>=0.9.7"],
+    'tornado': ["tornado>=0.2"],
+    'gthread': []
+}
+if sys.version_info[0] < 3:
+    extra_require['gthread'] = ["futures"]
+
 setup(
     name='gunicorn',
     version=__version__,
@@ -99,9 +109,5 @@ setup(
     [paste.server_runner]
     main=gunicorn.app.pasterapp:paste_server
     """,
-    extras_require={
-        'gevent':  ["gevent"],
-        'eventlet': ["eventlet"],
-        'tornado': ["tornado"],
-    },
+    extras_require=extra_require
 )

--- a/setup.py
+++ b/setup.py
@@ -74,13 +74,13 @@ class PyTestCommand(TestCommand):
 
 
 extra_require = {
-    'gevent':  ["gevent>=0.13"],
-    'eventlet': ["eventlet>=0.9.7"],
-    'tornado': ["tornado>=0.2"],
-    'gthread': []
+    'gevent':  ['gevent>=0.13'],
+    'eventlet': ['eventlet>=0.9.7'],
+    'tornado': ['tornado>=0.2'],
+    'gthread': [],
 }
 if sys.version_info[0] < 3:
-    extra_require['gthread'] = ["futures"]
+    extra_require['gthread'] = ['futures']
 
 setup(
     name='gunicorn',
@@ -109,5 +109,5 @@ setup(
     [paste.server_runner]
     main=gunicorn.app.pasterapp:paste_server
     """,
-    extras_require=extra_require
+    extras_require=extra_require,
 )

--- a/setup.py
+++ b/setup.py
@@ -98,5 +98,10 @@ setup(
 
     [paste.server_runner]
     main=gunicorn.app.pasterapp:paste_server
-    """
+    """,
+    extras_require={
+        'gevent':  ["gevent"],
+        'eventlet': ["eventlet"],
+        'tornado': ["tornado"],
+    },
 )


### PR DESCRIPTION
Fixes #1717

- [x] Add [`extras_require`](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies) to `setup.py`
- [x] Update documentation