### PR TITLE
Use Python's default SSL cipher list by default

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -506,9 +506,22 @@ ciphers
 ~~~~~~~
 
 * ``--ciphers``
-* ``TLSv1``
+* ``None``
 
-Ciphers to use (see stdlib ssl module's)
+SSL Cipher suite to use, in the format of an OpenSSL cipher list.
+
+By default we use the default cipher list from Python's ``ssl`` module,
+which contains ciphers considered strong at the time of each Python
+release.
+
+As a recommended alternative, the Open Web App Security Project (OWASP)
+offers `a vetted set of strong cipher strings rated A+ to C-
+<https://www.owasp.org/index.php/TLS_Cipher_String_Cheat_Sheet>`_.
+OWASP provides details on user-agent compatibility at each security level.
+
+See the `OpenSSL Cipher List Format Documentation
+<https://www.openssl.org/docs/manmaster/man1/ciphers.html#CIPHER-LIST-FORMAT>`_
+for details on the format of an OpenSSL cipher list.
 
 Security
 --------

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1963,9 +1963,22 @@ class Ciphers(Setting):
     section = "SSL"
     cli = ["--ciphers"]
     validator = validate_string
-    default = 'TLSv1'
+    default = None
     desc = """\
-    Ciphers to use (see stdlib ssl module's)
+    SSL Cipher suite to use, in the format of an OpenSSL cipher list.
+
+    By default we use the default cipher list from Python's ``ssl`` module,
+    which contains ciphers considered strong at the time of each Python
+    release.
+
+    As a recommended alternative, the Open Web App Security Project (OWASP)
+    offers `a vetted set of strong cipher strings rated A+ to C-
+    <https://www.owasp.org/index.php/TLS_Cipher_String_Cheat_Sheet>`_.
+    OWASP provides details on user-agent compatibility at each security level.
+
+    See the `OpenSSL Cipher List Format Documentation
+    <https://www.openssl.org/docs/manmaster/man1/ciphers.html#CIPHER-LIST-FORMAT>`_
+    for details on the format of an OpenSSL cipher list.
     """
 
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -72,4 +72,4 @@ def test_ciphers():
     assert Ciphers.name == 'ciphers'
     assert Ciphers.section == 'SSL'
     assert Ciphers.cli == ['--ciphers']
-    assert Ciphers.default == 'TLSv1'
+    assert Ciphers.default is None


### PR DESCRIPTION
Remove the default value `'TLSv1'` for `--ciphers` which *weakens* security over Python's defaults.

Setting to `None` appears to work everywhere. In one case (_gaihttp.py) it's already special-cased. Everywhere else it is passed to `ssl.wrap_socket()`, where `ciphers=None` is allowed, to use the default cipher set.

Fixes #1966.