### PR TITLE
Update docs to mention nginx's proxy_http_version

### DIFF
--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -29,6 +29,7 @@ To turn off buffering, you only need to add ``proxy_buffering off;`` to your
 
   ...
   location @proxy_to_app {
+      proxy_http_version 1.1;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -43,13 +43,15 @@ in tools like ``ps`` and ``top``. This helps for distinguishing the master
 process as well as between masters when running more than one app on a single
 machine. See the proc_name_ setting for more information.
 
-Why is there no HTTP Keep-Alive?
---------------------------------
+Why is there no HTTP Keep-Alive header?
+---------------------------------------
 
-The default Sync workers are designed to run behind Nginx which only uses
-HTTP/1.0 with its upstream servers. If you want to deploy Gunicorn to
-handle unbuffered requests (ie, serving requests directly from the internet)
-you should use one of the async workers.
+You need to enable Keep-Alive support in both gunicorn and your load balancer.
+To enable Keep-Alive support in gunicorn you must use an async worker class,
+which is any of the worker classes that aren't the default sync class. To
+enable Keep-Alive with nginx you must enable its HTTP 1.1 support. Add
+``proxy_http_version 1.1;`` to your nginx configuration to enable HTTP 1.1
+proxy requests.
 
 .. _Hey: https://github.com/rakyll/hey
 .. _setproctitle: https://pypi.python.org/pypi/setproctitle

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -56,6 +56,7 @@ http {
     }
 
     location @proxy_to_app {
+      proxy_http_version 1.1;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header Host $http_host;


### PR DESCRIPTION
Nginx added the `proxy_http_version` option to enable HTTP 1.1 proxy requests. The option was added in nginx 1.1.4, released on September 20th, 2011 so hopefully all of your users have upgraded by now.

The FAQ entry was written maybe a year before nginx 1.1.4 was released, so although it was correct at the time it is no longer relevant and I've taken it out. I also updated the example proxy configurations to enable HTTP 1.1.

Hopefully this will save some poor hacker some troubleshooting down the road when they've configured Nginx by copying out of the example from the docs, used an async worker and configured gunicorn's keepalive support and can't figure out why keepalive still isn't working.