### PR TITLE
Fix unclosed file warning when reading a python config module

### DIFF
--- a/gunicorn/_compat.py
+++ b/gunicorn/_compat.py
@@ -60,6 +60,6 @@ def execfile_(fname, *args):
     if fname.endswith(".pyc"):
         code = _get_codeobj(fname)
     else:
-        from pathlib import Path
-        code = compile(Path(fname).read_bytes(), fname, 'exec')
+        with open(fname, 'rb') as file:
+            code = compile(file.read(), fname, 'exec')
     return exec(code, *args)

--- a/gunicorn/_compat.py
+++ b/gunicorn/_compat.py
@@ -60,7 +60,6 @@ def execfile_(fname, *args):
     if fname.endswith(".pyc"):
         code = _get_codeobj(fname)
     else:
-        code = compile(open(fname, 'rb').read(), fname, 'exec')
+        from pathlib import Path
+        code = compile(Path(fname).read_bytes(), fname, 'exec')
     return exec(code, *args)
-
-


### PR DESCRIPTION
The raw open call in `_compat:execfile_` did not close the file handle.
Switch to using pathlib to read the raw bytes.

Logs:

```
Oct 02 05:04:38 ubuntu-bionic systemd[1]: Started Gunicorn server for hyperbola django.
Oct 02 05:04:38 ubuntu-bionic gunicorn[12173]: /hyperbola/app/releases/20181002050352/venv/lib/python3.6/site-packages/gunicorn/_compat.py:71: ResourceWarning: unclosed file <_io.BufferedReader name='/hyperbola/app/current/gunicorn.py'>
Oct 02 05:04:38 ubuntu-bionic gunicorn[12173]:   code = compile(open(fname, 'rb').read(), fname, 'exec')
Oct 02 05:04:38 ubuntu-bionic gunicorn[12173]: [2018-10-02 05:04:38 +0000] [12173] [INFO] Starting gunicorn 19.9.0
Oct 02 05:04:38 ubuntu-bionic gunicorn[12173]: [2018-10-02 05:04:38 +0000] [12173] [INFO] Listening at: unix:/var/run/hyperbola-local/hyperbola.sock (12173)
```

I am running gunicorn 19.9.0 and tested my fix by patching my virtualenv.