### PR TITLE
Capture os.sendfile before patching in gevent and eventlet workers.

### DIFF
--- a/gunicorn/workers/geventlet.py
+++ b/gunicorn/workers/geventlet.py
@@ -26,10 +26,10 @@ import greenlet
 from gunicorn.workers.base_async import AsyncWorker
 
 
-def _eventlet_sendfile(fdout, fdin, offset, nbytes):
+def _eventlet_sendfile(fdout, fdin, offset, nbytes, _os_sendfile=os.sendfile):
     while True:
         try:
-            return os.sendfile(fdout, fdin, offset, nbytes)
+            return _os_sendfile(fdout, fdin, offset, nbytes)
         except OSError as e:
             if e.args[0] == errno.EAGAIN:
                 trampoline(fdout, write=True)

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -30,10 +30,10 @@ from gunicorn.workers.base_async import AsyncWorker
 VERSION = "gevent/%s gunicorn/%s" % (gevent.__version__, gunicorn.__version__)
 
 
-def _gevent_sendfile(fdout, fdin, offset, nbytes):
+def _gevent_sendfile(fdout, fdin, offset, nbytes, _os_sendfile=os.sendfile):
     while True:
         try:
-            return os.sendfile(fdout, fdin, offset, nbytes)
+            return _os_sendfile(fdout, fdin, offset, nbytes)
         except OSError as e:
             if e.args[0] == errno.EAGAIN:
                 socket.wait_write(fdout)


### PR DESCRIPTION
Fixes #1925 and fixes #2170.

This is one possible way to do it.