### PR TITLE
Add instructions for secure_scheme_headers and forwarded_allow_ips

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -1046,9 +1046,9 @@ secure_scheme_headers
 * ``{'X-FORWARDED-PROTOCOL': 'ssl', 'X-FORWARDED-PROTO': 'https', 'X-FORWARDED-SSL': 'on'}``
 
 A dictionary containing headers and values that the front-end proxy
-uses to indicate HTTPS requests. These tell Gunicorn to set
-``wsgi.url_scheme`` to ``https``, so your application can tell that the
-request is secure.
+uses to indicate HTTPS requests. When remote host matched
+``forwarded_allow_ips``, these tell Gunicorn to set ``wsgi.url_scheme``
+to ``https``, so your application can tell that the request is secure.
 
 The dictionary should map upper-case header names to exact string
 values. The value comparisons are case-sensitive, unlike the header
@@ -1066,12 +1066,13 @@ forwarded_allow_ips
 * ``--forwarded-allow-ips STRING``
 * ``127.0.0.1``
 
-Front-end's IPs from which allowed to handle set secure headers.
-(comma separate).
+Comma separated front-end's IPs from which allowed to handle set secure
+headers.
 
 Set to ``*`` to disable checking of Front-end IPs (useful for setups
 where you don't know in advance the IP address of Front-end, but
-you still trust the environment).
+you still trust the environment, such as serving behind a reverse
+proxies, load balancer or inside a dockerized environment).
 
 By default, the value of the ``FORWARDED_ALLOW_IPS`` environment
 variable. If it is not defined, the default is ``"127.0.0.1"``.


### PR DESCRIPTION
`wsgi.url_scheme` plays a vital role for frameworks like django and flask in determine whether the connection between client and server is secure. When stacks are deployed in a complex environments, it can be hard to trace where did parameter mismatched.

In my case, my setup involves cloudflare CDN, docker, nginx, gunicorn, and finally, flask.

The problem begin with flask not generating proper URL through `url_for` function. After dozen hours of inspecting, tracing, document reading, the problem boil downed to gunicorn. It did recieve `X-Forwarded-Proto: https` from nginx, but did not set `wsgi.url_scheme` to `https` correspondingly. However, might be the case that I have issue with googling, or the fact that there aren't really much information about how to tweak the config to fit for this case (Github, stackoverflow,...nothing).

I first try scan through the docs for solution, but with no luck. Then I spent another dozen of hours, read through the source codes, and realize that `secure_scheme_headers` is not the option that I'm looking for, `forwarded_allow_ips ` is. There are, actually, footnotes stating the scenario where this option might be used, but not obvious enough to enlighten me.

So I've added some additional notes, hope this help some.