### PR TITLE
Upgrade gthread worker  when behind load balancer

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -238,7 +238,7 @@ class ThreadWorker(base.Worker):
             (keepalive, conn) = fs.result()
             # if the connection should be kept alived add it
             # to the eventloop and record it
-            if keepalive:
+            if keepalive and self.alive:
                 # flag the socket as non blocked
                 conn.sock.setblocking(False)
 
@@ -307,7 +307,7 @@ class ThreadWorker(base.Worker):
                                         conn.server, self.cfg)
             environ["wsgi.multithread"] = True
             self.nr += 1
-            if self.alive and self.nr >= self.max_requests:
+            if self.nr >= self.max_requests:
                 self.log.info("Autorestarting worker after current request.")
                 resp.force_close()
                 self.alive = False


### PR DESCRIPTION
when `gunicorn` works in the `gthread` mode, it does not close the connection properly. Many RST packets are generated, and will cause many 502 errors.

**Background**
let's say we have a load balancer (ELB) and a gunicorn server(`gthread` mode).
ELB maintains a persistent connection, it will send requests very frequently.
Gunicorn processes the requests, add the counter  and return response.

after working for a while, we find many RST packets received in ELB(captured by tcpdump).
and it cause many 502 errors.

**Problem**
Gunicorn closes the socket, but meanwhile packets are received in the socket.

**Reason**
1. line 241
a. in multithread mode, all threads share the same variable `self.nr`. 
b. assume that `max_requests` is 100. if thread1 reads it as 98, thread2 reads it as 100 and thread2 finishes first, then `epoll`is closed(self.alive == false, now).
c. thread1's response is telling ELB to keep alive connection, and send requests. but at the same time, thread1 is trying register socket into epoll and it's failed which will make codes goto `line 260`.
d. now, ELB is trying to send packets to socket, but gunicorn is trying to close it.

2. line 310
a. gunicorn uses a thread pool, maybe 4 threads are working. and thread pool may have 5 pending sockets to be processed. but process(self.alive) is not alive now.
b. gunicorn handle the remaining sockets gracefully,  but `handle_request` return True. it should close the connections.

**GunicornConfigExample**
```
worker_class = "gthread"
threads = 2
workers = 2
loglevel = "debug"

port = "8888"
host = "0.0.0.0"
bind = "{}:{}".format(host, port)
max_requests = 100
max_requests_jitter = 0
timeout = 120
graceful_timeout = 120
keepalive = 3600
```

**PersistentConnectionMock (should be Multiprocess)**
```
import time
import logging
import requests

logging.basicConfig(level=logging.DEBUG)
start_time = time.time()


def get_data(limit):
    session = requests.Session()
    url = "http://localhost:8888"

    for i in range(limit):

        response = session.get(url)
        #response_dict = json.loads(response.text)
        print("Received Data: " + response.text)


if __name__ == "__main__":
    limit = 200
    get_data(limit)
    print("--- %s seconds ---" % (time.time() - start_time))
```
