### PR TITLE
remove version from the Server header

### DIFF
--- a/gunicorn/__init__.py
+++ b/gunicorn/__init__.py
@@ -5,4 +5,4 @@
 
 version_info = (20, 0, 4)
 __version__ = ".".join([str(v) for v in version_info])
-SERVER_SOFTWARE = "gunicorn/%s" % __version__
+SERVER_SOFTWARE = "gunicorn"

--- a/gunicorn/__init__.py
+++ b/gunicorn/__init__.py
@@ -7,4 +7,3 @@ version_info = (20, 0, 4)
 __version__ = ".".join([str(v) for v in version_info])
 SERVER = "gunicorn"
 SERVER_SOFTWARE = "%s/%s" % (SERVER, __version__)
-

--- a/gunicorn/__init__.py
+++ b/gunicorn/__init__.py
@@ -5,4 +5,6 @@
 
 version_info = (20, 0, 4)
 __version__ = ".".join([str(v) for v in version_info])
-SERVER_SOFTWARE = "gunicorn"
+SERVER = "gunicorn"
+SERVER_SOFTWARE = "%s/%s" % (SERVER, __version__)
+

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -11,7 +11,7 @@ import sys
 
 from gunicorn.http.message import HEADER_RE
 from gunicorn.http.errors import InvalidHeader, InvalidHeaderName
-from gunicorn import SERVER_SOFTWARE
+from gunicorn import SERVER_SOFTWARE, SERVER
 import gunicorn.util as util
 
 # Send files in at most 1GB blocks as some operating systems can have problems
@@ -195,7 +195,7 @@ class Response(object):
     def __init__(self, req, sock, cfg):
         self.req = req
         self.sock = sock
-        self.version = SERVER_SOFTWARE
+        self.version = SERVER
         self.status = None
         self.chunked = False
         self.must_close = False


### PR DESCRIPTION
while we still want to know which server is running to ease operation, the version was giving too much information on the installation, so let's remove it.