### PR TITLE
Update CI configs for 3.5, 3.6, 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,24 @@ sudo: false
 language: python
 matrix:
   include:
+    - python: 3.6
+      env: TOXENV=lint
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
-    - python: 3.6-dev
-      env: TOXENV=py36-dev
-    - python: nightly
+    - python: 3.7
       env: TOXENV=py37
-    - python: 3.6
-      env: TOXENV=lint
+      dist: xenial
+      sudo: true
+    - python: 3.8-dev
+      env: TOXENV=py38-dev
+      dist: xenial
+      sudo: true
   allow_failures:
-    - env: TOXENV=py36-dev
-    - env: TOXENV=py37
+    - env: TOXENV=py38-dev
 install: pip install tox
 # TODO: https://github.com/tox-dev/tox/issues/149
 script: tox --recreate

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,8 @@ environment:
       PYTHON: "C:\\Python35-x64"
     - TOXENV: py36
       PYTHON: "C:\\Python36-x64"
-matrix:
-  allow_failures:
-    - TOXENV: py35
-    - TOXENV: py36
+    - TOXENV: py37
+      PYTHON: "C:\\Python37-x64"
 init: SET "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 install:
   - pip install tox


### PR DESCRIPTION
This PR updates the Travis config to do the following:
* Make tests against Python 3.7 required to pass
* Drop tests against Python 3.6-dev
* Test against 3.8-dev instead (but make it an allowed failure)

It also similarly updates the Appveyor config:
* Make tests against Python 3.5 required to pass
* Make tests against Python 3.6 required to pass
* Test against Python 3.7 (and make it required to pass)