### PR TITLE
Clarify log format usage of header & environment.

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -186,6 +186,11 @@ p            process ID
 {Variable}e  environment variable
 ===========  ===========
 
+Use lowercase for header and environment variable names, and put
+``{...}x`` names inside ``%(...)s``. For example::
+
+    %({x-forwarded-for}i)s
+
 .. _errorlog:
 
 errorlog

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -181,9 +181,9 @@ T            request time in seconds
 D            request time in microseconds
 L            request time in decimal seconds
 p            process ID
-{Header}i    request header
-{Header}o    response header
-{Variable}e  environment variable
+{header}i    request header
+{header}o    response header
+{variable}e  environment variable
 ===========  ===========
 
 Use lowercase for header and environment variable names, and put

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1245,6 +1245,11 @@ class AccessLogFormat(Setting):
         {Header}o    response header
         {Variable}e  environment variable
         ===========  ===========
+
+        Use lowercase for header and environment variable names, and put
+        ``{...}x`` names inside ``%(...)s``. For example::
+
+            %({x-forwarded-for}i)s
         """
 
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1241,9 +1241,9 @@ class AccessLogFormat(Setting):
         D            request time in microseconds
         L            request time in decimal seconds
         p            process ID
-        {Header}i    request header
-        {Header}o    response header
-        {Variable}e  environment variable
+        {header}i    request header
+        {header}o    response header
+        {variable}e  environment variable
         ===========  ===========
 
         Use lowercase for header and environment variable names, and put


### PR DESCRIPTION
Add a bit of detail on how to put headers and environment variables in the access log.

As you'll see, settings.rst is updated via `make -C docs html`.