### PR TITLE
Add additional logs when worker exits abnormally

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -527,6 +527,27 @@ class Arbiter(object):
                         reason = "App failed to load."
                         raise HaltServer(reason, self.APP_LOAD_ERROR)
 
+                    if exitcode > 0:
+                        # If the exit code of the worker is greater than 0,
+                        # let the user know.
+                        self.log.error("Worker (pid:%s) exited with code %s.",
+                                       wpid, exitcode)
+                    elif status > 0:
+                        # If the exit code of the worker is 0 and the status
+                        # is greater than 0, then it was most likely killed
+                        # via a signal.
+                        try:
+                            sig_name = signal.Signals(status).name
+                        except ValueError:
+                            sig_name = "code %s".format(status)
+                        msg = "Worker (pid:{}) was sent {}!".format(
+                            wpid, sig_name)
+
+                        # Additional hint for SIGKILL
+                        if status == signal.SIGKILL:
+                            msg += " Perhaps out of memory?"
+                        self.log.error(msg)
+
                     worker = self.WORKERS.pop(wpid, None)
                     if not worker:
                         continue

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -539,7 +539,7 @@ class Arbiter(object):
                         try:
                             sig_name = signal.Signals(status).name
                         except ValueError:
-                            sig_name = "code %s".format(status)
+                            sig_name = "code {}".format(status)
                         msg = "Worker (pid:{}) was sent {}!".format(
                             wpid, sig_name)
 


### PR DESCRIPTION
Fixes #1663 

To test out of memory detection:
```
$ cat g.py
print("eating memory")
a = []
while True:
    a.append(bytearray(512000000))

def app(environ, start_response):
    pass

$ docker run -it -m 256m --cpus=0.5 -v $PWD:/app python:3.7 /bin/bash
root@8bf8f22c0928:/# cd app
root@8bf8f22c0928:/app# pip install -e .
Obtaining file:///app
Requirement already satisfied: setuptools>=3.0 in /usr/local/lib/python3.7/site-packages (from gunicorn==20.0.4) (50.3.0)
Installing collected packages: gunicorn
  Running setup.py develop for gunicorn
Successfully installed gunicorn
root@8bf8f22c0928:/app# gunicorn g:app
[2020-09-12 05:37:48 +0000] [18] [INFO] Starting gunicorn 20.0.4
[2020-09-12 05:37:48 +0000] [18] [INFO] Listening at: http://127.0.0.1:8000 (18)
[2020-09-12 05:37:48 +0000] [18] [INFO] Using worker: sync
[2020-09-12 05:37:48 +0000] [21] [INFO] Booting worker with pid: 21
eating memory
[2020-09-12 05:37:52 +0000] [18] [ERROR] Worker (pid:21) was sent SIGKILL! Perhaps out of memory?
[2020-09-12 05:37:52 +0000] [22] [INFO] Booting worker with pid: 22
eating memory
[2020-09-12 05:37:55 +0000] [18] [ERROR] Worker (pid:22) was sent SIGKILL! Perhaps out of memory?
[2020-09-12 05:37:55 +0000] [23] [INFO] Booting worker with pid: 23
eating memory
[2020-09-12 05:37:58 +0000] [18] [ERROR] Worker (pid:23) was sent SIGKILL! Perhaps out of memory?
[2020-09-12 05:37:58 +0000] [24] [INFO] Booting worker with pid: 24
eating memory
```

To test other abnormal exits:
```
$ cat f.py
import sys

def app(environ, start_response):
    sys.exit(5)

$ gunicorn f:app &
$ [2020-09-11 22:52:11 -0700] [19736] [INFO] Starting gunicorn 20.0.4
[2020-09-11 22:52:11 -0700] [19736] [INFO] Listening at: http://127.0.0.1:8000 (19736)
[2020-09-11 22:52:11 -0700] [19736] [INFO] Using worker: sync
[2020-09-11 22:52:11 -0700] [19864] [INFO] Booting worker with pid: 19864
$ kill -1 19864
[2020-09-11 22:52:22 -0700] [19736] [ERROR] Worker (pid:19864) was sent SIGHUP!
[2020-09-11 22:52:22 -0700] [20352] [INFO] Booting worker with pid: 20352
$ kill -9 20352
[2020-09-11 22:52:28 -0700] [19736] [ERROR] Worker (pid:20352) was sent SIGKILL! Perhaps out of memory?
[2020-09-11 22:52:28 -0700] [20926] [INFO] Booting worker with pid: 20926
$ curl http://127.0.0.1:8000
curl: (52) Empty reply from server
[2020-09-11 22:52:33 -0700] [20926] [INFO] Worker exiting (pid: 20926)
[2020-09-11 22:52:33 -0700] [19736] [ERROR] Worker (pid:20926) exited with code 5.
[2020-09-11 22:52:33 -0700] [20966] [INFO] Booting worker with pid: 20966
```