### PR TITLE
Disable keepalive during graceful shutdown

### DIFF
--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -99,9 +99,8 @@ class AsyncWorker(base.Worker):
                 if self.alive:
                     self.log.info("Autorestarting worker after current request.")
                     self.alive = False
-                resp.force_close()
 
-            if not self.cfg.keepalive:
+            if not self.alive or not self.cfg.keepalive:
                 resp.force_close()
 
             respiter = self.wsgi(environ, resp.start_response)

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -313,7 +313,7 @@ class ThreadWorker(base.Worker):
                     self.alive = False
                 resp.force_close()
 
-            if not self.cfg.keepalive:
+            if not self.alive or not self.cfg.keepalive:
                 resp.force_close()
             elif len(self._keep) >= self.max_keepalived:
                 resp.force_close()


### PR DESCRIPTION
Fix graceful shutdown behavior so that clients receive notice to close
the connection.

After #2304 and the follow-up in ebb41da, Joe Kemp noticed that, while
the new behavior would successfully indicate a connect close after
hitting the maximum request limit for a worker during graceful shutdown,
the worker would not indicate a connection close if if it had not hit
the maximum request limit.

This change ensures that the worker exits gracefully when hitting the
request limit and also indicates to clients that the connection should
close once the shutdown begins.