### PR TITLE
[Typo] Custom Application Section

### DIFF
--- a/docs/source/custom.rst
+++ b/docs/source/custom.rst
@@ -37,9 +37,9 @@ pass them along as if you're directly giving them to Gunicorn:
 .. code-block:: bash
 
    # Custom parameters
-   $ python gunicorn.app.wsgiapp exampleapi:app --bind=0.0.0.0:8081 --workers=4
+   $ python -m gunicorn.app.wsgiapp exampleapi:app --bind=0.0.0.0:8081 --workers=4
    # Using a config file
-   $ python gunicorn.app.wsgiapp exampleapi:app -c config.py
+   $ python -m gunicorn.app.wsgiapp exampleapi:app -c config.py
     
 Note for those using PEX: use ``-c gunicorn`` as your entry at build
 time, and your compiled app should work with the entry point passed to it at


### PR DESCRIPTION
There is a typo in custom configuration's page where commands to run a custom app were missing a parameter.