### PR TITLE
Add --print-config option to print the resolved configuration

### DIFF
--- a/docs/source/configure.rst
+++ b/docs/source/configure.rst
@@ -25,10 +25,10 @@ Once again, in order of least to most authoritative:
 
 .. note::
 
-    To check your configuration when using the command line or the
+    To print your resolved configuration when using the command line or the
     configuration file you can run the following command::
 
-        $ gunicorn --check-config APP_MODULE
+        $ gunicorn --print-config APP_MODULE
 
     It also allows you to know if your application can be launched.
 

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -123,6 +123,16 @@ check_config
 
 Check the configuration.
 
+.. _print-config:
+
+print_config
+~~~~~~~~~~~~
+
+* ``--print-config``
+* ``False``
+
+Print the configuration settings as fully resolved. Implies :ref:`check-config`.
+
 Logging
 -------
 

--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -191,7 +191,10 @@ class Application(BaseApplication):
         self.chdir()
 
     def run(self):
-        if self.cfg.check_config:
+        if self.cfg.print_config:
+            print(self.cfg)
+
+        if self.cfg.print_config or self.cfg.check_config:
             try:
                 self.load()
             except:

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -57,8 +57,8 @@ class Config(object):
         for k in sorted(self.settings):
             v = self.settings[k].value
             if callable(v):
-                v = "<%s()>" % v.__qualname__
-            lines.append(f"{k:{kmax}} = {v}")
+                v = "<{}()>".format(v.__qualname__)
+            lines.append("{k:{kmax}} = {v}".format(k=k, v=v, kmax=kmax))
         return "\n".join(lines)
 
     def __getattr__(self, name):

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -51,6 +51,16 @@ class Config(object):
         self.prog = prog or os.path.basename(sys.argv[0])
         self.env_orig = os.environ.copy()
 
+    def __str__(self):
+        lines = []
+        kmax = max(len(k) for k in self.settings)
+        for k in sorted(self.settings):
+            v = self.settings[k].value
+            if callable(v):
+                v = "<%s()>" % v.__qualname__
+            lines.append(f"{k:{kmax}} = {v}")
+        return "\n".join(lines)
+
     def __getattr__(self, name):
         if name not in self.settings:
             raise AttributeError("No configuration setting for: %s" % name)
@@ -933,6 +943,18 @@ class ConfigCheck(Setting):
     default = False
     desc = """\
         Check the configuration.
+        """
+
+
+class PrintConfig(Setting):
+    name = "print_config"
+    section = "Debugging"
+    cli = ["--print-config"]
+    validator = validate_bool
+    action = "store_true"
+    default = False
+    desc = """\
+        Print the resolved configuration.
         """
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -454,7 +454,7 @@ def test_str():
     }
     for i, line in enumerate(o.splitlines()):
         m = re.match(r'^(\w+)\s+= ', line)
-        assert m, f"Config line {i} didn't match expected format: {line!r}"
+        assert m, "Line {} didn't match expected format: {!r}".format(i, line)
 
         key = m.group(1)
         try:
@@ -462,10 +462,12 @@ def test_str():
         except KeyError:
             continue
 
-        line_re = fr'^{key}\s+= {re.escape(s)}$'
-        assert re.match(line_re, line), f'{line_re!r} != {line!r}'
+        line_re = r'^{}\s+= {}$'.format(key, re.escape(s))
+        assert re.match(line_re, line), '{!r} != {!r}'.format(line_re, line)
 
         if not OUTPUT_MATCH:
             break
     else:
-        assert False, f'missing expected setting lines? {list(OUTPUT_MATCH.keys())}'
+        assert False, 'missing expected setting lines? {}'.format(
+            OUTPUT_MATCH.keys()
+        )


### PR DESCRIPTION
Implementation of #2052. WIP for review.

### Sample output:
```console
$ gunicorn --print-config foo
access_log_format                 = %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"
accesslog                         = None
backlog                           = 2048
bind                              = ['127.0.0.1:8000']
ca_certs                          = None
capture_output                    = False
cert_reqs                         = 0
certfile                          = None
chdir                             = /Users/rcoup/code/gunicorn
check_config                      = False
child_exit                        = <ChildExit.child_exit()>
ciphers                           = None
config                            = None
daemon                            = False
default_proc_name                 = foo
disable_redirect_access_to_syslog = False
do_handshake_on_connect           = False
dogstatsd_tags                    =
enable_stdio_inheritance          = False
errorlog                          = -
forwarded_allow_ips               = ['127.0.0.1']
graceful_timeout                  = 30
group                             = 20
initgroups                        = False
keepalive                         = 2
keyfile                           = None
limit_request_field_size          = 8190
limit_request_fields              = 100
limit_request_line                = 4094
logconfig                         = None
logconfig_dict                    = {}
logger_class                      = gunicorn.glogging.Logger
loglevel                          = info
max_requests                      = 0
max_requests_jitter               = 0
nworkers_changed                  = <NumWorkersChanged.nworkers_changed()>
on_exit                           = <OnExit.on_exit()>
on_reload                         = <OnReload.on_reload()>
on_starting                       = <OnStarting.on_starting()>
paste                             = None
pidfile                           = None
post_fork                         = <Postfork.post_fork()>
post_request                      = <PostRequest.post_request()>
post_worker_init                  = <PostWorkerInit.post_worker_init()>
pre_exec                          = <PreExec.pre_exec()>
pre_fork                          = <Prefork.pre_fork()>
pre_request                       = <PreRequest.pre_request()>
preload_app                       = False
print_config                      = True
proc_name                         = None
proxy_allow_ips                   = ['127.0.0.1']
proxy_protocol                    = False
pythonpath                        = None
raw_env                           = []
raw_paste_global_conf             = []
reload                            = False
reload_engine                     = auto
reload_extra_files                = []
reuse_port                        = False
secure_scheme_headers             = {'X-FORWARDED-PROTOCOL': 'ssl', 'X-FORWARDED-PROTO': 'https', 'X-FORWARDED-SSL': 'on'}
sendfile                          = None
spew                              = False
ssl_version                       = 2
statsd_host                       = None
statsd_prefix                     =
suppress_ragged_eofs              = True
syslog                            = False
syslog_addr                       = unix:///var/run/syslog
syslog_facility                   = user
syslog_prefix                     = None
threads                           = 1
timeout                           = 30
tmp_upload_dir                    = None
umask                             = 0
user                              = 501
when_ready                        = <WhenReady.when_ready()>
worker_abort                      = <WorkerAbort.worker_abort()>
worker_class                      = sync
worker_connections                = 1000
worker_exit                       = <WorkerExit.worker_exit()>
worker_int                        = <WorkerInt.worker_int()>
worker_tmp_dir                    = None
workers                           = 1
```

### Todo: 

- [ ] review approach
- [x] tests
- [x] ci passing
- [x] docs
- [x] ~why doesn't on_exit print like the other callables?~

### Questions:

1. Currently printing the config happens _before_ `Application.load()` is called? Can/does config change during `load()`? (ie. should it happen afterwards?)
2. Currently printing the config also does `check_config`. Which means (a) it always exits afterwards, and (b) it actually validates things work. Personally that's sane behaviour, but opinions welcome
3. Should we include whether the value == the default? I can see it's kinda useful, but it could also be that you've _set_ it the same as the default, so people might waste time trying to debug that.
