### PR TITLE
Fix a naming error for gthread worker

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -106,7 +106,7 @@ class Config(object):
         # are we using a threaded worker?
         is_sync = uri.endswith('SyncWorker') or uri == 'sync'
         if is_sync and self.threads > 1:
-            return "threads"
+            return "gthread"
         return uri
 
     @property


### PR DESCRIPTION
The name for threaded worker is `gthread`, not `threads`.

This fix only affects a startup log message says `Using worker: xxx` when `sync` is used and `threads` greater than 1.