### PR TITLE
Docs: serving WSGI app modules from Gunicorn

### DIFF
--- a/docs/source/custom.rst
+++ b/docs/source/custom.rst
@@ -14,3 +14,31 @@ a custom Application:
 
 .. literalinclude:: ../../examples/standalone_app.py
     :lines: 11-60
+
+Direct Usage of Existing WSGI Apps
+----------------------------------
+
+If necessary, you can run Gunicorn straight from python, allowing you to 
+specify a WSGI-compatible application at runtime. This might be useful for 
+rolling deploys or in the case of using PEX files to deploy your application,
+as the app and Gunicorn can be bundled in the same PEX file. At the time of
+writing, you can import and instantiate a WSGIApplication like so:
+
+.. code-block:: python
+    from gunicorn.app.wsgiapp import WSGIApplication
+    WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]").run()
+
+This can be used to run WSGI-compatible app instances such as those produced
+by Flask or Django. Assuming that the code above is in a file called `run.py`,
+your application's WSGI instance is called `app`, and it's exported by a package
+called `exampleapi`, then you should be able to fire up your server with a
+command similar to '``python run.py exampleapi:app``'. 
+
+This command will work with any Gunicorn CLI parameters or a config file - just
+pass them along as if you're directly giving them to Gunicorn as below
+
+.. code-block:: python
+    # Custom parameters
+    python run.py exampleapi:app --bind=0.0.0.0:8081 --workers=4
+    # Using a config file
+    python run.py exampleapi:app -c config.py

--- a/docs/source/custom.rst
+++ b/docs/source/custom.rst
@@ -18,34 +18,33 @@ a custom Application:
 Direct Usage of Existing WSGI Apps
 ----------------------------------
 
-If necessary, you can run Gunicorn straight from python, allowing you to 
-specify a WSGI-compatible application at runtime. This can be handy for 
+If necessary, you can run Gunicorn straight from Python, allowing you to
+specify a WSGI-compatible application at runtime. This can be handy for
 rolling deploys or in the case of using PEX files to deploy your application,
 as the app and Gunicorn can be bundled in the same PEX file. Gunicorn has
-this functionality built-in as a first class citizen known as 
-:class:`gunicorn.app.wsgiapp`. This can be used to run WSGI-compatible app 
-instances such as those produced by Flask or Django. Assuming your WSGI api 
-package is `exampleapi`, and your application instance is `app`, this is all 
-you need to get going:
+this functionality built-in as a first class citizen known as
+:class:`gunicorn.app.wsgiapp`. This can be used to run WSGI-compatible app
+instances such as those produced by Flask or Django. Assuming your WSGI API
+package is *exampleapi*, and your application instance is *app*, this is all
+you need to get going::
 
-.. code-block:: python
     gunicorn.app.wsgiapp exampleapi:app
 
 This command will work with any Gunicorn CLI parameters or a config file - just
-pass them along as if you're directly giving them to Gunicorn
+pass them along as if you're directly giving them to Gunicorn:
 
-.. code-block:: python
-    # Custom parameters
-    python gunicorn.app.wsgiapp exampleapi:app --bind=0.0.0.0:8081 --workers=4
-    # Using a config file
-    python gunicorn.app.wsgiapp exampleapi:app -c config.py
+.. code-block:: bash
+   # Custom parameters
+   $ python gunicorn.app.wsgiapp exampleapi:app --bind=0.0.0.0:8081 --workers=4
+   # Using a config file
+   $ python gunicorn.app.wsgiapp exampleapi:app -c config.py
     
-Note for those using PEX: use `-c gunicorn` as your entry at build
+Note for those using PEX: use ``-c gunicorn`` as your entry at build
 time, and your compiled app should work with the entry point passed to it at
 run time. 
 
 .. code-block:: bash
-    # Generic pex build command via bash from root of exampleapi project
-    pex . -v -c gunicorn -o compiledapp.pex
-    # Running it
-    ./compiledapp.pex exampleapi:app -c gunicorn_config.py
+   # Generic pex build command via bash from root of exampleapi project
+   $ pex . -v -c gunicorn -o compiledapp.pex
+   # Running it
+   ./compiledapp.pex exampleapi:app -c gunicorn_config.py

