### PR TITLE
Declare our setuptools dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,14 @@ class PyTestCommand(TestCommand):
         sys.exit(errno)
 
 
+install_requires = [
+    # We depend on functioning `pkg_resources.working_set.add_entry` and
+    # `pkg_resources.load_entry_point`. These both work as of 3.0 which
+    # is the first version to support python 3.4 which we require as a
+    # floor.
+    'setuptools>=3.0',
+]
+
 extra_require = {
     'gevent':  ['gevent>=0.13'],
     'eventlet': ['eventlet>=0.9.7'],
@@ -84,6 +92,7 @@ setup(
     url='http://gunicorn.org',
 
     python_requires='>=3.4',
+    install_requires=install_requires,
     classifiers=CLASSIFIERS,
     zip_safe=False,
     packages=find_packages(exclude=['examples', 'tests']),

--- a/setup.py
+++ b/setup.py
@@ -66,9 +66,9 @@ class PyTestCommand(TestCommand):
 
 
 install_requires = [
-    # We depend on functioning `pkg_resources.working_set.add_entry` and
-    # `pkg_resources.load_entry_point`. These both work as of 3.0 which
-    # is the first version to support python 3.4 which we require as a
+    # We depend on functioning pkg_resources.working_set.add_entry() and
+    # pkg_resources.load_entry_point(). These both work as of 3.0 which
+    # is the first version to support Python 3.4 which we require as a
     # floor.
     'setuptools>=3.0',
 ]


### PR DESCRIPTION
We rely on setuptools' pkg_resources in a few places so we declare our
dependency so that packaging and installation tools work.

Fixes #1716