### PR TITLE
Fix for #1755: Decode remote addr if it is a byte

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -158,7 +158,7 @@ def create(req, sock, client, server, cfg):
     if isinstance(client, string_types):
         environ['REMOTE_ADDR'] = client
     elif isinstance(client, binary_type):
-        environ['REMOTE_ADDR'] = str(client)
+        environ['REMOTE_ADDR'] = client.decode()
     else:
         environ['REMOTE_ADDR'] = client[0]
         environ['REMOTE_PORT'] = str(client[1])


### PR DESCRIPTION
After some debugging in issue #1755, I found that when using 

* Python 3.5 (<= 3.5.3)
* Python 3.6 (<= 3.6.2)

pythons built-in socket.getsockname returns ``b''`` as the socket name for unix sockets (see [Python Issue 30205](https://bugs.python.org/issue30205)).

This is problematic with gunicorn, as the ``REMOTE_ADDR`` is set to ``"b''``, which is caused by the following lines of code:
https://github.com/benoitc/gunicorn/blob/73cc860ead2e926e4d11bcf0cde0037dec8805ef/gunicorn/http/wsgi.py#L154-L164

Specifically this line: ``environ['REMOTE_ADDR'] = str(client)``

To overcome this issue, I propose using ``client.decode()`` instead of ``str(client)``:

```python
b''.decode()
# returns an empty string
str(b'')
# returns a string containing the three characters b''
```

This fixes issue #1755 for me.