### PR TITLE
Optimize the reopen_files by using FileHandler's method: close & _open

### DIFF
--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -377,9 +377,8 @@ class Logger(object):
                     handler.acquire()
                     try:
                         if handler.stream:
-                            handler.stream.close()
-                            handler.stream = open(handler.baseFilename,
-                                    handler.mode)
+                            handler.close()
+                            handler.stream = handler._open()
                     finally:
                         handler.release()
 


### PR DESCRIPTION
Fix #1739 

Reopen log files by using FileHandler's method,  so that gunicorn can be compatible with different handler.

I tested this change on my handler, gunicorn reopen files as expected. Also tested by tox, and succeeded in py26, py27, py35 on my server .