### PR TITLE
Encode header values using latin-1, not ascii

### DIFF
--- a/examples/test.py
+++ b/examples/test.py
@@ -20,7 +20,8 @@ def app(environ, start_response):
     response_headers = [
         ('Content-type', 'text/plain'),
         ('Content-Length', str(len(data))),
-        ('X-Gunicorn-Version', __version__)
+        ('X-Gunicorn-Version', __version__),
+        ('Foo', 'B\u00e5r'),  # Foo: Bår
     ]
     start_response(status, response_headers)
     return iter([data])

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -315,7 +315,7 @@ class Response(object):
         tosend.extend(["%s: %s\r\n" % (k, v) for k, v in self.headers])
 
         header_str = "%s\r\n" % "".join(tosend)
-        util.write(self.sock, util.to_bytestring(header_str, "ascii"))
+        util.write(self.sock, util.to_bytestring(header_str, "latin-1"))
         self.headers_sent = True
 
     def write(self, arg):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -81,8 +81,13 @@ def test_http_header_encoding():
     mocked_request = mock.MagicMock()
     response = Response(mocked_request, mocked_socket, None)
 
-    # set umlaut header
+    # set umlaut header value - latin-1 is OK
     response.headers.append(('foo', 'häder'))
+    response.send_headers()
+
+    # set a-breve header value - unicode, non-latin-1 fails
+    response = Response(mocked_request, mocked_socket, None)
+    response.headers.append(('apple', 'măr'))
     with pytest.raises(UnicodeEncodeError):
         response.send_headers()
 


### PR DESCRIPTION
This commit reverts one aspect changed by 5f4ebd2eb2b08783a5fbefe79d09fcb3fc1fbc73 (#1151);
header-values are again encoded as latin-1 and not ascii. Test is restored but uses
a latin-1-mappable test-character, not a general utf8 character.

Fixed #1778.

Per question in #791, is there a best way to automate the test?