### PR TITLE
Added a line to the documentation to further explain the use of logconfig_dict.

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -304,6 +304,8 @@ older file configuration format.
 
 Format: https://docs.python.org/3/library/logging.config.html#logging.config.dictConfig
 
+For more context you can look at the default configuration dictionary for logging, which can be found at ``gunicorn.glogging.CONFIG_DEFAULTS```.
+
 .. versionadded:: 19.8
 
 .. _syslog-addr:

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -304,7 +304,7 @@ older file configuration format.
 
 Format: https://docs.python.org/3/library/logging.config.html#logging.config.dictConfig
 
-For more context you can look at the default configuration dictionary for logging, which can be found at ``gunicorn.glogging.CONFIG_DEFAULTS```.
+For more context you can look at the default configuration dictionary for logging, which can be found at ``gunicorn.glogging.CONFIG_DEFAULTS``.
 
 .. versionadded:: 19.8
 


### PR DESCRIPTION
The usage of logconifg_dict can be confusing, not only since there is not a clear example on the site now, but also since the documentation of [python's dictConfig](https://docs.python.org/3/library/logging.config.html#logging.config.dictConfig) is minimal. And since you need to know about the specific loggers that gunicorn uses to configure them properly.