### PR TITLE
Update settings docs

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -1160,6 +1160,21 @@ The variables are passed to the the PasteDeploy entrypoint. Example::
 
 .. versionadded:: 19.7
 
+.. _strip-header-spaces:
+
+strip_header_spaces
+~~~~~~~~~~~~~~~~~~~
+
+* ``--strip-header-spaces``
+* ``False``
+
+Strip spaces present between the header name and the the ``:``.
+
+This is known to induce vulnerabilities and is not compliant with the HTTP/1.1 standard.
+See https://portswigger.net/research/http-desync-attacks-request-smuggling-reborn.
+
+Use with care and only if necessary.
+
 Server Socket
 -------------
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -774,10 +774,14 @@ class Timeout(Setting):
     desc = """\
         Workers silent for more than this many seconds are killed and restarted.
 
-        Generally set to thirty seconds. Only set this noticeably higher if
-        you're sure of the repercussions for sync workers. For the non sync
-        workers it just means that the worker process is still communicating and
-        is not tied to the length of time required to handle a single request.
+        Value is a positive number or 0. Setting it to 0 has the effect of
+        infinite timeouts by disabling timeouts for all workers entirely.
+
+        Generally, the default of thirty seconds should suffice. Only set this
+        noticeably higher if you're sure of the repercussions for sync workers.
+        For the non sync workers it just means that the worker process is still
+        communicating and is not tied to the length of time required to handle a
+        single request.
         """
 
 


### PR DESCRIPTION
A follow-up to #2292, adding the same description to `gunicorn/config.py` as well.

Also adds an additional section that seems to be missing from `docs/source/settings.rst` which as automatically added when I built the docs.