### PR TITLE
Fix sample command syntax highlighting in run.rst

### DIFF
--- a/docs/source/run.rst
+++ b/docs/source/run.rst
@@ -42,7 +42,7 @@ Example with the test app:
         start_response(status, response_headers)
         return iter([data])
 
-You can now run the app with the following command::
+You can now run the app with the following command:
 
 .. code-block:: text
 


### PR DESCRIPTION
Extra `:` was causing the syntax highlighting to mess up, resulting in the docs containing the `..code-block:: text` markup. Fix it by removing the offending colon

![Screenshot from 2019-12-13 15-00-45](https://user-images.githubusercontent.com/362769/70828459-65a9bf00-1db9-11ea-9709-b6e649a23b77.png)
