### PR TITLE
AppVeyor: allow failures, run lint using Python 3.7

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,11 @@ environment:
       PYTHON: "C:\\Python36-x64"
     - TOXENV: py37
       PYTHON: "C:\\Python37-x64"
+matrix:
+  allow_failures:
+    - TOXENV: py35
+    - TOXENV: py36
+    - TOXENV: py37
 init: SET "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 install:
   - pip install tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: '{branch}.{build}'
 environment:
   matrix:
     - TOXENV: lint
-      PYTHON: "C:\\Python35-x64"
+      PYTHON: "C:\\Python37-x64"
     - TOXENV: py35
       PYTHON: "C:\\Python35-x64"
     - TOXENV: py36


### PR DESCRIPTION
It's fine that AppVeyor has been activated for the repo, and I'm sure that will be appreciated by anyone working on Windows support (#524) in any form.

For now Windows support seems somewhat distant (although there may be great leaps) - in the interim it will be a little tiresome to have AppVeyor mark all PRs and branch builds as bad due to Windows platform failures.  You see it now in any new or rebased PR on master.

This PR marks all but the `lint` AppVeyor builds as members of `allow_failures`.  Each platform/version still runs and you can click-through to see the status and console/errors, but it won't mark the build as bad.  This makes sense because Windows is not currently supported, and the build is therefore expected to fail there.

When these builds are passing, this change can be reversed.

Also added a small fix to bump-up the version for AppVeyor `lint` (which is passing) to run Python 3.7.

This PR should be self-testing, i.e. build-checks should pass including AppVeyor, whereas current new PRs for master are being marked as failed.