### PR TITLE
Dual http https

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -119,6 +119,11 @@ class Config(object):
         return [util.parse_address(util.bytes_to_str(bind)) for bind in s]
 
     @property
+    def no_ssl_address(self):
+        s = self.settings['bind_no_ssl'].get()
+        return [util.parse_address(util.bytes_to_str(bind)) for bind in s]
+
+    @property
     def uid(self):
         return self.settings['user'].get()
 
@@ -570,6 +575,20 @@ class Bind(Setting):
         will bind the `test:app` application on localhost both on ipv6
         and ipv4 interfaces.
         """
+
+
+class BindNoSSL(Setting):
+    name = "bind_no_ssl"
+    action = "append"
+    section = "Server Socket"
+    cli = ["--bind-no-ssl"]
+    meta = "ADDRESS"
+    validator = validate_list_string
+    default = None
+
+    desc = """\
+        TODO
+    """
 
 
 class Backlog(Setting):

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -584,7 +584,7 @@ class BindNoSSL(Setting):
     cli = ["--bind-no-ssl"]
     meta = "ADDRESS"
     validator = validate_list_string
-    default = None
+    default = []
 
     desc = """\
         TODO

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -42,7 +42,8 @@ class Worker(object):
         self.age = age
         self.pid = "[booting]"
         self.ppid = ppid
-        self.sockets = sockets
+        self.sockets = [s for s , _ in sockets]
+        self.socket_ssl_mapping = {s: is_ssl for s, is_ssl in sockets}
         self.app = app
         self.timeout = timeout
         self.cfg = cfg

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -31,10 +31,10 @@ def test_arbiter_stop_closes_listeners(close_sockets):
     arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
     listener1 = mock.Mock()
     listener2 = mock.Mock()
-    listeners = [listener1, listener2]
+    listeners = [(listener1, False), (listener2, False)]
     arbiter.LISTENERS = listeners
     arbiter.stop()
-    close_sockets.assert_called_with(listeners, True)
+    close_sockets.assert_called_with([x for x, _ in listeners], True)
 
 
 @mock.patch('gunicorn.sock.close_sockets')
@@ -75,7 +75,7 @@ def test_arbiter_stop_does_not_unlink_when_using_reuse_port(close_sockets):
 @mock.patch('os.execvpe')
 def test_arbiter_reexec_passing_systemd_sockets(execvpe, fork, getpid):
     arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
-    arbiter.LISTENERS = [mock.Mock(), mock.Mock()]
+    arbiter.LISTENERS = [(mock.Mock(), False), (mock.Mock(), False)]
     arbiter.systemd = True
     fork.return_value = 0
     getpid.side_effect = [2, 3]
@@ -95,7 +95,7 @@ def test_arbiter_reexec_passing_gunicorn_sockets(execvpe, fork, getpid):
     listener2 = mock.Mock()
     listener1.fileno.return_value = 4
     listener2.fileno.return_value = 5
-    arbiter.LISTENERS = [listener1, listener2]
+    arbiter.LISTENERS = [(listener1, False), (listener2, False)]
     fork.return_value = 0
     getpid.side_effect = [2, 3]
     arbiter.reexec()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,7 +54,9 @@ class NoConfigApp(Application):
 def test_defaults():
     c = config.Config()
     for s in config.KNOWN_SETTINGS:
-        assert c.settings[s.name].validator(s.default) == c.settings[s.name].get()
+        expected = c.settings[s.name].validator(s.default)
+        got = c.settings[s.name].get()
+        assert expected == got, '%r == %r' % (expected, got)
 
 
 def test_property_access():


### PR DESCRIPTION
This takes a stab at solving #1466. It would be beneficial for some work I'm involved in where we need to convert all our apps to https communication, and would like to avoid adding technologies (nginx in front of the app, running two separate application pools, etc). 

*It doesn't quite work yet*, but I wanted to ask for an earlier look at methodology and implementation.

The idea is that there's a new flag `--bind-no-ssl` where, regardless of other configurations, ssl settings will not be applied. I chose to go this route to minimize compatibility problems.

Some examples:

* `gunicorn --bind-no-ssl 127.0.0.1:8001`: 
    Works the same as `gunicorn --bind 127.0.0.1:8001`

* `gunicorn --bind 127.0.0.1:8001 --bind-no-ssl 127.0.0.1:8002`: 
    Works the same as `gunicorn --bind 127.0.0.1:8001 --bind 127.0.0.1:8002`

* `gunicorn --certfile ./mycert --keyfile ./mykey --bind 127.0.0.1:8001 --bind-no-ssl 127.0.0.1:8002`: 
    Serves on https://127.0.0.1:8001 and http://127.0.0.1:8002