### PR TITLE
add OnHalt handler to server hooks

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -339,6 +339,7 @@ class Arbiter(object):
 
     def halt(self, reason=None, exit_status=0):
         """ halt arbiter """
+        self.cfg.on_halt(self)
         self.stop()
         self.log.info("Shutting down: %s", self.master_name)
         if reason is not None:

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1819,6 +1819,23 @@ class NumWorkersChanged(Setting):
         be ``None``.
         """
 
+
+class OnHalt(Setting):
+    name = "on_halt"
+    section = "Server Hooks"
+    validator = validate_callable(1)
+
+    def on_halt(server):
+        pass
+
+    default = staticmethod(on_halt)
+    desc = """\
+        Called just before halting server in Gunicorn.
+
+        The callable needs to accept a single instance variable for the Arbiter.
+        """
+
+
 class OnExit(Setting):
     name = "on_exit"
     section = "Server Hooks"


### PR DESCRIPTION
In some cases, it may be useful to perform clean up tasks similar to "OnExit", but before the workers have exited and the server has shutdown (e.g. completing background tasks and still serving requests related to them before exiting). This "OnHalt" server hook would allow a user to gracefully finish any pending server transactions/tasks before actually stopping the workers/master.