### PR TITLE
Updated requires Python to >= 3.5

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -4,7 +4,7 @@ Installation
 
 .. highlight:: bash
 
-:Requirements: **Python 3.x >= 3.4**
+:Requirements: **Python 3.x >= 3.5**
 
 To install the latest released version of Gunicorn::
 


### PR DESCRIPTION
This might be the final legit 3.4->3.5 mention update.  There's a 3.4 in the `docs` build requirements readme, but docs can still be built with 3.4 if you really want to ... maybe we should bump that anyway.