### PR TITLE
Enable pycodestyle

### DIFF
--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -142,7 +142,7 @@ class Application(BaseApplication):
                 continue
             try:
                 self.cfg.set(k.lower(), v)
-            except:
+            except Exception:
                 print("Invalid value for %s: %s\n" % (k, v), file=sys.stderr)
                 sys.stderr.flush()
                 raise
@@ -203,7 +203,7 @@ class Application(BaseApplication):
         if self.cfg.check_config:
             try:
                 self.load()
-            except:
+            except Exception:
                 msg = "\nError while loading the application:\n"
                 print(msg, file=sys.stderr)
                 traceback.print_exc()

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -590,7 +590,7 @@ class Arbiter(object):
             print("%s" % e, file=sys.stderr)
             sys.stderr.flush()
             sys.exit(self.APP_LOAD_ERROR)
-        except:
+        except Exception:
             self.log.exception("Exception in worker process")
             if not worker.booted:
                 sys.exit(self.WORKER_BOOT_ERROR)
@@ -600,9 +600,9 @@ class Arbiter(object):
             try:
                 worker.tmp.close()
                 self.cfg.worker_exit(self, worker)
-            except:
+            except Exception:
                 self.log.warning("Exception during worker exit:\n%s",
-                                  traceback.format_exc())
+                                 traceback.format_exc())
 
     def spawn_workers(self):
         """\

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -78,9 +78,9 @@ class Config(object):
         }
         parser = argparse.ArgumentParser(**kwargs)
         parser.add_argument("-v", "--version",
-                action="version", default=argparse.SUPPRESS,
-                version="%(prog)s (version " + __version__ + ")\n",
-                help="show program's version number and exit")
+                            action="version", default=argparse.SUPPRESS,
+                            version="%(prog)s (version " + __version__ + ")\n",
+                            help="show program's version number and exit")
         parser.add_argument("args", nargs="*", help=argparse.SUPPRESS)
 
         keys = sorted(self.settings, key=self.settings.__getitem__)
@@ -93,7 +93,7 @@ class Config(object):
     def worker_class_str(self):
         uri = self.settings['worker_class'].get()
 
-        ## are we using a threaded worker?
+        # are we using a threaded worker?
         is_sync = uri.endswith('SyncWorker') or uri == 'sync'
         if is_sync and self.threads > 1:
             return "threads"
@@ -103,7 +103,7 @@ class Config(object):
     def worker_class(self):
         uri = self.settings['worker_class'].get()
 
-        ## are we using a threaded worker?
+        # are we using a threaded worker?
         is_sync = uri.endswith('SyncWorker') or uri == 'sync'
         if is_sync and self.threads > 1:
             uri = "gunicorn.workers.gthread.ThreadWorker"
@@ -524,7 +524,7 @@ def validate_reload_engine(val):
 
 def get_default_config_file():
     config_path = os.path.join(os.path.abspath(os.getcwd()),
-            'gunicorn.conf.py')
+                               'gunicorn.conf.py')
     if os.path.exists(config_path):
         return config_path
     return None
@@ -549,6 +549,7 @@ class ConfigFile(Setting):
            Loading the config from a Python module requires the ``python:``
            prefix.
         """
+
 
 class Bind(Setting):
     name = "bind"
@@ -653,6 +654,7 @@ class WorkerClass(Setting):
         This alternative syntax will load the gevent class:
         ``gunicorn.workers.ggevent.GeventWorker``.
         """
+
 
 class WorkerThreads(Setting):
     name = "threads"
@@ -1025,6 +1027,7 @@ class Daemon(Setting):
         background.
         """
 
+
 class Env(Setting):
     name = "raw_env"
     action = "append"
@@ -1057,6 +1060,7 @@ class Pidfile(Setting):
 
         If not set, no PID file will be written.
         """
+
 
 class WorkerTmpDir(Setting):
     name = "worker_tmp_dir"
@@ -1110,6 +1114,7 @@ class Group(Setting):
         retrieved with a call to ``pwd.getgrnam(value)`` or ``None`` to not
         change the worker processes group.
         """
+
 
 class Umask(Setting):
     name = "umask"
@@ -1223,6 +1228,7 @@ class AccessLog(Setting):
 
         ``'-'`` means log to stdout.
         """
+
 
 class DisableRedirectAccessToSyslog(Setting):
     name = "disable_redirect_access_to_syslog"
@@ -1676,6 +1682,7 @@ class PostWorkerInit(Setting):
         Worker.
         """
 
