### PR TITLE
Add python_requires to help pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
     license='MIT',
     url='http://gunicorn.org',
 
+    python_requires='>=2.6, !=3.0.*, !=3.1.*',
     classifiers=CLASSIFIERS,
     zip_safe=False,
     packages=find_packages(exclude=['examples', 'tests']),


### PR DESCRIPTION
This helps pip install the correct version of Gunicorn depending on the user's version of Python.

For more info, see: https://hackernoon.com/phasing-out-python-runtimes-gracefully-956f112f33c4

This will be a useful first step before https://github.com/benoitc/gunicorn/issues/1195 and https://github.com/benoitc/gunicorn/pull/1288.
