### PR TITLE
More verbose exit logging

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -520,6 +520,8 @@ class Arbiter(object):
                     # that it could not boot, we'll shut it down to avoid
                     # infinite start/stop cycles.
                     exitcode = status >> 8
+                    if exitcode != 0:
+                        self.log.error('Worker (pid:%s) exited with code %s', wpid, exitcode)
                     if exitcode == self.WORKER_BOOT_ERROR:
                         reason = "Worker failed to boot."
                         raise HaltServer(reason, self.WORKER_BOOT_ERROR)

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -340,9 +340,12 @@ class Arbiter(object):
     def halt(self, reason=None, exit_status=0):
         """ halt arbiter """
         self.stop()
-        self.log.info("Shutting down: %s", self.master_name)
+
+        log_func = self.log.info if exit_status == 0 else self.log.error
+        log_func("Shutting down: %s", self.master_name)
         if reason is not None:
-            self.log.info("Reason: %s", reason)
+            log_func("Reason: %s", reason)
+
         if self.pidfile is not None:
             self.pidfile.unlink()
         self.cfg.on_exit(self)


### PR DESCRIPTION
- Add logging at error level for abnormal worker exit codes.
- Make arbiter shutdown log at error level for abnormal exits.