### PR TITLE
Remove reference to six.py

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,8 +41,7 @@ commands =
 
 [testenv:pycodestyle]
 commands =
-  pycodestyle gunicorn \
-  --exclude=gunicorn/six.py
+  pycodestyle gunicorn
 deps =
   pycodestyle
 


### PR DESCRIPTION
six.py was removed in https://github.com/benoitc/gunicorn/pull/2083 , there's no need to exclude it from tests.