### PR TITLE
Fixed jQuery not using https

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -179,7 +179,7 @@
     </div>
   </div>
 
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
   <script src="js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Page stopped working on new browsers 
https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content

output from FF console:
Blocked loading mixed active content “http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js”
gunicorn.org
Loading failed for the <script> with source “http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js”. gunicorn.org:182
 ReferenceError: $ is not defined