### PR TITLE
add systemd sd_notify support

### DIFF
--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -227,7 +227,7 @@ unix socket:
     After=network.target
 
     [Service]
-    PIDFile=/run/gunicorn/pid
+    Type=notify
     User=someuser
     Group=someuser
     RuntimeDirectory=gunicorn

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -158,7 +158,7 @@ class Arbiter(object):
         self.log.debug("Arbiter booted")
         self.log.info("Listening at: %s (%s)", listeners_str, self.pid)
         self.log.info("Using worker: %s", self.cfg.worker_class_str)
-        systemd.sd_notify("READY=1\nSTATUS=Gunicorn arbiter booted")
+        systemd.sd_notify("READY=1\nSTATUS=Gunicorn arbiter booted", self.log)
 
         # check worker class requirements
         if hasattr(self.worker_class, "check_config"):

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -158,6 +158,7 @@ class Arbiter(object):
         self.log.debug("Arbiter booted")
         self.log.info("Listening at: %s (%s)", listeners_str, self.pid)
         self.log.info("Using worker: %s", self.cfg.worker_class_str)
+        systemd.sd_notify("READY=1\nSTATUS=Gunicorn arbiter booted")
 
         # check worker class requirements
         if hasattr(self.worker_class, "check_config"):

--- a/gunicorn/systemd.py
+++ b/gunicorn/systemd.py
@@ -4,6 +4,7 @@
 # See the NOTICE for more information.
 
 import os
+import socket
 
 SD_LISTEN_FDS_START = 3
 
@@ -43,3 +44,37 @@ def listen_fds(unset_environment=True):
         os.environ.pop('LISTEN_FDS', None)
 
     return fds
+
+
+def sd_notify(state, unset_environment=False, debug=False):
+    """Send a notification to systemd. state is a string; see
+    the man page of sd_notify (http://www.freedesktop.org/software/systemd/man/sd_notify.html)
+    for a description of the allowable values.
+
+    If the unset_environment parameter is non-zero, sd_notify() will unset the $NOTIFY_SOCKET environment variable before
+    returning (regardless of whether the function call itself succeeded or not). Further calls to sd_notify() will then fail, but
+    the variable is no longer inherited by child processes.
+
+    Normally this method silently ignores exceptions (for example, if the
+    systemd notification socket is not available) to allow applications to
+    function on non-systemd based systems. However, setting debug=True will
+    cause this method to raise any exceptions generated to the caller, to
+    aid in debugging."""
+
+    addr = os.getenv('NOTIFY_SOCKET')
+    if addr == None:
+        # not run in a service, just a noop
+        return
+    if unset_environment:
+        os.unsetenv('NOTIFY_SOCKET')
+    try:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM | socket.SOCK_CLOEXEC)
+        if addr[0] == '@':
+            addr = '\0' + addr[1:]
+        sock.connect(addr)
+        sock.sendall(state.encode('utf-8'))
+    except:
+        if debug:
+            raise
+    finally:
+        sock.close()

--- a/gunicorn/systemd.py
+++ b/gunicorn/systemd.py
@@ -63,12 +63,12 @@ def sd_notify(state, unset_environment=False, debug=False):
     cause this method to raise any exceptions generated to the caller, to
     aid in debugging."""
 
-    addr = os.getenv('NOTIFY_SOCKET')
+    addr = os.environ.get('NOTIFY_SOCKET')
     if addr is None:
         # not run in a service, just a noop
         return
     if unset_environment:
-        os.unsetenv('NOTIFY_SOCKET')
+        os.environ.pop('NOTIFY_SOCKET')
     try:
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM | socket.SOCK_CLOEXEC)
         if addr[0] == '@':

--- a/gunicorn/systemd.py
+++ b/gunicorn/systemd.py
@@ -67,8 +67,6 @@ def sd_notify(state, unset_environment=False, debug=False):
     if addr is None:
         # not run in a service, just a noop
         return
-    if unset_environment:
-        os.environ.pop('NOTIFY_SOCKET')
     try:
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM | socket.SOCK_CLOEXEC)
         if addr[0] == '@':
@@ -79,4 +77,6 @@ def sd_notify(state, unset_environment=False, debug=False):
         if debug:
             raise
     finally:
+        if unset_environment:
+            os.environ.pop('NOTIFY_SOCKET')
         sock.close()

--- a/gunicorn/systemd.py
+++ b/gunicorn/systemd.py
@@ -46,7 +46,7 @@ def listen_fds(unset_environment=True):
     return fds
 
 
-def sd_notify(state, unset_environment=False, debug=False):
+def sd_notify(state, logger, unset_environment=False):
     """Send a notification to systemd. state is a string; see
     the man page of sd_notify (http://www.freedesktop.org/software/systemd/man/sd_notify.html)
     for a description of the allowable values.
@@ -56,12 +56,8 @@ def sd_notify(state, unset_environment=False, debug=False):
     whether the function call itself succeeded or not). Further calls to
     sd_notify() will then fail, but the variable is no longer inherited by
     child processes.
+    """
 
-    Normally this method silently ignores exceptions (for example, if the
-    systemd notification socket is not available) to allow applications to
-    function on non-systemd based systems. However, setting debug=True will
-    cause this method to raise any exceptions generated to the caller, to
-    aid in debugging."""
 
     addr = os.environ.get('NOTIFY_SOCKET')
     if addr is None:
@@ -74,8 +70,7 @@ def sd_notify(state, unset_environment=False, debug=False):
         sock.connect(addr)
         sock.sendall(state.encode('utf-8'))
     except:
-        if debug:
-            raise
+        logger.debug("Exception while invoking sd_notify()", exc_info=True)
     finally:
         if unset_environment:
             os.environ.pop('NOTIFY_SOCKET')

--- a/gunicorn/systemd.py
+++ b/gunicorn/systemd.py
@@ -51,9 +51,11 @@ def sd_notify(state, unset_environment=False, debug=False):
     the man page of sd_notify (http://www.freedesktop.org/software/systemd/man/sd_notify.html)
     for a description of the allowable values.
 
-    If the unset_environment parameter is non-zero, sd_notify() will unset the $NOTIFY_SOCKET environment variable before
-    returning (regardless of whether the function call itself succeeded or not). Further calls to sd_notify() will then fail, but
-    the variable is no longer inherited by child processes.
+    If the unset_environment parameter is True, sd_notify() will unset
+    the $NOTIFY_SOCKET environment variable before returning (regardless of
+    whether the function call itself succeeded or not). Further calls to
+    sd_notify() will then fail, but the variable is no longer inherited by
+    child processes.
 
     Normally this method silently ignores exceptions (for example, if the
     systemd notification socket is not available) to allow applications to
@@ -62,7 +64,7 @@ def sd_notify(state, unset_environment=False, debug=False):
     aid in debugging."""
 
     addr = os.getenv('NOTIFY_SOCKET')
-    if addr == None:
+    if addr is None:
         # not run in a service, just a noop
         return
     if unset_environment:


### PR DESCRIPTION
roughly based on sd_notify() from systemd and https://github.com/bb4242/sdnotify

only implements `READY=1` and `STATUS=Gunicorn arbiter booted` of the
protocol in the arbiter. in the future, reloads can be notified, and
possibly also other statuses.

see https://www.freedesktop.org/software/systemd/man/sd_notify.html for
more info

sd_notify() is a noop when not run in a systemd service (i.e
NOTIFY_SOCKET environment variable is not set)
