### PR TITLE
Move init/wrap_socket to handle phase

### DIFF
--- a/docs/source/2020-news.rst
+++ b/docs/source/2020-news.rst
@@ -10,8 +10,8 @@ Unreleased
 ==========
 
 - document WEB_CONCURRENCY is set by, at least, Heroku
-- capture peername from accept: Avoid calls to getpeername by capturing the peer name returned by
-accept
+- | capture peername from accept: Avoid calls to getpeername by capturing the peer name returned by
+  | accept
 - log a warning when a worker was terminated due to a signal
 - fix tornado usage with latest versions of Django 
 - add support for python -m gunicorn
@@ -30,11 +30,11 @@ accept
 - added PIP requirements to be used for example
 - remove version from the Server header
 - fix sendfile: use `socket.sendfile` instead of `os.sendfile`
-- reloader: use  absolute path to prevent empty to prevent0 `InotifyError` when a file 
-  is added to the working directory
+- | reloader: use  absolute path to prevent empty to prevent0 `InotifyError` when a file 
+  | is added to the working directory
 - Add --print-config option to print the resolved settings at startup.
-- remove the `--log-dict-config` CLI flag because it never had a working format
-  (the `logconfig_dict` setting in configuration files continues to work)
+- | remove the `--log-dict-config` CLI flag because it never had a working format
+  | (the `logconfig_dict` setting in configuration files continues to work)
 
 
 ** Breaking changes **

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -109,7 +109,6 @@ class ThreadWorker(base.Worker):
         fs.add_done_callback(self.finish_request)
 
     def enqueue_req(self, conn):
-        conn.init()
         # submit the connection to a worker
         fs = self.tpool.submit(self.handle, conn)
         self._wrap_future(fs, conn)
@@ -263,6 +262,7 @@ class ThreadWorker(base.Worker):
         keepalive = False
         req = None
         try:
+            conn.init()
             req = next(conn.parser)
             if not req:
                 return (False, conn)

--- a/tests/workers/test_gthread.py
+++ b/tests/workers/test_gthread.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+def test_import():
+    __import__('gunicorn.workers.gthread')


### PR DESCRIPTION
Proposed to move the ssl wrap_socket to the handle phase so a misbehaving SSL client
only blocks a single thread. Could happen when handshake is not happening on time or at all and the client keeps the connection open. Multiple misbehaving clients can still cause thread exhaustion through blocking and so a worker timeout.
The sync worker is subject to the same problem (causing a worker timeout), but there is no simple improvement for that.