### PR TITLE
Fix simple typo: convertable -> convertible

### DIFF
--- a/examples/websocket/gevent_websocket.py
+++ b/examples/websocket/gevent_websocket.py
@@ -353,7 +353,7 @@ class WebSocket(object):
     def send(self, message):
         """Send a message to the browser.
 
-        *message* should be convertable to a string; unicode objects should be
+        *message* should be convertible to a string; unicode objects should be
         encodable as utf-8.  Raises socket.error with errno of 32
         (broken pipe) if the socket has already been closed by the client."""
         if self.version in ['7', '8', '13']:

--- a/examples/websocket/websocket.py
+++ b/examples/websocket/websocket.py
@@ -354,7 +354,7 @@ class WebSocket(object):
     def send(self, message):
         """Send a message to the browser.
 
-        *message* should be convertable to a string; unicode objects should be
+        *message* should be convertible to a string; unicode objects should be
         encodable as utf-8.  Raises socket.error with errno of 32
         (broken pipe) if the socket has already been closed by the client."""
         if self.version in ['7', '8', '13']:


### PR DESCRIPTION
There is a small typo in examples/websocket/gevent_websocket.py, examples/websocket/websocket.py.
Should read `convertible` rather than `convertable`.

