### PR TITLE
Remove the --log-config-dict flag

### DIFF
--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Unreleased
+==========
+
+- remove the `--log-dict-config` CLI flag because it never had a working format
+  (the `logconfig_dict` setting in configuration files continues to work)
+
 20.0.4 / 2019/11/26
 ===================
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1419,7 +1419,6 @@ class LogConfig(Setting):
 class LogConfigDict(Setting):
     name = "logconfig_dict"
     section = "Logging"
-    cli = ["--log-config-dict"]
     validator = validate_dict
     default = {}
     desc = """\


### PR DESCRIPTION
There is no support for decoding any dictionary supplied on the command
line. The only way to supply a dictionary logging config is through the
configuration file.

Close #1909.