### PR TITLE
Added support to bind to open file descriptors.

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -59,6 +59,7 @@ Eric Florenzano <floguy@gmail.com>
 Eric Shull <eric@elevenbasetwo.com>
 Eugene Obukhov <irvind25@gmail.com>
 Evan Mezeske <evan@meebo-inc.com>
+Florian Apolloner <florian@apolloner.eu>
 Gaurav Kumar <gauravkumar37@gmail.com>
 George Kollias <georgioskollias@gmail.com>
 George Notaras <gnot@g-loaded.eu>

--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-20.0 XXXXXXXXXXXXXX
+20.0 / not released
 ===================
 
 - fix: Added support for binding to file descriptors (:issue:`1107`, :pr:`1809`)

--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+20.0 XXXXXXXXXXXXXX
+===================
+
+- fix: Added support for binding to file descriptors (:issue:`1107`, :pr:`1809`)
+
 19.9.0 / 2018/07/03
 ===================
 

--- a/docs/source/run.rst
+++ b/docs/source/run.rst
@@ -52,8 +52,8 @@ Commonly Used Arguments
 * ``-c CONFIG, --config=CONFIG`` - Specify a config file in the form
   ``$(PATH)``, ``file:$(PATH)``, or ``python:$(MODULE_NAME)``.
 * ``-b BIND, --bind=BIND`` - Specify a server socket to bind. Server sockets
-  can be any of ``$(HOST)``, ``$(HOST):$(PORT)``, or ``unix:$(PATH)``.
-  An IP is a valid ``$(HOST)``.
+  can be any of ``$(HOST)``, ``$(HOST):$(PORT)``, ``fd://$(FD)``, or
+  ``unix:$(PATH)``. An IP is a valid ``$(HOST)``.
 * ``-w WORKERS, --workers=WORKERS`` - The number of worker processes. This
   number should generally be between 2-4 workers per core in the server.
   Check the :ref:`faq` for ideas on tuning this parameter.

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -1103,8 +1103,11 @@ bind
 
 The socket to bind.
 
