### PR TITLE
load application from factory function

### DIFF
--- a/docs/source/run.rst
+++ b/docs/source/run.rst
@@ -44,8 +44,29 @@ Example with the test app:
 
 You can now run the app with the following command::
 
+.. code-block:: text
+
     $ gunicorn --workers=2 test:app
 
+The variable name can also be a function call. In that case the name
+will be imported from the module, then called to get the application
+object. This is commonly referred to as the "application factory"
+pattern.
+
+.. code-block:: python
+
+    def create_app():
+        app = FrameworkApp()
+        ...
+        return app
+
+.. code-block:: text
+
+    $ gunicorn --workers=2 'test:create_app()'
+
+Positional and keyword arguments can also be passed, but it is
+recommended to load configuration from environment variables rather than
+the command line.
 
 Commonly Used Arguments
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -2,7 +2,7 @@
 #
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
-
+import ast
 import email.utils
 import errno
 import fcntl
@@ -320,6 +320,32 @@ def write_error(sock, status_int, reason, mesg):
     write_nonblock(sock, http.encode('latin1'))
 
 
+def _called_with_wrong_args(f):
+    """Check whether calling a function raised a ``TypeError`` because
+    the call failed or because something in the function raised the
+    error.
+
+    :param f: The function that was called.
+    :return: ``True`` if the call failed.
+    """
+    tb = sys.exc_info()[2]
+
+    try:
+        while tb is not None:
+            if tb.tb_frame.f_code is f.__code__:
+                # In the function, it was called successfully.
+                return False
+
+            tb = tb.tb_next
+
+        # Didn't reach the function.
+        return True
+    finally:
+        # Delete tb to break a circular reference in Python 2.
+        # https://docs.python.org/2/library/sys.html#sys.exc_info
+        del tb
+
+
 def import_app(module):
     parts = module.split(":", 1)
     if len(parts) == 1:
@@ -335,13 +361,65 @@ def import_app(module):
             raise ImportError(msg % (module.rsplit(".", 1)[0], obj))
         raise
 
+    # Parse obj as a single expression to determine if it's a valid
+    # attribute name or function call.
+    try:
+        expression = ast.parse(obj, mode="eval").body
+    except SyntaxError:
+        raise AppImportError(
+            "Failed to parse %r as an attribute name or function call." % obj
+        )
+
+    if isinstance(expression, ast.Name):
+        name = expression.id
+        args = kwargs = None
+    elif isinstance(expression, ast.Call):
+        # Ensure the function name is an attribute name only.
+        if not isinstance(expression.func, ast.Name):
+            raise AppImportError("Function reference must be a simple name: %r" % obj)
+
+        name = expression.func.id
+
+        # Parse the positional and keyword arguments as literals.
+        try:
+            args = [ast.literal_eval(arg) for arg in expression.args]
+            kwargs = {kw.arg: ast.literal_eval(kw.value) for kw in expression.keywords}
+        except ValueError:
+            # literal_eval gives cryptic error messages, show a generic
+            # message with the full expression instead.
+            raise AppImportError(
+                "Failed to parse arguments as literal values: %r" % obj
+            )
+    else:
+        raise AppImportError(
+            "Failed to parse %r as an attribute name or function call." % obj
+        )
+
     is_debug = logging.root.level == logging.DEBUG
     try:
-        app = getattr(mod, obj)
+        app = getattr(mod, name)
     except AttributeError:
         if is_debug:
             traceback.print_exception(*sys.exc_info())
-        raise AppImportError("Failed to find application object %r in %r" % (obj, module))
+        raise AppImportError("Failed to find attribute %r in %r." % (name, module))
+
+    # If the expression was a function call, call the retrieved object
+    # to get the real application.
+    if args is not None:
+        try:
+            app = app(*args, **kwargs)
+        except TypeError as e:
+            # If the TypeError was due to bad arguments to the factory
+            # function, show Python's nice error message without a
+            # traceback.
+            if _called_with_wrong_args(app):
+                raise AppImportError(
+                    "".join(traceback.format_exception_only(TypeError, e)).strip()
+                )
+
+            # Otherwise it was raised from within the function, show the
+            # full traceback.
+            raise
 
     if app is None:
         raise AppImportError("Failed to find application object: %r" % obj)

--- a/tests/support.py
+++ b/tests/support.py
@@ -7,19 +7,32 @@ from wsgiref.validate import validator
 HOST = "127.0.0.1"
 
 
-@validator
-def app(environ, start_response):
-    """Simplest possible application object"""
+def create_app(name="World", count=1):
+    message = (('Hello, %s!\n' % name) * count).encode("utf8")
+    length = str(len(message))
 
-    data = b'Hello, World!\n'
-    status = '200 OK'
+    @validator
+    def app(environ, start_response):
+        """Simplest possible application object"""
 
-    response_headers = [
-        ('Content-type', 'text/plain'),
-        ('Content-Length', str(len(data))),
-    ]
-    start_response(status, response_headers)
-    return iter([data])
+        status = '200 OK'
+
+        response_headers = [
+            ('Content-type', 'text/plain'),
+            ('Content-Length', length),
+        ]
+        start_response(status, response_headers)
+        return iter([message])
+
+    return app
+
+
+app = application = create_app()
+none_app = None
+
+
+def error_factory():
+    raise TypeError("inner")
 
 
 def requires_mac_ver(*min_version):


### PR DESCRIPTION
Use `ast.parse` to validate that the string passed to the CLI is either an attribute name or a function call. Use `ast.literal_eval` to parse positional and keyword arguments to the function. Call the function to get the real application.

fixes #2159 

Todo:

- [x] tests
- [x] docs
- [ ] changelog