### PR TITLE
Add setproctitle to extras_require

### DIFF
--- a/docs/source/custom.rst
+++ b/docs/source/custom.rst
@@ -13,7 +13,8 @@ Here is a small example where we create a very small WSGI app and load it with
 a custom Application:
 
 .. literalinclude:: ../../examples/standalone_app.py
-    :lines: 11-60
+    :start-after: # See the NOTICE for more information
+    :lines: 2-
 
 Direct Usage of Existing WSGI Apps
 ----------------------------------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -52,6 +52,28 @@ want to consider one of the alternate worker types.
     installed, this is the most likely reason.
 
 
+Extra Packages
+==============
+Some Gunicorn options require additional packages. You can use the ``[extra]``
+syntax to install these at the same time as Gunicorn.
+
+Most extra packages are needed for alternate worker types. See the
+`design docs`_ for more information on when you'll want to consider an
+alternate worker type.
+
+* ``gunicorn[eventlet]`` - Eventlet-based greenlets workers
+* ``gunicorn[gevent]`` - Gevent-based greenlets workers
+* ``gunicorn[gthread]`` - Threaded workers
+* ``gunicorn[tornado]`` - Tornado-based workers, not recommended
+
+If you are running more than one instance of Gunicorn, the :ref:`proc-name`
+setting will help distinguish between them in tools like ``ps`` and ``top``.
+
+* ``gunicorn[setproctitle]`` - Enables setting the process name
+
+Multiple extras can be combined, like
+``pip install gunicorn[gevent,setproctitle]``.
+
 Debian GNU/Linux
 ================
 

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ extras_require = {
     'eventlet': ['eventlet>=0.9.7'],
     'tornado': ['tornado>=0.2'],
     'gthread': [],
+    'setproctitle': ['setproctitle'],
 }
 
 setup(


### PR DESCRIPTION
This allows you to specify that you want ``setproctitle`` installed so that ``gunicorn`` can set meaningful process names at install time (``pip install gunicorn[gevent,setproctitle]``) or in a requirements file (``gunicorn[gevent,setproctitle]==19.9.1``). Fixes issue #2085.