### PR TITLE
Proposed as a solution for issue #1658

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -1363,6 +1363,23 @@ For the non sync workers it just means that the worker process is still
 communicating and is not tied to the length of time required to handle a
 single request.
 
+.. _timeout-start-after:
+
+timeout_start_after
+~~~~~~~~~~~~~~~~~~~
+
+* ``--timeout-start-after INT``
+* ``0``
+
+Wait this many seconds before enforcing timeout on a worker.
+
+Some workers may take a long time to initialize, even though they are
+expected to be highly available once they're ready. Such a worker should
+have a small timeout setting, but Gunicorn needs a way to "forgive" the
+long delay during initialization. When non-zero (zero is the default),
+Gunicorn waits this many seconds after a worker is created before
+enforcing timeout.
+
 .. _graceful-timeout:
 
 graceful_timeout

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -100,6 +100,7 @@ class Arbiter(object):
         self.address = self.cfg.address
         self.num_workers = self.cfg.workers
         self.timeout = self.cfg.timeout
+        self.timeout_start_after = self.cfg.timeout_start_after
         self.proc_name = self.cfg.proc_name
 
         self.log.debug('Current configuration:\n{0}'.format(
@@ -492,7 +493,9 @@ class Arbiter(object):
         workers = list(self.WORKERS.items())
         for (pid, worker) in workers:
             try:
-                if time.time() - worker.tmp.last_update() <= self.timeout:
+                now = time.time()
+                grace = now - worker.created < self.timeout_start_after
+                if grace or now - worker.tmp.last_update() <= self.timeout:
                     continue
             except (OSError, ValueError):
                 continue

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -785,6 +785,26 @@ class Timeout(Setting):
         """
 
 
+class TimeoutStartAfter(Setting):
+    name = "timeout_start_after"
+    section = "Worker Processes"
+    cli = ["--timeout-start-after"]
+    meta = "INT"
+    validator = validate_pos_int
+    type = int
+    default = 0
+    desc = """\
+        Wait this many seconds before enforcing timeout on a worker.
+
+        Some workers may take a long time to initialize, even though they are
+        expected to be highly available once they're ready. Such a worker should
+        have a small timeout setting, but Gunicorn needs a way to "forgive" the
+        long delay during initialization. When non-zero (zero is the default),
+        Gunicorn waits this many seconds after a worker is created before
+        enforcing timeout.
+        """
+
+
 class GracefulTimeout(Setting):
     name = "graceful_timeout"
     section = "Worker Processes"

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -50,6 +50,7 @@ class Worker(object):
         self.booted = False
         self.aborted = False
         self.reloader = None
+        self.created = time.time()
 
         self.nr = 0
 


### PR DESCRIPTION
A new timeout-start-after value is added to config, granting workers an
initial grace period to do time-consuming initialization, after which
they are held to timeout stricture.

Previous attempts of mine to form an acceptable pull request have failed
linting in CI, all in code I didn't touch. This branch is newly minted
from the current upstream master.