### PR TITLE
Add milliseconds option to request_time in access_log

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -178,6 +178,7 @@ b            response length or ``'-'`` (CLF format)
 f            referer
 a            user agent
 T            request time in seconds
+M            request time in milliseconds
 D            request time in microseconds
 L            request time in decimal seconds
 p            process ID

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1266,6 +1266,7 @@ class AccessLogFormat(Setting):
         f            referer
         a            user agent
         T            request time in seconds
+        M            request time in milliseconds
         D            request time in microseconds
         L            request time in decimal seconds
         p            process ID

--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -299,7 +299,7 @@ class Logger(object):
             'a': environ.get('HTTP_USER_AGENT', '-'),
             'T': request_time.seconds,
             'D': (request_time.seconds * 1000000) + request_time.microseconds,
-            'M': (request_time.seconds*1000) + int(request_time.microseconds/1000),
+            'M': (request_time.seconds * 1000) + int(request_time.microseconds/1000),
             'L': "%d.%06d" % (request_time.seconds, request_time.microseconds),
             'p': "<%s>" % os.getpid()
         }

--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -296,6 +296,7 @@ class Logger(object):
             'a': environ.get('HTTP_USER_AGENT', '-'),
             'T': request_time.seconds,
             'D': (request_time.seconds*1000000) + request_time.microseconds,
+            'M': (request_time.seconds*1000) + int(request_time.microseconds/1000),
             'L': "%d.%06d" % (request_time.seconds, request_time.microseconds),
             'p': "<%s>" % os.getpid()
         }


### PR DESCRIPTION
I tested this code locally in my docker container and this is a sample output:

`ResponseTime:1|ResponseTime:1137|ResponseTime:1137324`

to this access_log_format:

`ResponseTime:%(T)s|ResponseTime:%(M)s|ResponseTime:%(D)s`