--- a/docs/source/custom.rst
+++ b/docs/source/custom.rst
@@ -40,12 +40,12 @@ pass them along as if you're directly giving them to Gunicorn
     # Using a config file
     python gunicorn.app.wsgiapp exampleapi:app -c config.py
     
-Note for those using PEX: use `-e gunicorn.app.wsgiapp` as your entry at build
+Note for those using PEX: use `-c gunicorn` as your entry at build
 time, and your compiled app should work with the entry point passed to it at
 run time. 
 
 .. code-block:: bash
     # Generic pex build command via bash from root of exampleapi project
-    pex . -v -e gunicorn.app.wsgiapp -o compiledapp.pex
+    pex . -v -c gunicorn -o compiledapp.pex
     # Running it
-    ./compiledapp.pex exampleapi:app -c config.py
+    ./compiledapp.pex exampleapi:app -c gunicorn_config.py

--- a/docs/source/custom.rst
+++ b/docs/source/custom.rst
@@ -19,26 +19,33 @@ Direct Usage of Existing WSGI Apps
 ----------------------------------
 
 If necessary, you can run Gunicorn straight from python, allowing you to 
-specify a WSGI-compatible application at runtime. This might be useful for 
+specify a WSGI-compatible application at runtime. This can be handy for 
 rolling deploys or in the case of using PEX files to deploy your application,
-as the app and Gunicorn can be bundled in the same PEX file. At the time of
-writing, you can import and instantiate a WSGIApplication like so:
+as the app and Gunicorn can be bundled in the same PEX file. Gunicorn has
+this functionality built-in as a first class citizen known as 
+:class:`gunicorn.app.wsgiapp`. This can be used to run WSGI-compatible app 
+instances such as those produced by Flask or Django. Assuming your WSGI api 
+package is `exampleapi`, and your application instance is `app`, this is all 
+you need to get going:
 
 .. code-block:: python
-    from gunicorn.app.wsgiapp import WSGIApplication
-    WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]").run()
-
-This can be used to run WSGI-compatible app instances such as those produced
-by Flask or Django. Assuming that the code above is in a file called `run.py`,
-your application's WSGI instance is called `app`, and it's exported by a package
-called `exampleapi`, then you should be able to fire up your server with a
-command similar to '``python run.py exampleapi:app``'. 
+    gunicorn.app.wsgiapp exampleapi:app
 
 This command will work with any Gunicorn CLI parameters or a config file - just
-pass them along as if you're directly giving them to Gunicorn as below
+pass them along as if you're directly giving them to Gunicorn
 
 .. code-block:: python
     # Custom parameters
-    python run.py exampleapi:app --bind=0.0.0.0:8081 --workers=4
+    python gunicorn.app.wsgiapp exampleapi:app --bind=0.0.0.0:8081 --workers=4
     # Using a config file
-    python run.py exampleapi:app -c config.py
+    python gunicorn.app.wsgiapp exampleapi:app -c config.py
+    
+Note for those using PEX: use `-e gunicorn.app.wsgiapp` as your entry at build
+time, and your compiled app should work with the entry point passed to it at
+run time. 
+
+.. code-block:: bash
+    # Generic pex build command via bash from root of exampleapi project
+    pex . -v -e gunicorn.app.wsgiapp -o compiledapp.pex
+    # Running it
+    ./compiledapp.pex exampleapi:app -c config.py


### PR DESCRIPTION
I had a use case where I needed to be able to standardize how our servers are running, but the application code could vary wildly within the scope of existing as a WSGI app ala flask or django. This had to happen within a PEX context, and I was able to get it working nicely and reliably after digging through the Gunicorn source to find this approach. Now I've got a happy little scaffold for wsgi apps that is standard for our company that works well PEX files by including Gunicorn in the build, but it was a real pain to figure this out, and it would've save me a day or two of researching in circles if this was mentioned somewhere

Hope this matches appropriate formatting, I checked CONTRIBUTING and it didn't mention much about docs and Github isn't rendering the preview quite right