### PR TITLE
✨ Add support for python -m gunicorn

### DIFF
--- a/gunicorn/__main__.py
+++ b/gunicorn/__main__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+from gunicorn.app.wsgiapp import run
+run()


### PR DESCRIPTION
✨ Add support for `python -m gunicorn`.

This just adds a simple `__main__.py` replicating the script defined in `setup.py`.

That adds support for `python -m gunicorn`, as described [here in the Python docs](https://docs.python.org/3.8/library/__main__.html).

It is useful when `python` or equivalent is available as a command but `gunicorn` is not, even though it is installed and available to import. And where the idea is still to call it from the CLI and not importing and running from code... :man_shrugging: 

I know that sounds contrived, but the specific use case is Pex: https://pex.readthedocs.io/

It is based on "zip applications" from this [PEP 441](https://www.python.org/dev/peps/pep-0441/).

So, it would be called like:

```console
$ ./some-binary-pex-file -m gunicorn
```