### PR TITLE
gevent monkey patch before any other imports

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -1168,11 +1168,11 @@ libraries may be installed using setuptools' ``extra_require`` feature.
 A string referring to one of the following bundled classes:
 
 * ``sync``
-* ``eventlet`` - Requires eventlet >= 0.9.7 (or install it via 
+* ``eventlet`` - Requires eventlet >= 0.9.7 (or install it via
   ``pip install gunicorn[eventlet]``)
-* ``gevent``   - Requires gevent >= 0.13 (or install it via 
+* ``gevent``   - Requires gevent >= 1.0 (or install it via
   ``pip install gunicorn[gevent]``)
-* ``tornado``  - Requires tornado >= 0.2 (or install it via 
+* ``tornado``  - Requires tornado >= 0.2 (or install it via
   ``pip install gunicorn[tornado]``)
 * ``gthread``  - Python 2 requires the futures package to be installed
   (or install it via ``pip install gunicorn[gthread]``)

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -611,11 +611,11 @@ class WorkerClass(Setting):
         A string referring to one of the following bundled classes:
 
         * ``sync``
-        * ``eventlet`` - Requires eventlet >= 0.9.7 (or install it via 
+        * ``eventlet`` - Requires eventlet >= 0.9.7 (or install it via
           ``pip install gunicorn[eventlet]``)
-        * ``gevent``   - Requires gevent >= 0.13 (or install it via 
+        * ``gevent``   - Requires gevent >= 1.0 (or install it via
           ``pip install gunicorn[gevent]``)
-        * ``tornado``  - Requires tornado >= 0.2 (or install it via 
+        * ``tornado``  - Requires tornado >= 0.2 (or install it via
           ``pip install gunicorn[tornado]``)
         * ``gthread``  - Python 2 requires the futures package to be installed
           (or install it via ``pip install gunicorn[gthread]``)
@@ -652,7 +652,7 @@ class WorkerThreads(Setting):
         If it is not defined, the default is ``1``.
 
         This setting only affects the Gthread worker type.
-        
+
         .. note::
            If you try to use the ``sync`` worker type and set the ``threads``
            setting to more than 1, the ``gthread`` worker type will be used

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ class PyTestCommand(TestCommand):
 
 
 extra_require = {
-    'gevent':  ['gevent>=0.13'],
+    'gevent':  ['gevent>=1.0'],
     'eventlet': ['eventlet>=0.9.7'],
     'tornado': ['tornado>=0.2'],
     'gthread': [],


### PR DESCRIPTION
I'm already using gunicorn with python 3.7 successfully in some of my apps in production. \o/

In those productions servers, since I'm running py3.7, I was forced to use gevent 1.3.4, and after the 1.3.x release, they introduce this warning:

```
/usr/local/lib/python3.7/site-packages/gunicorn/workers/ggevent.py:65: MonkeyPatchWarning: Monkey-patching ssl after ssl has already been imported may lead to errors, including RecursionError on Python 3.6. It may also silently lead to incorrect behaviour on Python 3.7. Please monkey-patch earlier. See https://github.com/gevent/gevent/issues/1016.
monkey.patch_all(subprocess=True)
```

Other issues already point this error also, like #1566. I don't know if this fix is naive and can cause other issues, but I hope we can be at least a first draft of a solution.