### PR TITLE
3Reload listeners if ssl configs have changed

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -430,6 +430,8 @@ class Arbiter(object):
 
     def reload(self):
         old_address = self.cfg.address
+        old_ssl_options = self.cfg.ssl_options
+        old_certificate_mtimes = self.cfg.certificate_mtimes
 
         # reset old environment
         for k in self.cfg.env:
@@ -452,7 +454,11 @@ class Arbiter(object):
         self.log.reopen_files()
 
         # do we need to change listener ?
-        if old_address != self.cfg.address:
+        if (
+            old_address != self.cfg.address
+            or old_ssl_options != self.cfg.ssl_options
+            or old_certificate_mtimes != self.cfg.certificate_mtimes
+        ):
             # close all listeners
             for l in self.LISTENERS:
                 l.close()

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -50,6 +50,8 @@ class Config(object):
         self.usage = usage
         self.prog = prog or os.path.basename(sys.argv[0])
         self.env_orig = os.environ.copy()
+        self._certificate_mtimes = {}
+        self._init_certificate_mtimes()
 
     def __getattr__(self, name):
         if name not in self.settings:
@@ -167,6 +169,18 @@ class Config(object):
             if value.section == 'SSL':
                 opts[name] = value.get()
         return opts
+
+    def _init_certificate_mtimes(self):
+        for name in ('certfile', 'keyfile', 'ca_certs'):
+            mtime = 0
+            setting = self.settings[name].get()
+            if setting:
+                mtime = os.path.getmtime(setting)
+            self._certificate_mtimes[name] = mtime
+
+    @property
+    def certificate_mtimes(self):
+        return self._certificate_mtimes
 
     @property
     def env(self):


### PR DESCRIPTION
Hi! 

I'm doing some work with certificate rotation, and it would be useful to be able to reload gunicorn when ssl configurations have changed.

The more interesting part is reloading gunicorn if the contents of the various certificate files have changed. This allows us to automate the process of certificate rotation - we have a separate process that creates new certificate bundles and puts them in a standard location and then signals other applications to reload them.

Let me know what you think?