### PR TITLE
Remove unnecessary call to dict keys method

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -539,7 +539,7 @@ class Arbiter(object):
         Maintain the number of workers by spawning or killing
         as required.
         """
-        if len(self.WORKERS.keys()) < self.num_workers:
+        if len(self.WORKERS) < self.num_workers:
             self.spawn_workers()
 
         workers = self.WORKERS.items()
@@ -610,7 +610,7 @@ class Arbiter(object):
         of the master process.
         """
 
-        for _ in range(self.num_workers - len(self.WORKERS.keys())):
+        for _ in range(self.num_workers - len(self.WORKERS)):
             self.spawn_worker()
             time.sleep(0.1 * random.random())
 


### PR DESCRIPTION
`keys()` is a dynamic view under Python 3 and these dictionaries are not modified concurrently, so we don't need call the dict keys method anymore. And using `len(dict)` is more pythonista to get dict count by the way