### PR TITLE
add os.path.abspath() in dirname generation of the reloader

### DIFF
--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -92,7 +92,7 @@ if has_inotify:
 
         def get_dirs(self):
             fnames = [
-                os.path.dirname(COMPILED_EXT_RE.sub('py', module.__file__))
+                os.path.dirname(os.path.abspath(COMPILED_EXT_RE.sub('py', module.__file__)))
                 for module in tuple(sys.modules.values())
                 if getattr(module, '__file__', None)
             ]


### PR DESCRIPTION
I ran into an error when running gunicorn with the reload option. 
When debugging it appeared that it was caused by a file that was caused in the working dir of gunicorn.

With the previous code, adding a watcher for a file located in the working directory generates an empty dirname, resulting in the following error:
```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.8/site-packages/gunicorn/reloader.py", line 105, in run
    self._watcher.add_watch(dirname, mask=self.event_mask)
  File "/usr/lib/python3.8/site-packages/inotify/adapters.py", line 98, in add_watch
    wd = inotify.calls.inotify_add_watch(self.__inotify_fd, path_bytes, mask)
  File "/usr/lib/python3.8/site-packages/inotify/calls.py", line 34, in _check_nonnegative
    raise InotifyError("Call failed (should not be -1): (%d)" % 
inotify.calls.InotifyError: Call failed (should not be -1): (-1) ERRNO=(0)

```
Caused by the fact that we call inotify with an empty path.
adding `os.path.abspath()` in the script seems legitimate and solves the issue.
