### PR TITLE
config file extension should be a python extension

### DIFF
--- a/docs/source/configure.rst
+++ b/docs/source/configure.rst
@@ -53,9 +53,9 @@ Configuration File
 
 The configuration file should be a valid Python source file with a **python
 extension** (e.g. `gunicorn.conf.py`). It only needs to be readable from the
-file system. More specifically, it does not need to be importable. Any Python
-is valid. Just consider that this will be run every time you start Gunicorn
-(including when you signal Gunicorn to reload).
+file system. More specifically, it does not have to be on the module path
+(sys.path, PYTHONPATH). Any Python is valid. Just consider that this will be
+run every time you start Gunicorn (including when you signal Gunicorn to reload).
 
 To set a parameter, just assign to it. There's no special syntax. The values
 you provide will be used for the configuration values.

--- a/docs/source/configure.rst
+++ b/docs/source/configure.rst
@@ -51,10 +51,11 @@ isn't mentioned in the list of :ref:`settings <settings>`.
 Configuration File
 ==================
 
-The configuration file should be a valid Python source file. It only needs to
-be readable from the file system. More specifically, it does not need to be
-importable. Any Python is valid. Just consider that this will be run every time
-you start Gunicorn (including when you signal Gunicorn to reload).
+The configuration file should be a valid Python source file with a **python
+extension** (e.g. `gunicorn.conf.py`). It only needs to be readable from the
+file system. More specifically, it does not need to be importable. Any Python
+is valid. Just consider that this will be run every time you start Gunicorn
+(including when you signal Gunicorn to reload).
 
 To set a parameter, just assign to it. There's no special syntax. The values
 you provide will be used for the configuration values.

--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -3,6 +3,7 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 import importlib.util
+import importlib.machinery
 import os
 import sys
 import traceback
@@ -94,9 +95,17 @@ class Application(BaseApplication):
         if not os.path.exists(filename):
             raise RuntimeError("%r doesn't exist" % filename)
 
+        ext = os.path.splitext(filename)[1]
+
         try:
             module_name = '__config__'
-            spec = importlib.util.spec_from_file_location(module_name, filename)
+            if ext in [".py", ".pyc"]:
+                spec = importlib.util.spec_from_file_location(module_name, filename)
+            else:
+                msg = "configuration file should have a valid Python extension.\n"
+                util.warn(msg)
+                loader_ = importlib.machinery.SourceFileLoader(module_name, filename)
+                spec = importlib.util.spec_from_file_location(module_name, filename, loader=loader_)
             mod = importlib.util.module_from_spec(spec)
             sys.modules[module_name] = mod
             spec.loader.exec_module(mod)


### PR DESCRIPTION
This change make it clear what is configuration file for Gunicorn.
Using a filename with an extension different than a python extension
was never supported. Also it gives us some room for a proper config file.

fix #2198 