### PR TITLE
change --reload-extra-file option to get multiple files at once

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -896,12 +896,14 @@ class ReloadEngine(Setting):
 
 class ReloadExtraFiles(Setting):
     name = "reload_extra_files"
-    action = "append"
+    action = "store"
     section = "Debugging"
     cli = ["--reload-extra-file"]
     meta = "FILES"
     validator = validate_list_of_existing_files
-    default = []
+    default = ""
+    nargs = "+"
+    type = str
     desc = """\
         Extends :ref:`reload` option to also watch and reload on additional files
         (e.g., templates, configurations, specifications, etc.).


### PR DESCRIPTION
If I want to reload when templates changes, I should do like this right now:
--reload-extra-file path/to/templates/file1 --reload-extra-file path/to/templates/file2 ...... 
add every file by file.
I changed config.py to get files like:
--reload-extra-file path/to/templates/*
or
--reload-extra-file path/to/templates/file1 path/to/templates/file2
