### PR TITLE
Fix setup field typo

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -363,6 +363,18 @@ statsd_host
 
 .. versionadded:: 19.1
 
+.. _dogstatsd-tags:
+
+dogstatsd_tags
+~~~~~~~~~~~~~~
+
+* ``--dogstatsd-tags DOGSTATSD_TAGS``
+* ``(empty string)``
+
+A comma-delimited list of datadog statsd (dogstatsd) tags to append to statsd metrics.
+
+.. versionadded:: 20
+
 .. _statsd-prefix:
 
 statsd_prefix
@@ -375,17 +387,6 @@ Prefix to use when emitting statsd metrics (a trailing ``.`` is added,
 if not provided).
 
 .. versionadded:: 19.2
-
-dogstatsd_tags
-~~~~~~~~~~~~~~
-
-* ``--dogstatsd-tags DOGSTATSD_TAGS``
-* ``(empty string)``
-
-Comma-delimited list of static dogstatsd (datadog statsd) tags sent with all statsd metrics
-See: `Datadog Docs <https://docs.datadoghq.com/developers/dogstatsd/>`
-
-.. versionadded:: 20
 
 Process Naming
 --------------
@@ -1218,25 +1219,19 @@ libraries may be installed using setuptools' ``extras_require`` feature.
 A string referring to one of the following bundled classes:
 
 * ``sync``
-* ``eventlet`` - Requires eventlet >= 0.9.7 (or install it via 
+* ``eventlet`` - Requires eventlet >= 0.24.1 (or install it via
   ``pip install gunicorn[eventlet]``)
-* ``gevent``   - Requires gevent >= 0.13 (or install it via 
+* ``gevent``   - Requires gevent >= 1.4 (or install it via
   ``pip install gunicorn[gevent]``)
-* ``tornado``  - Requires tornado >= 0.2 (or install it via 
+* ``tornado``  - Requires tornado >= 0.2 (or install it via
   ``pip install gunicorn[tornado]``)
 * ``gthread``  - Python 2 requires the futures package to be installed
   (or install it via ``pip install gunicorn[gthread]``)
-* ``gaiohttp`` - Deprecated.
 
 Optionally, you can provide your own worker by giving Gunicorn a
 Python path to a subclass of ``gunicorn.workers.base.Worker``.
 This alternative syntax will load the gevent class:
 ``gunicorn.workers.ggevent.GeventWorker``.
-
-.. deprecated:: 19.8
-   The ``gaiohttp`` worker is deprecated. Please use
-   ``aiohttp.worker.GunicornWebWorker`` instead. See
-   :ref:`asyncio-workers` for more information on how to use it.
 
 .. _threads:
 
@@ -1273,7 +1268,7 @@ worker_connections
 
 The maximum number of simultaneous clients.
 
-This setting only affects the Eventlet, Gevent and Gthread worker types.
+This setting only affects the Eventlet and Gevent worker types.
 
 .. _max-requests:
 

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -1213,7 +1213,7 @@ The type of workers to use.
 The default class (``sync``) should handle most "normal" types of
 workloads. You'll want to read :doc:`design` for information on when
 you might want to choose one of the other worker classes. Required
-libraries may be installed using setuptools' ``extra_require`` feature.
+libraries may be installed using setuptools' ``extras_require`` feature.
 
 A string referring to one of the following bundled classes:
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -625,7 +625,7 @@ class WorkerClass(Setting):
         The default class (``sync``) should handle most "normal" types of
         workloads. You'll want to read :doc:`design` for information on when
         you might want to choose one of the other worker classes. Required
-        libraries may be installed using setuptools' ``extra_require`` feature.
+        libraries may be installed using setuptools' ``extras_require`` feature.
 
         A string referring to one of the following bundled classes:
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ install_requires = [
     'setuptools>=3.0',
 ]
 
-extra_require = {
+extras_require = {
     'gevent':  ['gevent>=0.13'],
     'eventlet': ['eventlet>=0.9.7'],
     'tornado': ['tornado>=0.2'],
@@ -108,5 +108,5 @@ setup(
     [paste.server_runner]
     main=gunicorn.app.pasterapp:serve
     """,
-    extras_require=extra_require,
+    extras_require=extras_require,
 )


### PR DESCRIPTION
Content refers to the `"extra_require"` field from `setuptools.setup`.

This field is actually `"extras_require"`. I have made this mistake myself before.

[Setuptools Documentation](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies)

![image](https://user-images.githubusercontent.com/28621737/57464940-8800ba80-7275-11e9-8a20-242a6c41e46c.png)

- [Image Source](https://setuptools.readthedocs.io/en/latest/setuptools.html)