### PR TITLE
Document environment variables and $PORT

### DIFF
--- a/docs/source/configure.rst
+++ b/docs/source/configure.rst
@@ -6,15 +6,16 @@ Configuration Overview
 
 Gunicorn reads configuration information from five places.
 
-Gunicorn first reads environment variables for some
-configuration :ref:`settings <settings>`.
+Gunicorn first reads environment variables for some configuration
+:ref:`settings <settings>`.
 
-Gunicorn will then read configuration from a framework
-specific configuration file. Currently this only affects Paster applications.
+Gunicorn then reads configuration from a framework specific configuration
+file. Currently this only affects Paster applications.
 
-The third source of configuration information is a configuration file that is
-optionally specified using command line arguments. Anything specified in the
-Gunicorn config file will override any framework specific settings.
+The third source of configuration information is an optional configuration file
+``gunicorn.conf.py`` searched in the current working directory or specified
+using a command line argument. Anything specified in this configuration file
+will override any framework specific settings.
 
 The fourth place of configuration information are command line arguments
 stored in an environment variable named ``GUNICORN_CMD_ARGS``.

--- a/docs/source/configure.rst
+++ b/docs/source/configure.rst
@@ -4,23 +4,35 @@
 Configuration Overview
 ======================
 
-Gunicorn pulls configuration information from three distinct places.
+Gunicorn reads configuration information from five places.
 
-The first place that Gunicorn will read configuration from is the framework
+Gunicorn first reads environment variables for some
+configuration :ref:`settings <settings>`.
+
+Gunicorn will then read configuration from a framework
 specific configuration file. Currently this only affects Paster applications.
 
-The second source of configuration information is a configuration file that is
-optionally specified on the command line. Anything specified in the Gunicorn
-config file will override any framework specific settings.
+The third source of configuration information is a configuration file that is
+optionally specified using command line arguments. Anything specified in the
+Gunicorn config file will override any framework specific settings.
+
+The fourth place of configuration information are command line arguments
+stored in an environment variable named ``GUNICORN_CMD_ARGS``.
 
 Lastly, the command line arguments used to invoke Gunicorn are the final place
 considered for configuration settings. If an option is specified on the command
 line, this is the value that will be used.
 
+When a configuration file is specified in the command line arguments and in the
+``GUNICORN_CMD_ARGS`` environment variable, only the configuration
+file specified on the command line is used.
+
 Once again, in order of least to most authoritative:
-    1. Framework Settings
-    2. Configuration File
-    3. Command Line
+    1. Environment Variables
+    2. Framework Settings
+    3. Configuration File
+    4. ``GUNICORN_CMD_ARGS``
+    5. Command Line
 
 
 .. note::

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -1164,6 +1164,10 @@ Multiple addresses can be bound. ex.::
 will bind the `test:app` application on localhost both on ipv6
 and ipv4 interfaces.
 
+If the ``PORT`` environment variable is defined, the default
+is ``['0.0.0.0:$PORT']``. If it is not defined, the default
+is ``['127.0.0.1:8000']``.
+
 .. _backlog:
 
 backlog

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -579,6 +579,10 @@ class Bind(Setting):
 
         will bind the `test:app` application on localhost both on ipv6
         and ipv4 interfaces.
+
+        If the ``PORT`` environment variable is defined, the default
+        is ``['0.0.0.0:$PORT']``. If it is not defined, the default
+        is ``['127.0.0.1:8000']``.
         """
 
 


### PR DESCRIPTION
As described in #2247, this documents the effect of the `$PORT` environment variable on the default value of `--bind` and documents the impact and priority of the environment variables in the configuration overview.

~The dead code using the environment variable `LD_LIBRARY_PATH` is also removed.~