### PR TITLE
Updated systemd documentation to link the Socket with the Service

### DIFF
--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -252,6 +252,9 @@ to the newly created unix socket:
 
     [Unit]
     Description=gunicorn socket
+    # Restart the socket as PartOf the service so we never lose the
+    # socket file on a restart causing a 502 in nginx.
+    PartOf=gunicorn.service
 
     [Socket]
     ListenStream=/run/gunicorn.sock


### PR DESCRIPTION
When restarting the service the socket doesn't always get recreated, by linking the socket with the service, the socket file is always available to nginx.