+
 class WorkerInt(Setting):
     name = "worker_int"
     section = "Server Hooks"
@@ -1819,6 +1826,7 @@ class NumWorkersChanged(Setting):
         be ``None``.
         """
 
+
 class OnExit(Setting):
     name = "on_exit"
     section = "Server Hooks"
@@ -1899,6 +1907,7 @@ class CertFile(Setting):
     SSL certificate file
     """
 
+
 class SSLVersion(Setting):
     name = "ssl_version"
     section = "SSL"
@@ -1945,6 +1954,7 @@ class SSLVersion(Setting):
        constants.
     """
 
+
 class CertReqs(Setting):
     name = "cert_reqs"
     section = "SSL"
@@ -1954,6 +1964,7 @@ class CertReqs(Setting):
     desc = """\
     Whether client certificate is required (see stdlib ssl module's)
     """
+
 
 class CACerts(Setting):
     name = "ca_certs"
@@ -1966,6 +1977,7 @@ class CACerts(Setting):
     CA certificates file
     """
 
+
 class SuppressRaggedEOFs(Setting):
     name = "suppress_ragged_eofs"
     section = "SSL"
@@ -1976,6 +1988,7 @@ class SuppressRaggedEOFs(Setting):
     desc = """\
     Suppress ragged EOFs (see stdlib ssl module's)
     """
+
 
 class DoHandshakeOnConnect(Setting):
     name = "do_handshake_on_connect"

--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -7,7 +7,7 @@ import base64
 import binascii
 import time
 import logging
-logging.Logger.manager.emittedNoHandlerWarning = 1
+logging.Logger.manager.emittedNoHandlerWarning = 1  # noqa
 from logging.config import dictConfig
 from logging.config import fileConfig
 import os
@@ -21,28 +21,28 @@ from gunicorn import util
 
 # syslog facility codes
 SYSLOG_FACILITIES = {
-        "auth":     4,
-        "authpriv": 10,
-        "cron":     9,
-        "daemon":   3,
-        "ftp":      11,
-        "kern":     0,
-        "lpr":      6,
-        "mail":     2,
-        "news":     7,
-        "security": 4,  #  DEPRECATED
-        "syslog":   5,
-        "user":     1,
-        "uucp":     8,
-        "local0":   16,
-        "local1":   17,
-        "local2":   18,
-        "local3":   19,
-        "local4":   20,
-        "local5":   21,
-        "local6":   22,
-        "local7":   23
-        }
+    "auth": 4,
+    "authpriv": 10,
+    "cron": 9,
+    "daemon": 3,
+    "ftp": 11,
+    "kern": 0,
+    "lpr": 6,
+    "mail": 2,
+    "news": 7,
+    "security": 4,  # DEPRECATED
+    "syslog": 5,
+    "user": 1,
+    "uucp": 8,
+    "local0": 16,
+    "local1": 17,
+    "local2": 18,
+    "local3": 19,
+    "local4": 20,
+    "local5": 21,
+    "local6": 22,
+    "local7": 23
+}
 
 
 CONFIG_DEFAULTS = dict(
@@ -213,8 +213,10 @@ class Logger(object):
 
         # set gunicorn.access handler
         if cfg.accesslog is not None:
-            self._set_handler(self.access_log, cfg.accesslog,
-                fmt=logging.Formatter(self.access_fmt), stream=sys.stdout)
+            self._set_handler(
+                self.access_log, cfg.accesslog,
+                fmt=logging.Formatter(self.access_fmt), stream=sys.stdout
+            )
 
         # set syslog handler
         if cfg.syslog:
@@ -284,7 +286,8 @@ class Logger(object):
             'u': self._get_user(environ) or '-',
             't': self.now(),
             'r': "%s %s %s" % (environ['REQUEST_METHOD'],
-                environ['RAW_URI'], environ["SERVER_PROTOCOL"]),
+                               environ['RAW_URI'],
+                               environ["SERVER_PROTOCOL"]),
             's': status,
             'm': environ.get('REQUEST_METHOD'),
             'U': environ.get('PATH_INFO'),
@@ -295,7 +298,7 @@ class Logger(object):
             'f': environ.get('HTTP_REFERER', '-'),
             'a': environ.get('HTTP_USER_AGENT', '-'),
             'T': request_time.seconds,
-            'D': (request_time.seconds*1000000) + request_time.microseconds,
+            'D': (request_time.seconds * 1000000) + request_time.microseconds,
             'L': "%d.%06d" % (request_time.seconds, request_time.microseconds),
             'p': "<%s>" % os.getpid()
         }
