### PR TITLE
If inotify is not installed the error is opaque. Fix that.

### DIFF
--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -118,7 +118,7 @@ if has_inotify:
 else:
 
     class InotifyReloader(object):
-        def __init__(self, callback=None):
+        def __init__(self, *args, **kwargs):
             raise ImportError('You must have the inotify module installed to '
                               'use the inotify reloader')
 


### PR DESCRIPTION
As per the ticket, running `--reload-engine inotify` without inotify installed is supposed to cause an obvious error, but due to the different function specs on the `__init__` it just blows up with an error. This fix makes the actual error visible in the output, and future-proofs the init of the fake `InotifyReloader`.

Fixes #2352 