### PR TITLE
Unread method must add data to the beginning

### DIFF
--- a/gunicorn/http/unreader.py
+++ b/gunicorn/http/unreader.py
@@ -50,8 +50,14 @@ class Unreader(object):
         return data[:size]
 
     def unread(self, data):
-        self.buf.seek(0, os.SEEK_END)
-        self.buf.write(data)
+        self.buf.seek(0, os.SEEK_CUR)
+        if self.buf.tell() != 0:
+            read_chunk = self.buf.getvalue()
+            self.buf = io.BytesIO()
+            self.buf.write(data)
+            self.buf.write(read_chunk)
+        else:
+            self.buf.write(data)
 
 
 class SocketUnreader(Unreader):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -128,6 +128,18 @@ def test_unreader_unread():
     assert b'hi there' in unreader.read()
 
 
+def test_unreader_unread_prepends_data():
+    items = (b'123', b'456')
+    chunk_size = len(items[0]) + 1
+    unreader = IterUnreader(items)
+
+    chunk = unreader.read(chunk_size)
+    unreader.unread(b'0')
+
+    assert chunk == b'1234'
+    assert unreader.read(1024) == b'056'
+
+
 def test_unreader_read_zero_size():
     unreader = Unreader()
     unreader.chunk = mock.MagicMock(side_effect=[b'qwerty', b'asdfgh'])


### PR DESCRIPTION
Steps to reproduce:
-  `git checkout master`
- go to the [line](https://github.com/benoitc/gunicorn/blob/4bed9e7b192ae211b7d1f6c14065c373c9e1c0aa/gunicorn/http/body.py#L103) and change it like this ```sh data = unreader.read(8)```
- `make test`
On my machine, the tests failed