### PR TITLE
Don't build universal wheel, as Python 2 support has been removed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,5 @@ norecursedirs = examples lib local src
 testpaths = tests/
 addopts = --assert=plain --cov=gunicorn --cov-report=xml
 
-[wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE


### PR DESCRIPTION
Since Python 2 support has been dropped, we should no longer build and publish a universal py2/py3 wheel.

Note that this will change the wheel filename, and the new filename will by-default change from:

`gunicorn-20.0.4-py2.py3-none-any.whl`

to

- `gunicorn-20.0.4-cp35-none-any.whl` if built with current oldest-supported cpython
- `gunicorn-20.0.4-cp38-none-any.whl` if built with the current and supported latest cpython

So if there are any known dependencies on the wheel filename (shouldn't be), then we should be aware of that.  Probably not release-note worthy?

This reverts commit 765b8ab48b6fb991eeb9bcf4f60c0cba6f48359f .