### PR TITLE
Test under PyPy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
       env: TOXENV=py37
       dist: xenial
       sudo: true
+    - python: pypy3
+      env: TOXENV=pypy3
+      dist: xenial
     - python: 3.8-dev
       env: TOXENV=py38-dev
       dist: xenial

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3 :: Only',
+    'Programming Language :: Python :: Implementation :: CPython',
+    'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Internet',
     'Topic :: Utilities',
     'Topic :: Software Development :: Libraries :: Python Modules',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, py37, py38-dev, pypy, lint
+envlist = py34, py35, py36, py37, py38-dev, pypy3, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
One of the advantages `gunicorn` has is PyPy3 support (see uWSGI issue https://github.com/unbit/uwsgi/issues/869). This PR adds CI testing for PyPy3 so users can be confident that support does not regress.