### PR TITLE
Update latest version on start page to 20.1.0

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -16,7 +16,7 @@
     <div class="logo-div">
       <div class="latest">
         Latest version: <strong><a
-            href="https://docs.gunicorn.org/en/stable/">20.0.4</a></strong>
+            href="https://docs.gunicorn.org/en/stable/">20.1.0</a></strong>
       </div>
 
       <div class="logo"><img src="images/logo.jpg" ></div>
@@ -119,7 +119,7 @@
           <li><a href="https://github.com/benoitc/gunicorn/projects/3">Mailing list</a>
         </ul>
         <p>Project maintenance guidelines are avaible on the <a href="https://github.com/benoitc/gunicorn/wiki/Project-management">wiki</a></p>
-        
+
         <h1>Irc</h1>
         <p>The Gunicorn channel is on the <a href="http://freenode.net/">Freenode</a> IRC
           network. You can chat with the community on the <a href="http://webchat.freenode.net/?channels=gunicorn">#gunicorn channel</a>.</p>


### PR DESCRIPTION
The start page still show 20.0.4 as latest version but the docs have 20.1.0 and my servers (Debian repositories) already provide 20.1.0. I guess this can display 20.1.0 now too - no ?