### PR TITLE
fix: repair django wsgi running error

### DIFF
--- a/gunicorn/workers/gtornado.py
+++ b/gunicorn/workers/gtornado.py
@@ -110,6 +110,8 @@ class TornadoWorker(Worker):
             if not isinstance(app, tornado.web.Application) or \
             isinstance(app, tornado.wsgi.WSGIApplication):
                 app = WSGIContainer(app)
+        elif not isinstance(app, WSGIContainer):
+            app = WSGIContainer(app)
 
         # Monkey-patching HTTPConnection.finish to count the
         # number of requests being handled by Tornado. This


### PR DESCRIPTION
When running the WSGI of Django, you need to wrap it with WSGIContainer. Otherwise, the following error will be caused:

```
ERROR:tornado.application:Uncaught exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/tornado/http1connection.py", line 273, in _read_message
    delegate.finish()
  File "/usr/local/lib/python3.7/site-packages/tornado/httpserver.py", line 280, in finish
    self.request_callback(self.request)
TypeError: __call__() missing 1 required positional argument: 'start_response'
```

I think that in tornado6 and above, as long as it is not a WSGIContainer instance, we should wrap it into WSGIContainer
