### PR TITLE
util.py: improve import time

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -22,8 +22,6 @@ import time
 import traceback
 import warnings
 
-import pkg_resources
-
 from gunicorn.errors import AppImportError
 from gunicorn.workers import SUPPORTED_WORKERS
 import urllib.parse
@@ -56,6 +54,8 @@ except ImportError:
 
 def load_class(uri, default="gunicorn.workers.sync.SyncWorker",
                section="gunicorn.workers"):
+    import pkg_resources
+
     if inspect.isclass(uri):
         return uri
     if uri.startswith("egg:"):

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -52,10 +52,14 @@ except ImportError:
         pass
 
 
-def load_class(uri, default="gunicorn.workers.sync.SyncWorker",
-               section="gunicorn.workers"):
+def _load_entry_point(dist, section, name):
     import pkg_resources
 
+    return pkg_resources.load_entry_point(dist, section, name)
+
+
+def load_class(uri, default="gunicorn.workers.sync.SyncWorker",
+               section="gunicorn.workers"):
     if inspect.isclass(uri):
         return uri
     if uri.startswith("egg:"):
@@ -68,7 +72,7 @@ def load_class(uri, default="gunicorn.workers.sync.SyncWorker",
             name = default
 
         try:
-            return pkg_resources.load_entry_point(dist, section, name)
+            return _load_entry_point(dist, section, name)
         except Exception:
             exc = traceback.format_exc()
             msg = "class uri %r invalid or not found: \n\n[%s]"
@@ -85,7 +89,7 @@ def load_class(uri, default="gunicorn.workers.sync.SyncWorker",
                     break
 
                 try:
-                    return pkg_resources.load_entry_point(
+                    return _load_entry_point(
                         "gunicorn", section, uri
                     )
                 except Exception:


### PR DESCRIPTION
I know in general people hesitate to improve import time by deferring imports, but I claim this is worth it! `import pkg_resources` is really, really slow, often measured in seconds (e.g., see https://github.com/pypa/setuptools/issues/510 / the existence of importlib.metadata in the standard library in Python 3.8+).

Import times might not matter too much to gunicorn, but e.g. this impacts the import time of aiohttp, which is used for many things other than servers.

Resolves #2613 