### PR TITLE
Logging: Handle auth type case insensitively

### DIFF
--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -445,7 +445,7 @@ class Logger(object):
     def _get_user(self, environ):
         user = None
         http_auth = environ.get("HTTP_AUTHORIZATION")
-        if http_auth and http_auth.startswith('Basic'):
+        if http_auth and http_auth.lower().startswith('basic'):
             auth = http_auth.split(" ", 1)
             if len(auth) == 2:
                 try:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,6 +1,8 @@
 import datetime
 from types import SimpleNamespace
 
+import pytest
+
 from gunicorn.config import Config
 from gunicorn.glogging import Logger
 
@@ -47,7 +49,13 @@ def test_atoms_zero_bytes():
     assert atoms['B'] == 0
 
 
-def test_get_username_from_basic_auth_header():
+@pytest.mark.parametrize('auth', [
+    # auth type is case in-sensitive
+    'Basic YnJrMHY6',
+    'basic YnJrMHY6',
+    'BASIC YnJrMHY6',
+])
+def test_get_username_from_basic_auth_header(auth):
     request = SimpleNamespace(headers=())
     response = SimpleNamespace(
         status='200', response_length=1024, sent=1024,
@@ -57,7 +65,7 @@ def test_get_username_from_basic_auth_header():
         'REQUEST_METHOD': 'GET', 'RAW_URI': '/my/path?foo=bar',
         'PATH_INFO': '/my/path', 'QUERY_STRING': 'foo=bar',
         'SERVER_PROTOCOL': 'HTTP/1.1',
-        'HTTP_AUTHORIZATION': 'Basic YnJrMHY6',
+        'HTTP_AUTHORIZATION': auth,
     }
     logger = Logger(Config())
     atoms = logger.atoms(response, request, environ, datetime.timedelta(seconds=1))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -29,15 +29,15 @@ def test_parse_address(test_input, expected):
 
 
 def test_parse_address_invalid():
-    with pytest.raises(RuntimeError) as err:
+    with pytest.raises(RuntimeError) as exc_info:
         util.parse_address('127.0.0.1:test')
-    assert "'test' is not a valid port number." in str(err)
+    assert "'test' is not a valid port number." in str(exc_info.value)
 
 
 def test_parse_fd_invalid():
-    with pytest.raises(RuntimeError) as err:
+    with pytest.raises(RuntimeError) as exc_info:
         util.parse_address('fd://asd')
-    assert "'asd' is not a valid file descriptor." in str(err)
+    assert "'asd' is not a valid file descriptor." in str(exc_info.value)
 
 
 def test_http_date():
@@ -63,24 +63,24 @@ def test_warn(capsys):
 def test_import_app():
     assert util.import_app('support:app')
 
-    with pytest.raises(ImportError) as err:
+    with pytest.raises(ImportError) as exc_info:
         util.import_app('a:app')
-    assert 'No module' in str(err)
+    assert 'No module' in str(exc_info.value)
 
-    with pytest.raises(AppImportError) as err:
+    with pytest.raises(AppImportError) as exc_info:
         util.import_app('support:wrong_app')
     msg = "Failed to find application object 'wrong_app' in 'support'"
-    assert msg in str(err)
+    assert msg in str(exc_info.value)
 
 
 def test_to_bytestring():
     assert util.to_bytestring('test_str', 'ascii') == b'test_str'
     assert util.to_bytestring('test_str®') == b'test_str\xc2\xae'
     assert util.to_bytestring(b'byte_test_str') == b'byte_test_str'
-    with pytest.raises(TypeError) as err:
+    with pytest.raises(TypeError) as exc_info:
         util.to_bytestring(100)
     msg = '100 is not a string'
-    assert msg in str(err)
+    assert msg in str(exc_info.value)
 
 
 @pytest.mark.parametrize('test_input, expected', [


### PR DESCRIPTION
According RFC-7617 (inherited from RFC-2978) schema and parameter names are handled
case insensitively:
```
Note that both scheme and parameter names are matched case-
insensitively.
```

Signed-off-by: Martin Bašti <mbasti@redhat.com>