### PR TITLE
Show usage of raw_env in docs

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -935,6 +935,10 @@ Pass variables to the execution environment. Ex.::
 
 and test for the foo variable environment in your application.
 
+In the config file, use ``raw_env``, Ex.::
+
+    raw_env=['FOO=1', 'BAR=2']
+
 .. _pidfile:
 
 pidfile


### PR DESCRIPTION
It was documented the usage of the cli parameter `env` but in the config file it should be `raw_env`.
Related issue #1472