### PR TITLE
Fix compatility with tornado 6

### DIFF
--- a/gunicorn/workers/gtornado.py
+++ b/gunicorn/workers/gtornado.py
@@ -107,7 +107,7 @@ class TornadoWorker(Worker):
         app = self.wsgi
 
         # Patch for tornado5
-        if tornado.version_info[0] == 5:
+        if tornado.version_info[0] < 6:
             if not isinstance(app, tornado.web.Application) or \
             isinstance(app, tornado.wsgi.WSGIApplication):
                 app = WSGIContainer(app)

--- a/gunicorn/workers/gtornado.py
+++ b/gunicorn/workers/gtornado.py
@@ -106,7 +106,6 @@ class TornadoWorker(Worker):
         # instance of tornado.wsgi.WSGIApplication
         app = self.wsgi
 
-        # Patch for tornado5
         if tornado.version_info[0] < 6:
             if not isinstance(app, tornado.web.Application) or \
             isinstance(app, tornado.wsgi.WSGIApplication):

--- a/gunicorn/workers/gtornado.py
+++ b/gunicorn/workers/gtornado.py
@@ -105,9 +105,12 @@ class TornadoWorker(Worker):
         # instance of tornado.web.Application or is an
         # instance of tornado.wsgi.WSGIApplication
         app = self.wsgi
-        if not isinstance(app, tornado.web.Application) or \
-           isinstance(app, tornado.wsgi.WSGIApplication):
-            app = WSGIContainer(app)
+
+        # Patch for tornado5
+        if tornado.version_info[0] == 5:
+            if not isinstance(app, tornado.web.Application) or \
+            isinstance(app, tornado.wsgi.WSGIApplication):
+                app = WSGIContainer(app)
 
         # Monkey-patching HTTPConnection.finish to count the
         # number of requests being handled by Tornado. This


### PR DESCRIPTION
Hi @benoitc,

Following https://github.com/the-benchmarker/web-frameworks/pull/1012, this `PR` fix some backwards incompatibility of `tornado` **worker** for last release of https://github.com/tornadoweb/tornado

@see https://github.com/tornadoweb/tornado/blob/master/docs/releases/v6.0.0.rst

Regards,