### PR TITLE
Typo fixed in the AsyncIO docs

### DIFF
--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -74,7 +74,7 @@ connection job. On keepalive connections are put back in the loop
 waiting for an event. If no event happen after the keep alive timeout,
 the connection is closed.
 
-You can port also your application to use aiohttp_'s `web.Application`` API and use the
+You can port also your application to use aiohttp_'s ``web.Application`` API and use the
 ``aiohttp.worker.GunicornWebWorker`` worker.
 
 Choosing a Worker Type


### PR DESCRIPTION
It used to be like this:

<img width="625" alt="Снимок экрана 2020-12-19 в 20 21 56" src="https://user-images.githubusercontent.com/4660275/102695374-e6ef2980-4237-11eb-9b8d-411d7af39b39.png">
