### PR TITLE
Log access even when connection is closed

### DIFF
--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -107,14 +107,16 @@ class AsyncWorker(base.Worker):
             if self.is_already_handled(respiter):
                 return False
             try:
-                if isinstance(respiter, environ['wsgi.file_wrapper']):
-                    resp.write_file(respiter)
-                else:
-                    for item in respiter:
-                        resp.write(item)
-                resp.close()
-                request_time = datetime.now() - request_start
-                self.log.access(resp, req, environ, request_time)
+                try:
+                    if isinstance(respiter, environ['wsgi.file_wrapper']):
+                        resp.write_file(respiter)
+                    else:
+                        for item in respiter:
+                            resp.write(item)
+                    resp.close()
+                finally:
+                    request_time = datetime.now() - request_start
+                    self.log.access(resp, req, environ, request_time)
             finally:
                 if hasattr(respiter, "close"):
                     respiter.close()

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -319,15 +319,17 @@ class ThreadWorker(base.Worker):
 
             respiter = self.wsgi(environ, resp.start_response)
             try:
-                if isinstance(respiter, environ['wsgi.file_wrapper']):
-                    resp.write_file(respiter)
-                else:
-                    for item in respiter:
-                        resp.write(item)
+                try:
+                    if isinstance(respiter, environ['wsgi.file_wrapper']):
+                        resp.write_file(respiter)
+                    else:
+                        for item in respiter:
+                            resp.write(item)
 
-                resp.close()
-                request_time = datetime.now() - request_start
-                self.log.access(resp, req, environ, request_time)
+                    resp.close()
+                finally:
+                    request_time = datetime.now() - request_start
+                    self.log.access(resp, req, environ, request_time)
             finally:
                 if hasattr(respiter, "close"):
                     respiter.close()

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -176,14 +176,16 @@ class SyncWorker(base.Worker):
                 self.alive = False
             respiter = self.wsgi(environ, resp.start_response)
             try:
-                if isinstance(respiter, environ['wsgi.file_wrapper']):
-                    resp.write_file(respiter)
-                else:
-                    for item in respiter:
-                        resp.write(item)
-                resp.close()
-                request_time = datetime.now() - request_start
-                self.log.access(resp, req, environ, request_time)
+                try:
+                    if isinstance(respiter, environ['wsgi.file_wrapper']):
+                        resp.write_file(respiter)
+                    else:
+                        for item in respiter:
+                            resp.write(item)
+                    resp.close()
+                finally:
+                    request_time = datetime.now() - request_start
+                    self.log.access(resp, req, environ, request_time)
             finally:
                 if hasattr(respiter, "close"):
                     respiter.close()


### PR DESCRIPTION
When a client disconnects, `resp.write(item)` would result in a `BrokenPipeError` which prevents the access from being logged.

Fixes #1060.