### PR TITLE
Add a __repr__ to config to include its value

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -308,6 +308,15 @@ class Setting(object):
                 self.order < other.order)
     __cmp__ = __lt__
 
+    def __repr__(self):
+        return "<%s.%s object at %x with value %r>" % (
+            self.__class__.__module__,
+            self.__class__.__name__,
+            id(self),
+            self.value,
+        )
+
+
 Setting = SettingMeta('Setting', (Setting,), {})
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -435,3 +435,10 @@ def test_bind_fd():
     with AltArgs(["prog_name", "-b", "fd://42"]):
         app = NoConfigApp()
     assert app.cfg.bind == ["fd://42"]
+
+
+def test_repr():
+    c = config.Config()
+    c.set("workers", 5)
+
+    assert "with value 5" in repr(c.settings['workers'])


### PR DESCRIPTION
It's sometimes helpful to be able to trivially dump all the config values
for debugging purposes. This commit defines a repr for that. See #2075 