### PR TITLE
fix attributes when importing config module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
       env: TOXENV=lint
       dist: xenial
       sudo: true
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ The documentation is hosted at http://docs.gunicorn.org.
 Installation
 ------------
 
-Gunicorn requires **Python 3.x >= 3.4**.
+Gunicorn requires **Python 3.x >= 3.5**.
 
 Install from PyPI::
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ Features
 * Simple Python configuration
 * Multiple worker configurations
 * Various server hooks for extensibility
-* Compatible with Python 3.x >= 3.4
+* Compatible with Python 3.x >= 3.5
 
 
 Contents

--- a/gunicorn/__init__.py
+++ b/gunicorn/__init__.py
@@ -3,6 +3,6 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
-version_info = (20, 0, 0)
+version_info = (20, 0, 1)
 __version__ = ".".join([str(v) for v in version_info])
 SERVER_SOFTWARE = "gunicorn/%s" % __version__

--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -6,7 +6,6 @@ import importlib.util
 import os
 import sys
 import traceback
-import types
 
 from gunicorn import util
 from gunicorn.arbiter import Arbiter

--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -2,7 +2,7 @@
 #
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
-import importlib.machinery
+import importlib.util
 import os
 import sys
 import traceback
@@ -97,9 +97,10 @@ class Application(BaseApplication):
 
         try:
             module_name = '__config__'
-            mod = types.ModuleType(module_name)
-            loader = importlib.machinery.SourceFileLoader(module_name, filename)
-            loader.exec_module(mod)
+            spec = importlib.util.spec_from_file_location(module_name, filename)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = mod
+            spec.loader.exec_module(mod)
         except Exception:
             print("Failed to read config file: %s" % filename, file=sys.stderr)
             traceback.print_exc()

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ CLASSIFIERS = [
     'Operating System :: POSIX',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, py37, py38, pypy3, lint
+envlist = py35, py36, py37, py38, pypy3, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
current import of the config module doesn't add the `__file__` attribute to the imported module. 

Fix is done by loading the module as suggested in the Python docs winds up setting __file__ as expected (https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly).

Since this change only work on Python >= 3.5 and Python 3.4 is unsupported we also remove its support.

fix #2182 

