### PR TITLE
Remove dead code: find_library and _findWalk_ldpath

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -3,7 +3,6 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 import ast
-import ctypes.util
 import email.utils
 import errno
 import fcntl
@@ -638,34 +637,3 @@ def bytes_to_str(b):
 
 def unquote_to_wsgi_str(string):
     return urllib.parse.unquote_to_bytes(string).decode('latin-1')
-
-
-def _findWalk_ldpath(name):
-    def _is_elf(filepath):
-        try:
-            with open(filepath, 'rb') as fh:
-                return fh.read(4) == b'\x7fELF'
-        except:
-            return False
-    from glob import glob
-    if os.path.isabs(name):
-        return name
-
-    # search LD_LIBRARY_PATH list
-    paths = ['/lib', '/usr/local/lib', '/usr/lib']
-    if 'LD_LIBRARY_PATH' in os.environ:
-        paths = os.environ['LD_LIBRARY_PATH'].split(':') + paths
-
-    for d in paths:
-        f = os.path.join(d, name)
-        if _is_elf(f):
-            return os.path.basename(f)
-        prefix = os.path.join(d, 'lib'+name)
-        for suffix in ['so', 'so.*', '*.so.*', 'a']:
-            for f in glob('{0}.{1}'.format(prefix, suffix)):
-                if _is_elf(f) or suffix == 'a':
-                    return os.path.basename(f)
-
-
-def find_library(name):
-    return ctypes.util.find_library(name) or _findWalk_ldpath(name)


### PR DESCRIPTION
This is just a bit of dead code discovered while investigating #2247 .

The code was added to fix #2160 for socketfromfd.py which was itself [removed later](https://github.com/benoitc/gunicorn/commit/67cb62099c27de00cf80b30e37a7617c2c0ec2ed#diff-cd1a6450c95ae0e121da73674dc3e908).