@@ -337,12 +340,13 @@ class Logger(object):
         # wrap atoms:
         # - make sure atoms will be test case insensitively
         # - if atom doesn't exist replace it by '-'
-        safe_atoms = self.atoms_wrapper_class(self.atoms(resp, req, environ,
-            request_time))
+        safe_atoms = self.atoms_wrapper_class(
+            self.atoms(resp, req, environ, request_time)
+        )
 
         try:
             self.access_log.info(self.cfg.access_log_format, safe_atoms)
-        except:
+        except Exception:
             self.error(traceback.format_exc())
 
     def now(self):
@@ -360,7 +364,6 @@ class Logger(object):
                 self.logfile = open(self.cfg.errorlog, 'a+')
                 os.dup2(self.logfile.fileno(), sys.stdout.fileno())
                 os.dup2(self.logfile.fileno(), sys.stderr.fileno())
-
 
         for log in loggers():
             for handler in log.handlers:

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -10,9 +10,11 @@ from errno import ENOTCONN
 
 from gunicorn.http.unreader import SocketUnreader
 from gunicorn.http.body import ChunkedReader, LengthReader, EOFReader, Body
-from gunicorn.http.errors import (InvalidHeader, InvalidHeaderName, NoMoreData,
+from gunicorn.http.errors import (
+    InvalidHeader, InvalidHeaderName, NoMoreData,
     InvalidRequestLine, InvalidRequestMethod, InvalidHTTPVersion,
-    LimitRequestLine, LimitRequestHeaders)
+    LimitRequestLine, LimitRequestHeaders,
+)
 from gunicorn.http.errors import InvalidProxyLine, ForbiddenProxyRequest
 from gunicorn.http.errors import InvalidSchemeHeaders
 from gunicorn.util import bytes_to_str, split_request_uri
@@ -105,7 +107,7 @@ class Message(object):
                 header_length += len(curr)
                 if header_length > self.limit_request_field_size > 0:
                     raise LimitRequestHeaders("limit request headers "
-                            + "fields size")
+                                              "fields size")
                 value.append(curr)
             value = ''.join(value).rstrip()
 

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -303,7 +303,7 @@ class Response(object):
 
         headers = [
             "HTTP/%s.%s %s\r\n" % (self.req.version[0],
-                self.req.version[1], self.status),
+                                   self.req.version[1], self.status),
             "Server: %s\r\n" % self.version,
             "Date: %s\r\n" % util.http_date(),
             "Connection: %s\r\n" % connection

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -19,6 +19,7 @@ GAUGE_TYPE = "gauge"
 COUNTER_TYPE = "counter"
 HISTOGRAM_TYPE = "histogram"
 
+
 class Statsd(Logger):
     """statsD-based instrumentation, that passes as a logger
     """

--- a/gunicorn/pidfile.py
+++ b/gunicorn/pidfile.py
@@ -57,7 +57,7 @@ class Pidfile(object):
 
             if pid1 == self.pid:
                 os.unlink(self.fname)
-        except:
+        except Exception:
             pass
 
     def validate(self):

--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -53,6 +53,7 @@ class Reloader(threading.Thread):
                         self._callback(filename)
             time.sleep(self._interval)
 
+
 has_inotify = False
 if sys.platform.startswith('linux'):
     try:

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -56,7 +56,7 @@ except ImportError:
 
 
 def load_class(uri, default="gunicorn.workers.sync.SyncWorker",
-        section="gunicorn.workers"):
+               section="gunicorn.workers"):
     if inspect.isclass(uri):
         return uri
     if uri.startswith("egg:"):
