### PR TITLE
Labeled the name of the file in the sample

### DIFF
--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -17,7 +17,7 @@ An `example configuration`_ file for fast clients with Nginx_:
 
 .. literalinclude:: ../../examples/nginx.conf
    :language: nginx
-   :caption: nginx.conf
+   :caption: **nginx.conf**
 
 If you want to be able to handle streaming request/responses or other fancy
 features like Comet, Long polling, or Web sockets, you need to turn off the

--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -15,6 +15,9 @@ You can use Hey_ to check if your proxy is behaving properly.
 
 An `example configuration`_ file for fast clients with Nginx_:
 
+*nginx.conf*
+
+
 .. literalinclude:: ../../examples/nginx.conf
    :language: nginx
 

--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -15,11 +15,9 @@ You can use Hey_ to check if your proxy is behaving properly.
 
 An `example configuration`_ file for fast clients with Nginx_:
 
-*nginx.conf*
-
-
 .. literalinclude:: ../../examples/nginx.conf
    :language: nginx
+   :caption: nginx.conf
 
 If you want to be able to handle streaming request/responses or other fancy
 features like Comet, Long polling, or Web sockets, you need to turn off the


### PR DESCRIPTION
The sample as-is was not clear about what file the configuration was to go in. 
This sample is to go into nginx.conf, but nginx as of 20180516 has nginx.conf + conf.f/default.conf
This sample overrides all that into the single file so being specific is better.