### PR TITLE
Fix the RecursionError during pickling Config

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -62,6 +62,8 @@ class Config(object):
         return "\n".join(lines)
 
     def __getattr__(self, name):
+        if name == "settings":
+            raise AttributeError()
         if name not in self.settings:
             raise AttributeError("No configuration setting for: %s" % name)
         return self.settings[name].get()


### PR DESCRIPTION
## What problem did I encounter?
Platform: MacOS Python version: 3.8.2
I try to use the multiprocessing module to start Gunicorn's Application and load a custom configuration.
Expected: Normal like with Python 3.7
Actual: RecursionError
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/multiprocessing/spawn.py", line 116, in spawn_main
    exitcode = _main(fd, parent_sentinel)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/multiprocessing/spawn.py", line 126, in _main
    self = reduction.pickle.load(from_parent)
  File "/Users/xxx/serving-backends/venv/lib/python3.8/site-packages/gunicorn/config.py", line 55, in __getattr__
    if name not in self.settings:
  File "/Users/xxx/serving-backends/venv/lib/python3.8/site-packages/gunicorn/config.py", line 55, in __getattr__
    if name not in self.settings:
  File "/Users/xxx/serving-backends/venv/lib/python3.8/site-packages/gunicorn/config.py", line 55, in __getattr__
    if name not in self.settings:
  [Previous line repeated 993 more times]
RecursionError: maximum recursion depth exceeded
```
## Details
From Python3.8, the multiprocessing module uses the `spawn` method to start a new process by default on MacOS.
ref: https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods

It employed pickle to pass objects between parent process and child process.

`pickle.load` would try to read attribute `__setstate__` when retrieving objects. It happens after `__new__` but before the `__dict__` resumed, while the attribute `settings` didn't exist. Since reading `__setstate__` hits `__getattr__`, it caused RecursionError.