### PR TITLE
Capture peer name from accept

### DIFF
--- a/gunicorn/http/parser.py
+++ b/gunicorn/http/parser.py
@@ -11,13 +11,14 @@ class Parser(object):
 
     mesg_class = None
 
-    def __init__(self, cfg, source):
+    def __init__(self, cfg, source, source_addr):
         self.cfg = cfg
         if hasattr(source, "recv"):
             self.unreader = SocketUnreader(source)
         else:
             self.unreader = IterUnreader(source)
         self.mesg = None
+        self.source_addr = source_addr
 
         # request counter (for keepalive connetions)
         self.req_count = 0
@@ -38,7 +39,7 @@ class Parser(object):
 
         # Parse the next request
         self.req_count += 1
-        self.mesg = self.mesg_class(self.cfg, self.unreader, self.req_count)
+        self.mesg = self.mesg_class(self.cfg, self.unreader, self.source_addr, self.req_count)
         if not self.mesg:
             raise StopIteration()
         return self.mesg

--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -33,7 +33,7 @@ class AsyncWorker(base.Worker):
     def handle(self, listener, client, addr):
         req = None
         try:
-            parser = http.RequestParser(self.cfg, client)
+            parser = http.RequestParser(self.cfg, client, addr)
             try:
                 listener_name = listener.getsockname()
                 if not self.cfg.keepalive:

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -53,7 +53,7 @@ class TConn(object):
                                             **self.cfg.ssl_options)
 
             # initialize the parser
-            self.parser = http.RequestParser(self.cfg, self.sock)
+            self.parser = http.RequestParser(self.cfg, self.sock, self.client)
 
     def set_timeout(self):
         # set the timeout

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -131,7 +131,7 @@ class SyncWorker(base.Worker):
                 client = ssl.wrap_socket(client, server_side=True,
                                          **self.cfg.ssl_options)
 
-            parser = http.RequestParser(self.cfg, client)
+            parser = http.RequestParser(self.cfg, client, addr)
             req = next(parser)
             self.handle_request(listener, req, client, addr)
         except http.errors.NoMoreData as e:

--- a/tests/t.py
+++ b/tests/t.py
@@ -29,7 +29,7 @@ class request(object):
     def __call__(self, func):
         def run():
             src = data_source(self.fname)
-            func(src, RequestParser(src, None))
+            func(src, RequestParser(src, None, None))
         run.func_name = func.func_name
         return run
 

--- a/tests/treq.py
+++ b/tests/treq.py
@@ -245,7 +245,7 @@ class request(object):
 
     def check(self, cfg, sender, sizer, matcher):
         cases = self.expect[:]
-        p = RequestParser(cfg, sender())
+        p = RequestParser(cfg, sender(), None)
         for req in p:
             self.same(req, sizer, matcher, cases.pop(0))
         assert not cases
@@ -282,5 +282,5 @@ class badrequest(object):
             read += chunk
 
     def check(self, cfg):
-        p = RequestParser(cfg, self.send())
+        p = RequestParser(cfg, self.send(), None)
         next(p)


### PR DESCRIPTION
Avoid calls to getpeername by capturing the peer name returned by
accept.