### PR TITLE
Warn in the case of bad systemd configuration

### DIFF
--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -219,7 +219,8 @@ class Application(BaseApplication):
 
         if self.cfg.daemon:
             if os.environ.get('NOTIFY_SOCKET'):
-                msg = "Warning: you shouldn't specify `daemon = True` when launching by systemd with `Type = notify`"
+                msg = "Warning: you shouldn't specify `daemon = True`" \
+                      " when launching by systemd with `Type = notify`"
                 print(msg, file=sys.stderr, flush=True)
 
             util.daemonize(self.cfg.enable_stdio_inheritance)

--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -218,6 +218,10 @@ class Application(BaseApplication):
             debug.spew()
 
         if self.cfg.daemon:
+            if os.environ.get('NOTIFY_SOCKET'):
+                msg = "Warning: you shouldn't specify `daemon = True` when launching by systemd with `Type = notify`"
+                print(msg, file=sys.stderr, flush=True)
+
             util.daemonize(self.cfg.enable_stdio_inheritance)
 
         # set python paths


### PR DESCRIPTION
The timing of [calling sd_notify](https://github.com/benoitc/gunicorn/blob/20.0.4/gunicorn/arbiter.py#L161) is after [daemonizing](https://github.com/benoitc/gunicorn/blob/20.0.4/gunicorn/app/base.py#L217).  Hense, launching will fail eternally if user specify `Type = notify` and `daemon = True`.

User can face this pattern if user already have existing `gunicorn.py` setting file and try to use systemd.  I added warning to make user easilly figure out.