@@ -70,7 +70,7 @@ def load_class(uri, default="gunicorn.workers.sync.SyncWorker",
 
         try:
             return pkg_resources.load_entry_point(dist, section, name)
-        except:
+        except Exception:
             exc = traceback.format_exc()
             msg = "class uri %r invalid or not found: \n\n[%s]"
             raise RuntimeError(msg % (uri, exc))
@@ -86,9 +86,10 @@ def load_class(uri, default="gunicorn.workers.sync.SyncWorker",
                     break
 
                 try:
-                    return pkg_resources.load_entry_point("gunicorn",
-                                section, uri)
-                except:
+                    return pkg_resources.load_entry_point(
+                        "gunicorn", section, uri
+                    )
+                except Exception:
                     exc = traceback.format_exc()
                     msg = "class uri %r invalid or not found: \n\n[%s]"
                     raise RuntimeError(msg % (uri, exc))
@@ -259,6 +260,7 @@ def close(sock):
         sock.close()
     except socket.error:
         pass
+
 
 try:
     from os import closerange
@@ -439,7 +441,7 @@ def getcwd():
             cwd = os.environ['PWD']
         else:
             cwd = os.getcwd()
-    except:
+    except Exception:
         cwd = os.getcwd()
     return cwd
 

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -28,8 +28,9 @@ from gunicorn.workers.workertmp import WorkerTmp
 
 class Worker(object):
 
-    SIGNALS = [getattr(signal, "SIG%s" % x)
-            for x in "ABRT HUP QUIT INT TERM USR1 USR2 WINCH CHLD".split()]
+    SIGNALS = [getattr(signal, "SIG%s" % x) for x in (
+        "ABRT HUP QUIT INT TERM USR1 USR2 WINCH CHLD".split()
+    )]
 
     PIPE = []
 
@@ -203,12 +204,14 @@ class Worker(object):
     def handle_error(self, req, client, addr, exc):
         request_start = datetime.now()
         addr = addr or ('', -1)  # unix socket case
-        if isinstance(exc, (InvalidRequestLine, InvalidRequestMethod,
-                InvalidHTTPVersion, InvalidHeader, InvalidHeaderName,
-                LimitRequestLine, LimitRequestHeaders,
-                InvalidProxyLine, ForbiddenProxyRequest,
-                InvalidSchemeHeaders,
-                SSLError)):
+        if isinstance(exc, (
+            InvalidRequestLine, InvalidRequestMethod,
+            InvalidHTTPVersion, InvalidHeader, InvalidHeaderName,
+            LimitRequestLine, LimitRequestHeaders,
+            InvalidProxyLine, ForbiddenProxyRequest,
+            InvalidSchemeHeaders,
+            SSLError,
+        )):
 
             status_int = 400
             reason = "Bad Request"
@@ -261,7 +264,7 @@ class Worker(object):
 
         try:
             util.write_error(client, status_int, reason, mesg)
-        except:
+        except Exception:
             self.log.debug("Failed to send error message.")
 
     def handle_winch(self, sig, fname):

--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -92,7 +92,7 @@ class AsyncWorker(base.Worker):
         try:
             self.cfg.pre_request(self, req)
             resp, environ = wsgi.create(req, sock, addr,
-                    listener_name, self.cfg)
+                                        listener_name, self.cfg)
             environ["wsgi.multithread"] = True
             self.nr += 1
             if self.alive and self.nr >= self.max_requests:

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -40,6 +40,7 @@ def _gevent_sendfile(fdout, fdin, offset, nbytes, _os_sendfile=os.sendfile):
             else:
                 raise
 
+
 def patch_sendfile():
     setattr(os, "sendfile", _gevent_sendfile)
 
@@ -129,7 +130,7 @@ class GeventWorker(AsyncWorker):
             self.log.warning("Worker graceful timeout (pid:%s)" % self.pid)
             for server in servers:
                 server.stop(timeout=1)
-        except:
+        except Exception:
             pass
 
     def handle(self, listener, client, addr):

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -50,7 +50,7 @@ class TConn(object):
             # wrap the socket if needed
             if self.cfg.is_ssl:
                 self.sock = ssl.wrap_socket(self.sock, server_side=True,
-                        **self.cfg.ssl_options)
+                                            **self.cfg.ssl_options)
 
             # initialize the parser
             self.parser = http.RequestParser(self.cfg, self.sock)
@@ -83,7 +83,7 @@ class ThreadWorker(base.Worker):
 
         if max_keepalived <= 0 and cfg.keepalive:
             log.warning("No keepalived connections can be handled. " +
-                    "Check the number of worker connections and threads.")
+                        "Check the number of worker connections and threads.")
 
     def init_process(self):
         self.tpool = self.get_thread_pool()
@@ -123,8 +123,8 @@ class ThreadWorker(base.Worker):
             # enqueue the job
             self.enqueue_req(conn)
         except EnvironmentError as e:
-            if e.errno not in (errno.EAGAIN,
-                    errno.ECONNABORTED, errno.EWOULDBLOCK):
+            if e.errno not in (errno.EAGAIN, errno.ECONNABORTED,
+                               errno.EWOULDBLOCK):
                 raise
 
     def reuse_connection(self, conn, client):
