### PR TITLE
shutdown() socket before close()

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -256,6 +256,9 @@ def set_non_blocking(fd):
 
 def close(sock):
     try:
+        # It's unsafe to close the socket immediately after writing data
+        # without first calling shutdown().
+        sock.shutdown(socket.SHUT_RDWR)
         sock.close()
     except socket.error:
         pass

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -255,10 +255,19 @@ def set_non_blocking(fd):
 
 
 def close(sock):
+    if hasattr(sock, 'unwrap'):
+        try:
+            sock = sock.unwrap()
+        except socket.error as e:
+            if e.args[0] != 0:
+                # Some platforms sometimes produce an exception with errno = 0 here
+                # Or maybe that's just a gevent thing.
+                raise
     try:
-        # It's unsafe to close the socket immediately after writing data
-        # without first calling shutdown().
         sock.shutdown(socket.SHUT_RDWR)
+    except socket.error:
+        pass
+    try:
         sock.close()
     except socket.error:
         pass


### PR DESCRIPTION
This should prevent problems where writing a bunch of data to the socket
before closing it causes data to be lost, because the data was not
actually written before the socket and the TCP connection go away.

Fixes #840 

For more information, see https://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable