### PR TITLE
Fixed two bugs related to gevent + gunicorn + statsd.

### DIFF
--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -95,6 +95,8 @@ class Statsd(Logger):
         Logger.access(self, resp, req, environ, request_time)
         duration_in_ms = request_time.seconds * 1000 + float(request_time.microseconds) / 10 ** 3
         status = resp.status
+        if isinstance(status, bytes):
+            status = status.decode('utf-8')
         if isinstance(status, str):
             status = int(status.split(None, 1)[0])
         self.histogram("gunicorn.request.duration", duration_in_ms)

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -165,7 +165,11 @@ class PyWSGIHandler(pywsgi.WSGIHandler):
         finish = datetime.fromtimestamp(self.time_finish)
         response_time = finish - start
         resp_headers = getattr(self, 'response_headers', {})
-        resp = GeventResponse(self.status, resp_headers, self.response_length)
+
+        # Status is expected to be a string but is encoded to bytes in gevent for PY3
+        # Except when it isn't because gevent uses hardcoded strings for network errors.
+        status = self.status.decode() if isinstance(self.status, bytes) else self.status
+        resp = GeventResponse(status, resp_headers, self.response_length)
         if hasattr(self, 'headers'):
             req_headers = self.headers.items()
         else:


### PR DESCRIPTION
Fixes https://github.com/benoitc/gunicorn/issues/2335. Changes are simply decoding `status` (when logging access for statsd or logging requests for gevent) from bytes to str if necessary. Tested this locally with Python 3.7 and gevent 1.4.0, and it works just fine.