### PR TITLE
fix wsgi.input_terminated

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -33,6 +33,7 @@ class Message(object):
         self.version = None
         self.headers = []
         self.trailers = []
+        self.terminated = True
         self.body = None
         self.scheme = "https" if cfg.is_ssl else "http"
 
@@ -151,6 +152,7 @@ class Message(object):
             if content_length < 0:
                 raise InvalidHeader("CONTENT-LENGTH", req=self)
 
+            self.terminated = False
             self.body = Body(LengthReader(self.unreader, content_length))
         else:
             self.body = Body(EOFReader(self.unreader))

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -82,6 +82,7 @@ def default_environ(req, sock, cfg):
     env = base_environ(cfg)
     env.update({
         "wsgi.input": req.body,
+        "wsgi.input_terminated": req.terminated,
         "gunicorn.socket": sock,
         "REQUEST_METHOD": req.method,
         "QUERY_STRING": req.query,
@@ -131,7 +132,6 @@ def create(req, sock, client, server, cfg):
             continue
         elif hdr_name == "CONTENT-LENGTH":
             environ['CONTENT_LENGTH'] = hdr_value
-            environ['wsgi.input_terminated'] = False
             continue
 
         key = 'HTTP_' + hdr_name.replace('-', '_')


### PR DESCRIPTION
Sometimes both TRANSFER-ENCODING=chunked and CONTENT_LENGTH are set. Since gunicorn prioritise (following the HTTP1.1 spec) chunked encoding we should make sure in this case to signal to th application that the input is terminated by the server.

Without the change gunicorn were always setting wsg.input_terminated to False when a CONTENT_LENGTH header was present ignoring that Gunicorn was afaik handling the termination.