### PR TITLE
Ensured that default logging streams are prefixed with ext:// so they work correctly

### DIFF
--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -74,12 +74,12 @@ CONFIG_DEFAULTS = dict(
             "console": {
                 "class": "logging.StreamHandler",
                 "formatter": "generic",
-                "stream": "sys.stdout"
+                "stream": "ext://sys.stdout"
             },
             "error_console": {
                 "class": "logging.StreamHandler",
                 "formatter": "generic",
-                "stream": "sys.stderr"
+                "stream": "ext://sys.stderr"
             },
         },
         formatters={


### PR DESCRIPTION
Hey there friends, this fix relates to issue #1793 

Thanks heaps
Fotis