### PR TITLE
Use GUNICORN_FD if available

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -147,7 +147,7 @@ class Arbiter(object):
                 fds = range(systemd.SD_LISTEN_FDS_START,
                             systemd.SD_LISTEN_FDS_START + listen_fds)
 
-            elif self.master_pid:
+            elif os.environ.get('GUNICORN_FD', ''):
                 fds = []
                 for fd in os.environ.pop('GUNICORN_FD').split(','):
                     fds.append(int(fd))


### PR DESCRIPTION
What case does gunicorn use `GUNICORN_FD`:

- current code
  - master_pid is not 0
- This PR
- Gunicorn before #1310 (< v19.7.0)
  - `GUNICORN_FD` is set
- Unicorn
  - `UNICORN_FD` is set

I want to use superdaemon like the `start_server`.

- https://metacpan.org/pod/Server::Starter
  - https://www.slideshare.net/kazuho/server-starter-a-superdaemon-to-hotdeploy-server-programs
- https://github.com/lestrrat/go-server-starter (Go port)

`start_server` opens socket, forks gunicorn and set fd of opened socket to `SERVER_STARTER_PORT`. Gunicorn can use fd of socket by setting `GUNICORN_FD` from `SERVER_STARTER_PORT`.

But since #1310 gunicorn does not use `GUNICORN_FD` at first startup (master_pid is 0).

This PR makes gunicorn to use `GUNICORN_FD` if `GUNICORN_FD` is set.
