### PR TITLE
Add socket backlog metric

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -558,6 +558,13 @@ class Arbiter(object):
                                   "value": active_worker_count,
                                   "mtype": "gauge"})
 
+        backlog = sum([sock.get_backlog() for sock in self.LISTENERS])
+        if backlog:
+            self.log.debug("socket backlog: {0}".format(backlog),
+                           extra={"metric": "gunicorn.backlog",
+                                  "value": backlog,
+                                  "mtype": "histogram"})
+
     def spawn_worker(self):
         self.worker_age += 1
         worker = self.worker_class(self.worker_age, self.pid, self.LISTENERS,

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -18,6 +18,7 @@ MTYPE_VAR = "mtype"
 GAUGE_TYPE = "gauge"
 COUNTER_TYPE = "counter"
 HISTOGRAM_TYPE = "histogram"
+TIMER_TYPE = "timer"
 
 
 class Statsd(Logger):
@@ -78,6 +79,8 @@ class Statsd(Logger):
                         self.increment(metric, value)
                     elif typ == HISTOGRAM_TYPE:
                         self.histogram(metric, value)
+                    elif typ == TIMER_TYPE:
+                        self.timer(metric, value)
                     else:
                         pass
 
@@ -97,7 +100,7 @@ class Statsd(Logger):
         status = resp.status
         if isinstance(status, str):
             status = int(status.split(None, 1)[0])
-        self.histogram("gunicorn.request.duration", duration_in_ms)
+        self.timer("gunicorn.request.duration", duration_in_ms)
         self.increment("gunicorn.requests", 1)
         self.increment("gunicorn.request.status.%d" % status, 1)
 
@@ -112,8 +115,11 @@ class Statsd(Logger):
     def decrement(self, name, value, sampling_rate=1.0):
         self._sock_send("{0}{1}:-{2}|c|@{3}".format(self.prefix, name, value, sampling_rate))
 
-    def histogram(self, name, value):
+    def timer(self, name, value):
         self._sock_send("{0}{1}:{2}|ms".format(self.prefix, name, value))
+
+    def histogram(self, name, value):
+        self._sock_send("{0}{1}:{2}|h".format(self.prefix, name, value))
 
     def _sock_send(self, msg):
         try:

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -9,8 +9,10 @@ import socket
 import stat
 import sys
 import time
+import struct
 
 from gunicorn import util
+PLATFORM = sys.platform
 
 
 class BaseSocket(object):
@@ -70,6 +72,9 @@ class BaseSocket(object):
 
         self.sock = None
 
+    def get_backlog(self):
+        return 0
+
 
 class TCPSocket(BaseSocket):
 
@@ -88,6 +93,18 @@ class TCPSocket(BaseSocket):
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         return super().set_options(sock, bound=bound)
 
+    def get_backlog(self):
+        if self.sock and PLATFORM == "linux":
+            # tcp_info struct from include/uapi/linux/tcp.h
+            fmt = 'B'*8+'I'*24
+            try:
+                tcp_info_struct = self.sock.getsockopt(socket.IPPROTO_TCP,
+                                                      socket.TCP_INFO, 104)
+                # 12 is tcpi_unacked
+                return struct.unpack(fmt, tcp_info_struct)[12]
+            except AttributeError:
+                pass
+        return 0
 
 class TCP6Socket(TCPSocket):
 


### PR DESCRIPTION
If all the workers are busy or max connections are reached, new connections will queue in the socket backlog, which defaults to 2048. The `gunicorn.backlog` metric provides visibility into this queue and gives an idea on concurrency, and worker saturation. However, this is only available on Linux platforms.

This also adds a distinction between the `timer` and `histogram` statsd metric types, which although treated the same, can be the difference, for e.g. in this case histogram is not a timer: https://github.com/b/statsd_spec#timers

Also, another point to note is on Linux the backlog is also limited by `net.core.somaxconn` which is 128 by default. Not sure if that is the case on other platforms as well. Would it then make sense to reduce the default backlog from 2048?

Partially Fixes: #2057