### PR TITLE
Custom date formatting for logging

### DIFF
--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -175,7 +175,7 @@ class Logger(object):
     loglevel = logging.INFO
 
     error_fmt = r"%(asctime)s [%(process)d] [%(levelname)s] %(message)s"
-    datefmt = r"[%Y-%m-%d %H:%M:%S %z]"
+    default_datefmt = r"[%Y-%m-%d %H:%M:%S %z]"
 
     access_fmt = "%(message)s"
     syslog_fmt = "[%(process)d] %(message)s"
@@ -198,6 +198,7 @@ class Logger(object):
         self.loglevel = self.LOG_LEVELS.get(cfg.loglevel.lower(), logging.INFO)
         self.error_log.setLevel(self.loglevel)
         self.access_log.setLevel(logging.INFO)
+        self.datefmt = cfg.logconfig_dict.get('datefmt', self.default_datefmt)
 
         # set gunicorn.error handler
         if self.cfg.capture_output and cfg.errorlog != "-":
@@ -352,7 +353,7 @@ class Logger(object):
 
     def now(self):
         """ return date in Apache Common Log Format """
-        return time.strftime('[%d/%b/%Y:%H:%M:%S %z]')
+        return time.strftime(self.datefmt)
 
     def reopen_files(self):
         if self.cfg.capture_output and self.cfg.errorlog != "-":

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -49,6 +49,27 @@ def test_atoms_zero_bytes():
     assert atoms['B'] == 0
 
 
+def test_custom_date_format():
+    response = SimpleNamespace(
+        status='200', response_length=0,
+        headers=(('Content-Type', 'application/json'),), sent=0,
+    )
+    request = SimpleNamespace(headers=(('Accept', 'application/json'),))
+    environ = {
+        'REQUEST_METHOD': 'GET', 'RAW_URI': '/my/path?foo=bar',
+        'PATH_INFO': '/my/path', 'QUERY_STRING': 'foo=bar',
+        'SERVER_PROTOCOL': 'HTTP/1.1',
+    }
+    conf = Config()
+    conf.set('logconfig_dict', {'datefmt': "[%a %Y-%m-%d %H:%M:%S %z]"})
+    logger = Logger(conf)
+    atoms = logger.atoms(response, request, environ, datetime.timedelta(seconds=1))
+    try:
+        datetime.datetime.strptime(atoms['t'], "[%a %Y-%m-%d %H:%M:%S %z]")
+    except ValueError as e:
+        pytest.fail("{}".format(e))
+
+
 @pytest.mark.parametrize('auth', [
     # auth type is case in-sensitive
     'Basic YnJrMHY6',


### PR DESCRIPTION
This is my naive first approach to #2328 and I'd like some feedback to make sure I'm heading in the right direction.

- Am I properly addressing the scope of the issue in #2328? Should the date format be configurable for all handlers (using`cfg.logconfig_dict.formatters` ), or would we rather keep the hardcoded default (Apache Common) for everything except access logs?
- The author of the original issue desires microsecond precision for formatted dates, however `now()` currently makes use of `time.strftime()` which [doesn't support microsecond resolution] (https://docs.python.org/3/library/time.html#time.strftime). To support this we would have to switch to using `datetime.now().strftime()`
- I'll introduce some more comprehensive testing once I have a clearer sense of where to go from here

Thanks!