### PR TITLE
Document that gthread also uses worker_connections

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -1312,7 +1312,7 @@ worker_connections
 
 The maximum number of simultaneous clients.
 
-This setting only affects the Eventlet and Gevent worker types.
+This setting only affects the ``gthread``, ``eventlet`` and ``gevent`` worker types.
 
 .. _max-requests:
 


### PR DESCRIPTION
The `ThreadWorker` uses `worker_connections` it in its run loop to limit how many connections are accepted.

See https://github.com/benoitc/gunicorn/blob/4ae2a05/gunicorn/workers/gthread.py#L198