### PR TITLE
Refactor imports of unittest.mock

### DIFF
--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -4,11 +4,7 @@
 # See the NOTICE for more information.
 
 import os
-
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+import unittest.mock as mock
 
 import gunicorn.app.base
 import gunicorn.arbiter

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -3,17 +3,13 @@
 import io
 import t
 import pytest
+import unittest.mock as mock
 
 from gunicorn import util
 from gunicorn.http.body import Body, LengthReader, EOFReader
 from gunicorn.http.wsgi import Response
 from gunicorn.http.unreader import Unreader, IterUnreader, SocketUnreader
 from gunicorn.http.errors import InvalidHeader, InvalidHeaderName
-
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
 
 
 def assert_readline(payload, size, expected):

--- a/tests/test_pidfile.py
+++ b/tests/test_pidfile.py
@@ -5,12 +5,8 @@
 
 import errno
 
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
-
 import gunicorn.pidfile
+import unittest.mock as mock
 
 
 def builtin(name):

--- a/tests/test_pidfile.py
+++ b/tests/test_pidfile.py
@@ -4,9 +4,9 @@
 # See the NOTICE for more information.
 
 import errno
+import unittest.mock as mock
 
 import gunicorn.pidfile
-import unittest.mock as mock
 
 
 def builtin(name):

--- a/tests/test_sock.py
+++ b/tests/test_sock.py
@@ -3,10 +3,7 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+import unittest.mock as mock
 
 from gunicorn import sock
 

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -5,11 +5,7 @@
 
 from contextlib import contextmanager
 import os
-
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+import unittest.mock as mock
 
 import pytest
 


### PR DESCRIPTION
unittest.mock is new in version 3.3
https://docs.python.org/3/library/unittest.mock.html#module-unittest.mock