### PR TITLE
added on_reload_spawn hook

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -480,6 +480,9 @@ class Arbiter(object):
         for _ in range(self.cfg.workers):
             self.spawn_worker()
 
+        # call post_reload_spawn hook
+        self.cfg.post_reload_spawn(self)
+
         # manage workers
         self.manage_workers()
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1568,8 +1568,8 @@ class OnReload(Setting):
         The callable needs to accept a single instance variable for the Arbiter.
         """
 
-class OnReloadSpawn(Setting):
-    name = "on_reload_spawn"
+class PostReloadSpawn(Setting):
+    name = "post_reload_spawn"
     section = "Server Hooks"
     validator = validate_callable(1)
     type = six.callable

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1568,6 +1568,20 @@ class OnReload(Setting):
         The callable needs to accept a single instance variable for the Arbiter.
         """
 
+class OnReloadSpawn(Setting):
+    name = "on_reload_spawn"
+    section = "Server Hooks"
+    validator = validate_callable(1)
+    type = six.callable
+
+    def post_reload_spawn(server):
+        pass
+    default = staticmethod(post_reload_spawn)
+    desc = """\
+        Called after spawn_worker() and before manage_workers() during a reload via SIGHUP.
+
+        The callable needs to accept a single instance variable for the Arbiter.
+        """
 
 class WhenReady(Setting):
     name = "when_ready"


### PR DESCRIPTION
We have a pretty "fat" app which takes a lot of time to load.
Simple reload via SIGHUP is not enough, because gunicorn kills old workers before new ones loads up completely.
We have added workaround by adding hook call after spawn_worker() and before manage_workers() in reload().

Simple example:
```
def post_reload_spawn(server):
    server.log.info("Forked workers. Waiting 30 seconds...")
    time.sleep(30);
    pass
```
If we are inventing something that already exists, please direct us in the right way.
Thx.
