### PR TITLE
Issue 2244

### DIFF
--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -104,7 +104,8 @@ if has_inotify:
             self._dirs = self.get_dirs()
 
             for dirname in self._dirs:
-                self._watcher.add_watch(dirname, mask=self.event_mask)
+                if os.path.isdir(dirname):
+                    self._watcher.add_watch(dirname, mask=self.event_mask)
 
             for event in self._watcher.event_gen():
                 if event is None:

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -117,8 +117,6 @@ class Worker(object):
 
         self.init_signals()
 
-        self.load_wsgi()
-
         # start the reloader
         if self.cfg.reload:
             def changed(fname):
@@ -132,6 +130,9 @@ class Worker(object):
             reloader_cls = reloader_engines[self.cfg.reload_engine]
             self.reloader = reloader_cls(extra_files=self.cfg.reload_extra_files,
                                          callback=changed)
+
+        self.load_wsgi()
+        if self.reloader:
             self.reloader.start()
 
         self.cfg.post_worker_init(self)

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -1,0 +1,68 @@
+import unittest.mock as mock
+
+from gunicorn.app.base import Application
+from gunicorn.workers.base import Worker
+from gunicorn.reloader import reloader_engines
+
+
+class ReloadApp(Application):
+    def __init__(self):
+        super().__init__("no usage", prog="gunicorn_test")
+
+    def do_load_config(self):
+        self.load_default_config()
+        self.cfg.set('reload', True)
+        self.cfg.set('reload_engine', 'poll')
+
+
+class SyntaxErrorApp(ReloadApp):
+    def wsgi(self):
+        error = SyntaxError('invalid syntax')
+        error.filename = 'syntax_error_filename'
+        raise error
+
+
+class MyWorker(Worker):
+    def run(self):
+        pass
+
+
+def test_reload_on_syntax_error():
+    """
+    Test that reloading works if the application has a syntax error.
+    """
+    reloader = mock.Mock()
+    reloader_engines['poll'] = lambda *args, **kw: reloader
+
+    app = SyntaxErrorApp()
+    cfg = app.cfg
+    log = mock.Mock()
+    worker = MyWorker(age=0, ppid=0, sockets=[], app=app, timeout=0, cfg=cfg, log=log)
+
+    worker.init_process()
+    reloader.start.assert_called_with()
+    reloader.add_extra_file.assert_called_with('syntax_error_filename')
+
+
+def test_start_reloader_after_load_wsgi():
+    """
+    Check that the reloader is started after the wsgi app has been loaded.
+    """
+    reloader = mock.Mock()
+    reloader_engines['poll'] = lambda *args, **kw: reloader
+
+    app = ReloadApp()
+    cfg = app.cfg
+    log = mock.Mock()
+    worker = MyWorker(age=0, ppid=0, sockets=[], app=app, timeout=0, cfg=cfg, log=log)
+
+    worker.load_wsgi = mock.Mock()
+    mock_parent = mock.Mock()
+    mock_parent.attach_mock(worker.load_wsgi, 'load_wsgi')
+    mock_parent.attach_mock(reloader.start, 'reloader_start')
+
+    worker.init_process()
+    mock_parent.assert_has_calls([
+        mock.call.load_wsgi(),
+        mock.call.reloader_start(),
+    ])


### PR DESCRIPTION
This PR contains a test and fix for #2244 

The "chicken and egg problem" with the (inotify-based) reloader depending on the wsgi app to be loaded first, and `load_wsgi` depending on the reloader to be present is solved by initializing the reloader first, but only starting it after the wsgi app was loaded.

I've added an integration test that runs `gunicorn --reload` in a tmpdir, replaces the WSGI app and checks for changes in the HTTP response via a unix domain socket. In order to not slow down the tests too much, I've made the default poll interval for the poll-based reloader (1 second) overridable via an (undocumented) [environment variable](https://github.com/benoitc/gunicorn/pull/2249/commits/f1f0d011aec16adcb7b28b7fb5b0f3bb391de2fe). I hope this is OK.

Initially, the test was very flaky and failed most of the time even with the fix (but only when running under `pytest`): gunicorn would pick up the changed file and restart the worker, but the new worker would still be running the old code! It took me a while to figure out that this must have something to do with the compiled bytecode (maybe a timestamp issue?). [Starting gunicorn with writing of bytecode disabled](https://github.com/benoitc/gunicorn/pull/2249/commits/6923709396afca7f8966bc19528094bd5af566d0#diff-3d4ef4fd9b978e57e60dfb39ca4c5baeR27-R31) fixed the issue for me. I was not able to reproduce this outside of pytest.

There was also an issue where the inotify-based reloader would throw an exception if a directory it tried to watch did not exist, which happens when using `--reload` and `--chdir` together (the poll-based reloader already ignores all missing/unreadable files).