### PR TITLE
Log a warning when a worker was terminated due to a signal

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -526,6 +526,12 @@ class Arbiter(object):
                     if exitcode == self.APP_LOAD_ERROR:
                         reason = "App failed to load."
                         raise HaltServer(reason, self.APP_LOAD_ERROR)
+                    if os.WIFSIGNALED(status):
+                        self.log.warning(
+                            "Worker with pid %s was terminated due to signal %s",
+                            wpid,
+                            os.WTERMSIG(status)
+                        )
 
                     worker = self.WORKERS.pop(wpid, None)
                     if not worker:


### PR DESCRIPTION
This happens for example when being OOM killed.

See #2215