### PR TITLE
Add link to reference docs in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,10 @@ Documentation
 
 The documentation is hosted at https://docs.gunicorn.org.
 
+Reference Docs
+--------------
+https://docs.contour.so/benoitc/gunicorn/getting-started
+
 Installation
 ------------
 


### PR DESCRIPTION
Hi there!

My name is Leo, a CS student at Brown building an automated platform for editable codebase documentation.

I generated documentation for this repository and placed a link in the README. Please feel free to try it out and let me know what you think!