### PR TITLE
Start the reloader after the wsgi app has been loaded.

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -163,6 +163,7 @@ Stephen DiCato <Locker537@gmail.com>
 Stephen Holsapple <sholsapp@gmail.com>
 Steven Cummings <estebistec@gmail.com>
 Sébastien Fievet <zyegfryed@gmail.com>
+Talha Malik <talham7391@hotmail.com>
 TedWantsMore <TedWantsMore@gmx.com>
 Thomas Grainger <tagrain@gmail.com>
 Thomas Steinacher <tom@eggdrop.ch>

--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -19,13 +19,11 @@ class Reloader(threading.Thread):
         super().__init__()
         self.setDaemon(True)
         self._extra_files = set(extra_files or ())
-        self._extra_files_lock = threading.RLock()
         self._interval = interval
         self._callback = callback
 
     def add_extra_file(self, filename):
-        with self._extra_files_lock:
-            self._extra_files.add(filename)
+        self._extra_files.add(filename)
 
     def get_files(self):
         fnames = [
@@ -34,8 +32,7 @@ class Reloader(threading.Thread):
             if getattr(module, '__file__', None)
         ]
 
-        with self._extra_files_lock:
-            fnames.extend(self._extra_files)
+        fnames.extend(self._extra_files)
 
         return fnames
 

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -116,6 +116,8 @@ class Worker(object):
 
         self.init_signals()
 
+        self.load_wsgi()
+
         # start the reloader
         if self.cfg.reload:
             def changed(fname):
@@ -130,7 +132,6 @@ class Worker(object):
                                          callback=changed)
             self.reloader.start()
 
-        self.load_wsgi()
         self.cfg.post_worker_init(self)
 
         # Enter main run loop


### PR DESCRIPTION
When launching Gunicorn with the `--reload` option, workers will start the Reloader and then load the wsgi app. This is problematic because user files are loaded when the wsgi app is loaded, and the reloader depends on the user files to be loaded so that it can watch them.

So when the Reloader starts, it isn't watching any user files. This isn't an issue when using the default polling reloader as it updates what files it is watching every time it polls but this is an issue with the inotify reloader.

This PR makes sure the reloader is started after wsgi app has been loaded so that the InotifyReloader is able to pickup and watch the proper files/folders.