### PR TITLE
Add PyPI badges to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ License
 Gunicorn is released under the MIT License. See the LICENSE_ file for more
 details.
 
-.. _Unicorn: http://unicorn.bogomips.org/
-.. _`#gunicorn`: http://webchat.freenode.net/?channels=gunicorn
-.. _Freenode: http://freenode.net
-.. _LICENSE: http://github.com/benoitc/gunicorn/blob/master/LICENSE
+.. _Unicorn: https://bogomips.org/unicorn/
+.. _`#gunicorn`: https://webchat.freenode.net/?channels=gunicorn
+.. _Freenode: https://freenode.net/
+.. _LICENSE: https://github.com/benoitc/gunicorn/blob/master/LICENSE

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,7 @@
 Gunicorn
 --------
 
-.. image::
-    https://secure.travis-ci.org/benoitc/gunicorn.png?branch=master
+.. image:: https://travis-ci.org/benoitc/gunicorn.svg?branch=master
     :alt: Build Status
     :target: https://travis-ci.org/benoitc/gunicorn
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,14 @@
 Gunicorn
 --------
 
+.. image:: https://img.shields.io/pypi/v/gunicorn.svg?style=flat
+    :alt: PyPI version
+    :target: https://pypi.python.org/pypi/gunicorn
+
+.. image:: https://img.shields.io/pypi/pyversions/gunicorn.svg
+    :alt: Supported Python versions
+    :target: https://pypi.python.org/pypi/gunicorn
+
 .. image:: https://travis-ci.org/benoitc/gunicorn.svg?branch=master
     :alt: Build Status
     :target: https://travis-ci.org/benoitc/gunicorn


### PR DESCRIPTION
As suggested in https://github.com/benoitc/gunicorn/issues/1634:

> Pypi seems to be still at 19.7.1 https://pypi.python.org/pypi/gunicorn
As a side thought could the README.md be made to have stable version number?
going trough pypi to check what is the current release feels bit funky, or perhaps I'm missing some obvious version number displayed somewhere 😕

Preview:

![image](https://user-images.githubusercontent.com/1324225/37586005-b46d31e8-2b63-11e8-8511-3aa0bee04e79.png)

Also upgrade the Travis badge to SVG which looks better, and whilst we're here, update HTTP links to HTTPS.