### PR TITLE
Fix for #2184 solaris erroring out on getsockopt

### DIFF
--- a/gunicorn/socketfromfd.py
+++ b/gunicorn/socketfromfd.py
@@ -10,6 +10,8 @@ import ctypes
 import os
 import socket
 import sys
+import platform
+
 from ctypes.util import find_library
 
 __all__ = ('fromfd',)
@@ -34,8 +36,10 @@ def _errcheck_errno(result, func, arguments):
         raise OSError(errno, os.strerror(errno))
     return arguments
 
-
-_libc_getsockopt = libc.getsockopt
+if platform.system() == 'SunOS':
+    _libc_getsockopt = libc._so_getsockopt
+else:
+    _libc_getsockopt = libc.getsockopt
 _libc_getsockopt.argtypes = [
     ctypes.c_int,  # int sockfd
     ctypes.c_int,  # int level


### PR DESCRIPTION
This patches the `fromfd` code in `socketfromfd` by grabbing the correct symbol under SmartOS (SunOS).  

The patch is pretty straightforward, basically switching on the OS to determine what the symbol is likely to be.  If need be, I could put a try block around the original libc.getsockopt and then fall back to looking for `_so_getsockopt`, if that's preferred in this codebase. 
