### PR TITLE
Move ThreadPoolExecutor() creation into own method

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -85,10 +85,14 @@ class ThreadWorker(base.Worker):
                     "Check the number of worker connections and threads.")
 
     def init_process(self):
-        self.tpool = futures.ThreadPoolExecutor(max_workers=self.cfg.threads)
+        self.tpool = self.get_thread_pool()
         self.poller = selectors.DefaultSelector()
         self._lock = RLock()
         super(ThreadWorker, self).init_process()
+
+    def get_thread_pool(self):
+        """Override this method to customize how the thread pool is created"""
+        return futures.ThreadPoolExecutor(max_workers=self.cfg.threads)
 
     def handle_quit(self, sig, frame):
         self.alive = False


### PR DESCRIPTION
Move ThreadPoolExecutor() creation into it's own method so it is easier
to override when subclassing.