### PR TITLE
Avoid unnecessary chown of temporary files

### DIFF
--- a/gunicorn/workers/workertmp.py
+++ b/gunicorn/workers/workertmp.py
@@ -21,10 +21,12 @@ class WorkerTmp(object):
         if fdir and not os.path.isdir(fdir):
             raise RuntimeError("%s doesn't exist. Can't create workertmp." % fdir)
         fd, name = tempfile.mkstemp(prefix="wgunicorn-", dir=fdir)
-
-        # allows the process to write to the file
-        util.chown(name, cfg.uid, cfg.gid)
         os.umask(old_umask)
+
+        # change the owner and group of the file if the worker will run as
+        # a different user or group, so that the worker can modify the file
+        if cfg.uid != os.geteuid() or cfg.gid != os.getegid():
+            util.chown(name, cfg.uid, cfg.gid)
 
         # unlink the file so we don't leak tempory files
         try:


### PR DESCRIPTION
When Gunicorn is configured to change the effective user or group of the
worker processes, it changes the owner and group fo the the temporary
files used for interprocess communication.

With this change, Gunicorn does not change the owner or group of the
files if the worker processes will run as the current effective user and
gorup. This change avoids calling chown when it is not necessary, which
may allow Gunicorn to be used in environments that restrict use of the
chown syscall.

Relates to #2059.