### PR TITLE
Make http request body file-like

### DIFF
--- a/gunicorn/http/body.py
+++ b/gunicorn/http/body.py
@@ -174,10 +174,11 @@ class EOFReader(object):
         return ret
 
 
-class Body(object):
+class Body(io.IOBase):
     def __init__(self, reader):
         self.reader = reader
         self.buf = io.BytesIO()
+        super().__init__()
 
     def __iter__(self):
         return self
@@ -188,6 +189,9 @@ class Body(object):
             raise StopIteration()
         return ret
     next = __next__
+
+    def readable(self):
+        return True
 
     def getsize(self, size):
         if size is None:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -227,3 +227,10 @@ def test_eof_reader_read_invalid_size():
         reader.read([100])
     with pytest.raises(ValueError):
         reader.read(-100)
+
+
+def test_body_is_file_like():
+    body = Body(io.BytesIO(b"abc\ndef\nghij\n"))
+    assert body.readable()
+    assert not body.writable()
+    assert list(io.TextIOWrapper(body)) == ["abc\n", "def\n", "ghij\n"]


### PR DESCRIPTION
When use request body in stream text mode, it should have these methods:

* readable
* writable
* seekable
* closed

ref: https://docs.python.org/3/library/io.html#io.IOBase