### PR TITLE
Correction on default value for config file

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -29,7 +29,7 @@ config
 ~~~~~~
 
 * ``-c CONFIG, --config CONFIG``
-* ``None``
+* ``./gunicorn.conf.py``
 
 The Gunicorn config file.
 
@@ -37,6 +37,9 @@ A string of the form ``PATH``, ``file:PATH``, or ``python:MODULE_NAME``.
 
 Only has an effect when specified on the command line or as part of an
 application specific configuration.
+
+By default, a file named `gunicorn.conf.py` will be read from the same
+directory where gunicorn is being run.
 
 .. versionchanged:: 19.4
    Loading the config from a Python module requires the ``python:``


### PR DESCRIPTION
Running `gunicorn project.app` while having a file called `gunicorn.conf.py` in the current directory will read configuration from that file and actually fail if the file raises an exception. I just state this on the docs because it caught me off guard.