### PR TITLE
InotifyReloader: Handle `module.__file__ is None`

### DIFF
--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -96,7 +96,7 @@ if has_inotify:
             fnames = [
                 os.path.dirname(COMPILED_EXT_RE.sub('py', module.__file__))
                 for module in tuple(sys.modules.values())
-                if hasattr(module, '__file__')
+                if getattr(module, '__file__', None)
             ]
 
             return set(fnames)


### PR DESCRIPTION
https://github.com/benoitc/gunicorn/commit/0f527a01f427fe06dc0219e2bc8ad6897c8f54fb added a fix for the case when some modules have the `__file__` attr set to `None`, for the polling reloader. Unfortunately, it missed making the same fix for the inotify reloader.

This change copies that fix into InotifyReloader