### PR TITLE
Allow reporting StatsD metrics over UDS sockets

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -363,6 +363,17 @@ statsd_host
 
 .. versionadded:: 19.1
 
+.. _statsd-socket:
+
+statsd_socket
+~~~~~~~~~~~~~
+
+* ``--statsd-socket STATSD_SOCKET``
+* ``None``
+
+Unix domain socket of the statsd server to log to.
+Supersedes ``statsd_host`` if provided.
+
 .. _dogstatsd-tags:
 
 dogstatsd_tags

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -359,20 +359,14 @@ statsd_host
 * ``--statsd-host STATSD_ADDR``
 * ``None``
 
-``host:port`` of the statsd server to log to.
+The address of the StatsD server to log to.
+
+Address is a string of the form:
+
+* ``unix://PATH`` : for a unix domain socket.
+* ``HOST:PORT`` : for a network address
 
 .. versionadded:: 19.1
-
-.. _statsd-socket:
-
-statsd_socket
-~~~~~~~~~~~~~
-
-* ``--statsd-socket STATSD_SOCKET``
-* ``None``
-
-Unix domain socket of the statsd server to log to.
-Supersedes ``statsd_host`` if provided.
 
 .. _dogstatsd-tags:
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -144,8 +144,10 @@ class Config(object):
         # if default logger is in use, and statsd is on, automagically switch
         # to the statsd logger
         if uri == LoggerClass.default:
-            statsd_address = 'statsd_socket' in self.settings and self.settings['statsd_socket'].value or \
-                             'statsd_host' in self.settings and self.settings['statsd_host'].value
+            statsd_address = 'statsd_socket' in self.settings and \
+                             self.settings['statsd_socket'].value or \
+                             'statsd_host' in self.settings and \
+                             self.settings['statsd_host'].value
             if statsd_address is not None:
                 uri = "gunicorn.instrument.statsd.Statsd"
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -144,7 +144,9 @@ class Config(object):
         # if default logger is in use, and statsd is on, automagically switch
         # to the statsd logger
         if uri == LoggerClass.default:
