### PR TITLE
Add extensible worker arguments

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -50,6 +50,7 @@ class Config(object):
         self.usage = usage
         self.prog = prog or os.path.basename(sys.argv[0])
         self.env_orig = os.environ.copy()
+        self.worker_kwargs = {}
 
     def __str__(self):
         lines = []

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -174,7 +174,7 @@ class SyncWorker(base.Worker):
             if self.nr >= self.max_requests:
                 self.log.info("Autorestarting worker after current request.")
                 self.alive = False
-            respiter = self.wsgi(environ, resp.start_response)
+            respiter = self.wsgi(environ, resp.start_response, **self.cfg.handler_kwargs)
             try:
                 if isinstance(respiter, environ['wsgi.file_wrapper']):
                     resp.write_file(respiter)


### PR DESCRIPTION
So this is mainly to solicit feedback. It's certainly not complete, but I figured a code example and a place to grow this idea was helpful.

**Problem:** I need to share some state across worker processes. In this case write to a file across multiple processes that don't clobber each other. That file then needs to be shipped off after X time/size and the mess of race conditions that surround that using multiple writers with no clear leader.

**Solution:**
Fork off a helper from the master process that can listen to a shared multiprocess queue and be the one source of truth for that. The issue is sharing this queue with the worker processes.

For a quick example (with this PR applied) I could do something like:

server.py
```
def app(environ, start_response, app_queue, **kwargs):
    """Simplest possible application object"""

    # Add stuff to our shared queue
    app_queue.put(f"Req from: {environ['HTTP_USER_AGENT']}")

    data = b'Send data!\n'
    status = '200 OK'
    response_headers = [
        ('Content-type', 'text/plain'),
        ('Content-Length', str(len(data)))
    ]
    start_response(status, response_headers)
    return iter([data])
```


config.py
```
import multiprocessing

app_queue = multiprocessing.JoinableQueue()
helper_proc: multiprocessing.Process = None

def helper(server, app_queue):
    while True:
        try:
            msg = app_queue.get(block=True, timeout=3)
            server.log.info(f"WORKER MSG: ${msg}")
            app_queue.task_done()
        except queue.Empty:
            server.log.info("Worker waiting for messages...")


def pre_fork(server, worker):
    server.log.info("Pre-fork spawned (pid: %s)", worker.pid)
    # New part, modify these args that get passed to the handler.
    worker.cfg.handler_kwargs['app_queue'] = app_queue


def when_ready(server):
    global helper_proc
    server.log.info("Server is ready. Spawning workers and helper")
    helper_proc = multiprocessing.Process(target=helper, args=(server, app_queue,))
    helper_proc.start()


def on_exit(server):
    server.log.info("on_exit event")
    app_queue.join()
    helper_proc.kill()  # Everything is done processing if the messages were all ack-ed
```

I'm guessing other worker classes I'm less familiar with don't handle this as well? This seems like a great extension that allows a lot of flexibility though.

I think this could help #2216 #1938 