### PR TITLE
Simplify futures import

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -10,6 +10,7 @@
 # If no event happen after the keep alive timeout, the connection is
 # closed.
 
+import concurrent.futures as futures
 import errno
 import os
 import selectors
@@ -27,13 +28,6 @@ from .. import http
 from .. import util
 from ..http import wsgi
 
-try:
-    import concurrent.futures as futures
-except ImportError:
-    raise RuntimeError("""
-    You need to install the 'futures' package to use this worker with this
-    Python version.
-    """)
 
 class TConn(object):
 


### PR DESCRIPTION
Commits e974f305 and 78208c8c removed support for Python 2 and Python
<3.4 respectively so the conditional logic for importing
`concurrent.futures` is no longer necessary as it has been part of the
standard library since Python 3.2.