-            if 'statsd_host' in self.settings and self.settings['statsd_host'].value is not None:
+            statsd_address = 'statsd_socket' in self.settings and self.settings['statsd_socket'].value or \
+                             'statsd_host' in self.settings and self.settings['statsd_host'].value
+            if statsd_address is not None:
                 uri = "gunicorn.instrument.statsd.Statsd"
 
         logger_class = util.load_class(
@@ -1476,6 +1478,18 @@ class StatsdHost(Setting):
     ``host:port`` of the statsd server to log to.
 
     .. versionadded:: 19.1
+    """
+
+class StatsdSocket(Setting):
+    name = "statsd_socket"
+    section = "Logging"
+    cli = ["--statsd-socket"]
+    meta = "STATSD_SOCKET"
+    default = None
+    validator = validate_string
+    desc = """\
+    Unix domain socket of the statsd server to log to.
+    Supersedes ``statsd_host`` if provided.
     """
 
 # Datadog Statsd (dogstatsd) tags. https://docs.datadoghq.com/developers/dogstatsd/

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -27,10 +27,18 @@ class Statsd(Logger):
         """
         Logger.__init__(self, cfg)
         self.prefix = sub(r"^(.+[^.]+)\.*$", "\\g<1>.", cfg.statsd_prefix)
-        try:
+
+        if cfg.statsd_socket:
+            address_family = socket.AF_UNIX
+            address = cfg.statsd_socket
+        elif cfg.statsd_host:
+            address_family = socket.AF_INET
             host, port = cfg.statsd_host
-            self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            self.sock.connect((host, int(port)))
+            address = (host, int(port))
+
+        try:
+            self.sock = socket.socket(address_family, socket.SOCK_DGRAM)
+            self.sock.connect(address)
         except Exception:
             self.sock = None
 

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -23,22 +23,17 @@ class Statsd(Logger):
     """statsD-based instrumentation, that passes as a logger
     """
     def __init__(self, cfg):
-        """host, port: statsD server
-        """
         Logger.__init__(self, cfg)
         self.prefix = sub(r"^(.+[^.]+)\.*$", "\\g<1>.", cfg.statsd_prefix)
 
-        if cfg.statsd_socket:
+        if isinstance(cfg.statsd_host, str):
             address_family = socket.AF_UNIX
-            address = cfg.statsd_socket
-        elif cfg.statsd_host:
+        else:
             address_family = socket.AF_INET
-            host, port = cfg.statsd_host
-            address = (host, int(port))
 
         try:
             self.sock = socket.socket(address_family, socket.SOCK_DGRAM)
-            self.sock.connect(address)
+            self.sock.connect(cfg.statsd_host)
         except Exception:
             self.sock = None
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -306,17 +306,23 @@ def test_nworkers_changed():
     assert c.nworkers_changed(1, 2, 3) == 3
 
 
-def test_statsd_host_changes_logger():
+def test_statsd_host():
+    c = config.Config()
+    assert c.statsd_host is None
+    c.set("statsd_host", "localhost")
+    assert c.statsd_host == ("localhost", 8125)
+    c.set("statsd_host", "statsd:7777")
+    assert c.statsd_host == ("statsd", 7777)
+    c.set("statsd_host", "unix:/path/to.sock")
+    assert c.statsd_host == "/path/to.sock"
+    pytest.raises(TypeError, c.set, "statsd_host", 666)
+    pytest.raises(TypeError, c.set, "statsd_host", "host:string")
+
+
+def test_statsd_changes_logger():
     c = config.Config()
     assert c.logger_class == glogging.Logger
     c.set('statsd_host', 'localhost:12345')
-    assert c.logger_class == statsd.Statsd
-
-
-def test_statsd_socket_changes_logger():
-    c = config.Config()
-    assert c.logger_class == glogging.Logger
-    c.set('statsd_socket', '/var/run/sock')
     assert c.logger_class == statsd.Statsd
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -313,10 +313,21 @@ def test_statsd_host():
     assert c.statsd_host == ("localhost", 8125)
     c.set("statsd_host", "statsd:7777")
     assert c.statsd_host == ("statsd", 7777)
-    c.set("statsd_host", "unix:/path/to.sock")
+    c.set("statsd_host", "unix:///path/to.sock")
     assert c.statsd_host == "/path/to.sock"
     pytest.raises(TypeError, c.set, "statsd_host", 666)
     pytest.raises(TypeError, c.set, "statsd_host", "host:string")
+
+
+def test_statsd_host_with_unix_as_hostname():
+    # This is a regression test for major release 20. After this release
+    # we should consider modifying the behavior of util.parse_address to
+    # simplify gunicorn's code
+    c = config.Config()
+    c.set("statsd_host", "unix:7777")
+    assert c.statsd_host == ("unix", 7777)
+    c.set("statsd_host", "unix://some.socket")
+    assert c.statsd_host == "some.socket"
 
 
 def test_statsd_changes_logger():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -306,10 +306,17 @@ def test_nworkers_changed():
     assert c.nworkers_changed(1, 2, 3) == 3
 
 
-def test_statsd_changes_logger():
+def test_statsd_host_changes_logger():
     c = config.Config()
     assert c.logger_class == glogging.Logger
     c.set('statsd_host', 'localhost:12345')
+    assert c.logger_class == statsd.Statsd
+
+
+def test_statsd_socket_changes_logger():
+    c = config.Config()
+    assert c.logger_class == glogging.Logger
+    c.set('statsd_socket', '/var/run/sock')
     assert c.logger_class == statsd.Statsd
 
 

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -59,6 +59,18 @@ def test_statsd_fail():
     logger.exception("No impact on logging")
 
 
+def test_statsd_host_initialization():
+    c = Config()
+    c.set('statsd_host', 'unix:test.sock')
+    logger = Statsd(c)
+    logger.info("Can be initialized and used with a UDS socket")
+
+    # Can be initialized and used with a UDP address
+    c.set('statsd_host', 'host:8080')
+    logger = Statsd(c)
+    logger.info("Can be initialized and used with a UDP socket")
+
+
 def test_dogstatsd_tags():
     c = Config()
     tags = 'yucatan,libertine:rhubarb'


### PR DESCRIPTION
This is a follow-up PR to #2067

It allows gunicorn users to specify a UDS address leveraging the `statsd_host` config option, and reporting metrics through a socket.

I've tried to touch the fewest things possible, added a couple of tests and done a manual test you can reproduce like this:

__datadog.yml__:
```yaml
use_dogstatsd: true
dogstatsd_port: 8125
bind_host: '127.0.0.1'
dogstatsd_non_local_traffic: true
dogstatsd_socket: '/var/run/datadog/dsd.socket'
```

__docker-compose.yml__:
```yaml
version: '3.7'
services:
  gunicorn:
    image: python:3.8-slim
    command:
      - python 
      - /app/gunicorn/app/wsgiapp.py 
      - --bind=0.0.0.0
      - --statsd-prefix=test.gunicorn
      - --statsd-host=unix:/var/run/datadog/dsd.socket
      - test:app
    working_dir: "/app/examples"
    environment:
      PYTHONPATH: "/app"
    ports:
      - "8000:8000"
    networks:
      - default
    volumes:
      - .:/app
      - datadog:/var/run/datadog/
    depends_on:
      - datadog

  datadog:
    image: datadog/agent:6.13.0
    environment:
      DD_API_KEY: <a_valid_dd_api_key>
    volumes:
      - ./datadog.yml:/etc/datadog-agent/datadog.yaml
      - datadog:/var/run/datadog/
    networks:
      - default

networks:
  default:

volumes:
  datadog:
```

Manual test steps:
* Run `docker-compose up`
* Go to localhost:8000 several times
* Verify the metrics `test.gunicorn.*` appear in your datadog account
* Change to `--statsd-host=datadog` or `--statsd-host=datadog:8125` and repeat the steps