-A string of the form: ``HOST``, ``HOST:PORT``, ``unix:PATH``. An IP is
-a valid ``HOST``.
+A string of the form: ``HOST``, ``HOST:PORT``, ``unix:PATH``,
+``fd://FD``. An IP is a valid ``HOST``.
+
+.. versionchanged:: 20.0
+   Support for ``fd://FD`` got added.
 
 Multiple addresses can be bound. ex.::
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -535,8 +535,11 @@ class Bind(Setting):
     desc = """\
         The socket to bind.
 
-        A string of the form: ``HOST``, ``HOST:PORT``, ``unix:PATH``. An IP is
-        a valid ``HOST``.
+        A string of the form: ``HOST``, ``HOST:PORT``, ``unix:PATH``,
+        ``fd://FD``. An IP is a valid ``HOST``.
+
+        .. versionchanged:: 20.0
+           Support for ``fd://FD`` got added.
 
         Multiple addresses can be bound. ex.::
 

--- a/gunicorn/socketfromfd.py
+++ b/gunicorn/socketfromfd.py
@@ -1,0 +1,96 @@
+# Copyright (C) 2016  Christian Heimes
+"""socketfromfd -- socket.fromd() with auto-discovery
+
+ATTENTION: Do not remove this backport till the minimum required version is
+           Python 3.7. See https://bugs.python.org/issue28134 for details.
+"""
+from __future__ import print_function
+
+import ctypes
+import os
+import socket
+import sys
+from ctypes.util import find_library
+
+__all__ = ('fromfd',)
+
+SO_DOMAIN = getattr(socket, 'SO_DOMAIN', 39)
+SO_TYPE = getattr(socket, 'SO_TYPE', 3)
+SO_PROTOCOL = getattr(socket, 'SO_PROTOCOL', 38)
+
+
+_libc_name = find_library('c')
+if _libc_name is not None:
+    libc = ctypes.CDLL(_libc_name, use_errno=True)
+else:
+    raise OSError('libc not found')
+
+
+def _errcheck_errno(result, func, arguments):
+    """Raise OSError by errno for -1
+    """
+    if result == -1:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno))
+    return arguments
+
+
+_libc_getsockopt = libc.getsockopt
+_libc_getsockopt.argtypes = [
+    ctypes.c_int,  # int sockfd
+    ctypes.c_int,  # int level
+    ctypes.c_int,  # int optname
+    ctypes.c_void_p,  # void *optval
+    ctypes.POINTER(ctypes.c_uint32)  # socklen_t *optlen
+]
+_libc_getsockopt.restype = ctypes.c_int  # 0: ok, -1: err
+_libc_getsockopt.errcheck = _errcheck_errno
+
+
+def _raw_getsockopt(fd, level, optname):
+    """Make raw getsockopt() call for int32 optval
+
+    :param fd: socket fd
+    :param level: SOL_*
+    :param optname: SO_*
+    :return: value as int
+    """
+    optval = ctypes.c_int(0)
+    optlen = ctypes.c_uint32(4)
+    _libc_getsockopt(fd, level, optname,
+                     ctypes.byref(optval), ctypes.byref(optlen))
+    return optval.value
+
+
+def fromfd(fd, keep_fd=True):
+    """Create a socket from a file descriptor
+
+    socket domain (family), type and protocol are auto-detected. By default
+    the socket uses a dup()ed fd. The original fd can be closed.
+
+    The parameter `keep_fd` influences fd duplication. Under Python 2 the
+    fd is still duplicated but the input fd is closed. Under Python 3 and
+    with `keep_fd=True`, the new socket object uses the same fd.
+
+    :param fd: socket fd
+    :type fd: int
+    :param keep_fd: keep input fd
+    :type keep_fd: bool
+    :return: socket.socket instance
+    :raises OSError: for invalid socket fd
+    """
+    family = _raw_getsockopt(fd, socket.SOL_SOCKET, SO_DOMAIN)
+    typ = _raw_getsockopt(fd, socket.SOL_SOCKET, SO_TYPE)
+    proto = _raw_getsockopt(fd, socket.SOL_SOCKET, SO_PROTOCOL)
+    if sys.version_info.major == 2:
+        # Python 2 has no fileno argument and always duplicates the fd
+        sockobj = socket.fromfd(fd, family, typ, proto)
+        sock = socket.socket(None, None, None, _sock=sockobj)
+        if not keep_fd:
+            os.close(fd)
+        return sock
+    else:
+        if keep_fd:
+            return socket.fromfd(fd, family, typ, proto)
+        else:
+            return socket.socket(family, typ, proto, fileno=fd)

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -251,6 +251,13 @@ def parse_address(netloc, default_port=8000):
     if re.match(r'unix:(//)?', netloc):
         return re.split(r'unix:(//)?', netloc)[-1]
 
+    if netloc.startswith("fd://"):
+        fd = netloc[5:]
+        try:
+            return int(fd)
+        except ValueError:
+            raise RuntimeError("%r is not a valid file descriptor." % fd) from None
+
     if netloc.startswith("tcp://"):
         netloc = netloc.split("tcp://")[1]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -386,3 +386,9 @@ def test_umask_config(options, expected):
     with AltArgs(cmdline):
         app = NoConfigApp()
     assert app.cfg.umask == expected
+
+
+def test_bind_fd():
+    with AltArgs(["prog_name", "-b", "fd://42"]):
+        app = NoConfigApp()
+    assert app.cfg.bind == ["fd://42"]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -17,7 +17,8 @@ from urllib.parse import SplitResult
     ('[::1]:8000', ('::1', 8000)),
     ('localhost:8000', ('localhost', 8000)),
     ('127.0.0.1:8000', ('127.0.0.1', 8000)),
-    ('localhost', ('localhost', 8000))
+    ('localhost', ('localhost', 8000)),
+    ('fd://33', 33),
 ])
 def test_parse_address(test_input, expected):
     assert util.parse_address(test_input) == expected
@@ -27,6 +28,12 @@ def test_parse_address_invalid():
     with pytest.raises(RuntimeError) as err:
         util.parse_address('127.0.0.1:test')
     assert "'test' is not a valid port number." in str(err)
+
+
+def test_parse_fd_invalid():
+    with pytest.raises(RuntimeError) as err:
+        util.parse_address('fd://asd')
+    assert "'asd' is not a valid file descriptor." in str(err)
 
 
 def test_http_date():


### PR DESCRIPTION
This is an initial try to fix #1107.

@benoitc Which kind of tests do you expect here? I couldn't find much in the testsuite; I'll add parsing tests for `fd://` but is there anything else I should add?

This commit currently vendors https://github.com/tiran/socketfromfd/blob/master/socketfromfd.py from @tiran -- Christian: Would you be okay with this approach (and relicensing under the gunicorn license) or would you like use to use the pypi package (I'd rather vendor given that gunicorn has no dependency).