### PR TITLE
added the parameter 'min_requests_jitter' in order to overwrite the d…

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -716,6 +716,23 @@ class MaxRequests(Setting):
         restarts are disabled.
         """
 
+class MinRequestsJitter(Setting):
+    name = "min_requests_jitter"
+    section = "Worker Processes"
+    cli = ["--min-requests-jitter"]
+    meta = "INT"
+    validator = validate_pos_int
+    type = int
+    default = 0
+    desc = """\
+        The minimum jitter to add to the *max_requests* setting.
+
+        The jitter causes the restart per worker to be randomized by
+        ``randint(minimum_requests_jitter, max_requests_jitter)``. This is intended to stagger worker
+        restarts to avoid all workers restarting at the same time.
+
+        Minimum_requests_jitter can optionally be used if the default (0) should be overwritten.
+        """
 
 class MaxRequestsJitter(Setting):
     name = "max_requests_jitter"

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -53,7 +53,7 @@ class Worker(object):
         self.nr = 0
 
         if cfg.max_requests > 0:
-            jitter = randint(0, cfg.max_requests_jitter)
+            jitter = randint(cfg.min_requests_jitter, cfg.max_requests_jitter)
             self.max_requests = cfg.max_requests + jitter
         else:
             self.max_requests = sys.maxsize


### PR DESCRIPTION
**The parameter I've added is supposed to only be optional even when using "max_requests_jitter".**

added the parameter 'min_requests_jitter' in order to overwrite the default (0) in 'jitter = randint(0, cfg.max_requests_jitter)'

**First of all many many thanks for your efforts!!!**

I have a python-flask app that takes ~8min to start-up (reading large files and allocating contiguous memory, etc.) and have several (e.g. 3) workers. Workers should re-spawn after "max_requests" + "jitter". But there can be situations when "lots of requests" go to gunicorn, and all workers reach their max_requests in a short amount of time. Which causes one after the other to re-spawn, but they are not fast enough (due to long start-up) and therefore there will be down-time in which requests are not answered until the workers are up again. This new parameter would enable me to set 
e.g.
max_requests = 10000 
min_requests_jitter = 5000
max_requests_jitter = 50000
which would give a process enough time to be ready in time. I can of course set "max_request" and "max_requests_jitter" to very high values without "min_requests_jitter" but then there could still be a situation where "randint" picks a small number and the issue described above occurs. 


Please let me know if I've missed a setting that would take care of this situation otherwise. 

Kind regards,
David