### PR TITLE
Fixeds #2130

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -163,6 +163,7 @@ Stephen DiCato <Locker537@gmail.com>
 Stephen Holsapple <sholsapp@gmail.com>
 Steven Cummings <estebistec@gmail.com>
 Sébastien Fievet <zyegfryed@gmail.com>
+Talha Malik <talham7391@hotmail.com>
 TedWantsMore <TedWantsMore@gmx.com>
 Thomas Grainger <tagrain@gmail.com>
 Thomas Steinacher <tom@eggdrop.ch>

--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -58,7 +58,7 @@ class Reloader(threading.Thread):
 has_inotify = False
 if sys.platform.startswith('linux'):
     try:
-        from inotify.adapters import Inotify
+        from inotify.adapters import InotifyTrees
         import inotify.constants
         has_inotify = True
     except ImportError:
@@ -78,7 +78,7 @@ if has_inotify:
             self.setDaemon(True)
             self._callback = callback
             self._dirs = set()
-            self._watcher = Inotify()
+            self._watcher = InotifyTrees(mask=self.event_mask)
 
             for extra_file in extra_files:
                 self.add_extra_file(extra_file)
@@ -89,7 +89,7 @@ if has_inotify:
             if dirname in self._dirs:
                 return
 
-            self._watcher.add_watch(dirname, mask=self.event_mask)
+            self._watcher.__load_trees([dirname])
             self._dirs.add(dirname)
 
         def get_dirs(self):
@@ -105,7 +105,7 @@ if has_inotify:
             self._dirs = self.get_dirs()
 
             for dirname in self._dirs:
-                self._watcher.add_watch(dirname, mask=self.event_mask)
+                self._watcher.__load_trees(dirname)
 
             for event in self._watcher.event_gen():
                 if event is None:


### PR DESCRIPTION
When gunicorn is configured to reload using polling, it will recognize any changes in nested folders of the directories being watched. When gunicorn is configured to use inotify as the reloader, it does not reload when there are changes in nested folders. 

This PR configures `InotifyReloader` to reload on nested folder changes to match the default polling behaviour.