### PR TITLE
Bug #1913: Prevent OSError bubbling when socket disconnected

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -72,13 +72,16 @@ class Message(object):
         if '*' in cfg.forwarded_allow_ips:
             secure_scheme_headers = cfg.secure_scheme_headers
         elif isinstance(self.unreader, SocketUnreader):
-            remote_addr = self.unreader.sock.getpeername()
-            if self.unreader.sock.family in (socket.AF_INET, socket.AF_INET6):
-                remote_host = remote_addr[0]
-                if remote_host in cfg.forwarded_allow_ips:
+            try:
+                remote_addr = self.unreader.sock.getpeername()
+                if self.unreader.sock.family in (socket.AF_INET, socket.AF_INET6):
+                    remote_host = remote_addr[0]
+                    if remote_host in cfg.forwarded_allow_ips:
+                        secure_scheme_headers = cfg.secure_scheme_headers
+                elif self.unreader.sock.family == socket.AF_UNIX:
                     secure_scheme_headers = cfg.secure_scheme_headers
-            elif self.unreader.sock.family == socket.AF_UNIX:
-                secure_scheme_headers = cfg.secure_scheme_headers
+            except OSError:
+                raise NoMoreData()
 
         # Parse headers into key/value pairs paying attention
         # to continuation lines.


### PR DESCRIPTION
Here's a fix for Bug #1913. I'm not sure if this is the best way to do it, but it works. 