@@ -204,11 +204,11 @@ class ThreadWorker(base.Worker):
 
                 # check (but do not wait) for finished requests
                 result = futures.wait(self.futures, timeout=0,
-                        return_when=futures.FIRST_COMPLETED)
+                                      return_when=futures.FIRST_COMPLETED)
             else:
                 # wait for a request to finish
                 result = futures.wait(self.futures, timeout=1.0,
-                        return_when=futures.FIRST_COMPLETED)
+                                      return_when=futures.FIRST_COMPLETED)
 
             # clean up finished requests
             for fut in result.done:
@@ -249,11 +249,11 @@ class ThreadWorker(base.Worker):
 
                     # add the socket to the event loop
                     self.poller.register(conn.sock, selectors.EVENT_READ,
-                            partial(self.reuse_connection, conn))
+                                         partial(self.reuse_connection, conn))
             else:
                 self.nr_conns -= 1
                 conn.close()
-        except:
+        except Exception:
             # an exception happened, make sure to close the
             # socket.
             self.nr_conns -= 1
@@ -304,7 +304,7 @@ class ThreadWorker(base.Worker):
             self.cfg.pre_request(self, req)
             request_start = datetime.now()
             resp, environ = wsgi.create(req, conn.sock, conn.client,
-                    conn.server, self.cfg)
+                                        conn.server, self.cfg)
             environ["wsgi.multithread"] = True
             self.nr += 1
             if self.alive and self.nr >= self.max_requests:

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -17,8 +17,10 @@ import gunicorn.http.wsgi as wsgi
 import gunicorn.util as util
 import gunicorn.workers.base as base
 
+
 class StopWaiting(Exception):
     """ exception raised to stop waiting for a connection """
+
 
 class SyncWorker(base.Worker):
 
@@ -72,7 +74,7 @@ class SyncWorker(base.Worker):
 
             except EnvironmentError as e:
                 if e.errno not in (errno.EAGAIN, errno.ECONNABORTED,
-                        errno.EWOULDBLOCK):
+                                   errno.EWOULDBLOCK):
                     raise
 
             if not self.is_parent_alive():
@@ -101,7 +103,7 @@ class SyncWorker(base.Worker):
                         self.accept(listener)
                     except EnvironmentError as e:
                         if e.errno not in (errno.EAGAIN, errno.ECONNABORTED,
-                                errno.EWOULDBLOCK):
+                                           errno.EWOULDBLOCK):
                             raise
 
             if not self.is_parent_alive():
@@ -127,7 +129,7 @@ class SyncWorker(base.Worker):
         try:
             if self.cfg.is_ssl:
                 client = ssl.wrap_socket(client, server_side=True,
-                    **self.cfg.ssl_options)
+                                         **self.cfg.ssl_options)
 
             parser = http.RequestParser(self.cfg, client)
             req = next(parser)
@@ -163,7 +165,7 @@ class SyncWorker(base.Worker):
             self.cfg.pre_request(self, req)
             request_start = datetime.now()
             resp, environ = wsgi.create(req, client, addr,
-                    listener.getsockname(), self.cfg)
+                                        listener.getsockname(), self.cfg)
             # Force the connection closed until someone shows
             # a buffering proxy that supports Keep-Alive to
             # the backend.

--- a/gunicorn/workers/workertmp.py
+++ b/gunicorn/workers/workertmp.py
@@ -35,7 +35,7 @@ class WorkerTmp(object):
             # In Python 3.8, open() emits RuntimeWarning if buffering=1 for binary mode.
             # Because we never write to this file, pass 0 to switch buffering off.
             self._tmp = os.fdopen(fd, 'w+b', 0)
-        except:
+        except Exception:
             os.close(fd)
             raise
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,3 +38,14 @@ deps =
 commands =
   rst-lint README.rst docs/README.rst
   bash -c "(set -o pipefail; rst-lint --encoding utf-8 docs/source/*.rst | grep -v 'Unknown interpreted text role\|Unknown directive type'); test $? == 1"
+
+[testenv:pycodestyle]
+commands =
+  pycodestyle gunicorn \
+  --exclude=gunicorn/six.py
+deps =
+  pycodestyle
+
+[pycodestyle]
+max-line-length = 120
+ignore = E129,W503,W504,W606


### PR DESCRIPTION
Adds pycodestyle (latest version; 2.4.0 at this moment) in CI now, while prospector was deprecated by solo pylint (#1678).

## additional ignore errors/warnings

In general, this PR follows the default rules of pycodestyle 2.4.0. The following errors/warnings, however, are ignored at this moment to avoid the delay of merging with unintentional discussion as this PR would be just the first step:

- E129
- W503
- W504
- W606

Replaces #1600