### PR TITLE
Ensure header value is string before conducting regex search.

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -253,7 +253,8 @@ class Response(object):
             if HEADER_RE.search(name):
                 raise InvalidHeaderName('%r' % name)
 
-            value = str(value)
+            if not isinstance(value, str):
+                raise TypeError('%r is not a string' % value)
 
             if HEADER_VALUE_RE.search(value):
                 raise InvalidHeader('%r' % value)

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -253,10 +253,12 @@ class Response(object):
             if HEADER_RE.search(name):
                 raise InvalidHeaderName('%r' % name)
 
+            value = str(value)
+
             if HEADER_VALUE_RE.search(value):
                 raise InvalidHeader('%r' % value)
 
-            value = str(value).strip()
+            value = value.strip()
             lname = name.lower().strip()
             if lname == "content-length":
                 self.response_length = int(value)


### PR DESCRIPTION
When integrating with WebApp2 3.0.0b1 (latest, Python 3) and WebOb 1.8.5 (latest), header value was being passed as byte string and resulted in the exception: "TypeError: cannot use a string pattern on a bytes-like object". Regex search fails due to this value. Current gunicorn implementation parses the value as string, but only after regex search. Changing the casting of value to string before regex search ensures this exception will not occur. This change fixes integration with these libraries.