### PR TITLE
Add boot_timeout setting

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -28,6 +28,7 @@ Ben Oswald <ben.oswald@root-space.de>
 Benjamin Gilbert <bgilbert@backtick.net>
 Benoit Chesneau <bchesneau@gmail.com>
 Berker Peksag <berker.peksag@gmail.com>
+bhiller <benhiller@gmail.com>
 bninja <andrew@poundpay.com>
 Bob Hagemann <bob+code@twilio.com>
 Bobby Beckmann <bobby@macs-MacBook-Pro.local>

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -100,6 +100,7 @@ class Arbiter(object):
         self.address = self.cfg.address
         self.num_workers = self.cfg.workers
         self.timeout = self.cfg.timeout
+        self.boot_timeout = self.cfg.boot_timeout
         self.proc_name = self.cfg.proc_name
 
         self.log.debug('Current configuration:\n{0}'.format(
@@ -487,12 +488,21 @@ class Arbiter(object):
         """\
         Kill unused/idle workers
         """
-        if not self.timeout:
+        if not self.timeout and not self.boot_timeout:
             return
         workers = list(self.WORKERS.items())
         for (pid, worker) in workers:
             try:
-                if time.time() - worker.tmp.last_update() <= self.timeout:
+                timeout = None
+                if worker.tmp.has_updated():
+                    timeout = self.timeout
+                else:
+                    timeout = self.boot_timeout or self.timeout
+
+                time_since_update = time.time() - worker.tmp.last_update()
+                timed_out = timeout and time_since_update > timeout
+
+                if not timed_out:
                     continue
             except (OSError, ValueError):
                 continue

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -789,6 +789,27 @@ class Timeout(Setting):
         """
 
 
+
+class BootTimeout(Setting):
+    name = "boot_timeout"
+    section = "Worker Processes"
+    cli = ["--boot-timeout"]
+    meta = "INT"
+    validator = validate_pos_int
+    type = int
+    default = 0
+    desc = """\
+        This implements the same behavior as timeout but is applied for workers
+        before they enter the booted state. This is useful if the worker may be
+        slow to boot but should have a lower timeout once it has booted and
+        begun handling requests.
+
+        If this is set to 0 then the timeout setting will be applied during
+        boot instead.
+        """
+
+
+
 class GracefulTimeout(Setting):
     name = "graceful_timeout"
     section = "Worker Processes"

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -137,6 +137,11 @@ class Worker(object):
 
         self.cfg.post_worker_init(self)
 
+        # Notify before setting booted to True, in case the arbiter evaluates
+        # the timeout after booted is set to True, but before the worker has
+        # called notify
+        self.notify()
+
         # Enter main run loop
         self.booted = True
         self.run()

--- a/gunicorn/workers/workertmp.py
+++ b/gunicorn/workers/workertmp.py
@@ -11,7 +11,6 @@ from gunicorn import util
 
 PLATFORM = platform.system()
 IS_CYGWIN = PLATFORM.startswith('CYGWIN')
-HAS_UPDATED_FLAG = 2
 
 
 class WorkerTmp(object):
@@ -22,9 +21,6 @@ class WorkerTmp(object):
         if fdir and not os.path.isdir(fdir):
             raise RuntimeError("%s doesn't exist. Can't create workertmp." % fdir)
         fd, name = tempfile.mkstemp(prefix="wgunicorn-", dir=fdir)
-        # Reset the file permissions so that we can reliably check whether
-        # notify has been called in has_updated
-        os.fchmod(fd, 0)
         os.umask(old_umask)
 
         # change the owner and group of the file if the worker will run as
@@ -43,17 +39,18 @@ class WorkerTmp(object):
             os.close(fd)
             raise
 
+        self.initial_ctime = os.fstat(self._tmp.fileno()).st_ctime
         self.spinner = 0
 
     def notify(self):
         self.spinner = (self.spinner + 1) % 2
-        os.fchmod(self._tmp.fileno(), HAS_UPDATED_FLAG | self.spinner)
+        os.fchmod(self._tmp.fileno(), self.spinner)
 
     def last_update(self):
         return os.fstat(self._tmp.fileno()).st_ctime
 
     def has_updated(self):
-        return bool(os.fstat(self._tmp.fileno()).st_mode & HAS_UPDATED_FLAG)
+        return os.fstat(self._tmp.fileno()).st_ctime > self.initial_ctime
 
     def fileno(self):
         return self._tmp.fileno()


### PR DESCRIPTION
Summary: We have an issue with our use of gunicorn where the workers
frequently timeout during boot due to our 29s timeout. That is a
reasonable timeout once they start handling requests, but it doesn't
really make sense for booting, which can be slower without impacting 
request latency.

Unfortunately, gunicorn currently only lets us set a single timeout that
controls both the worker booting and responding to requests. This PR 
adds a new setting to guicorn, `--boot-timeout`, which would allow us 
to set a longer timeout for workers when they are booting.

To preserve backwards compatibility with existing gunicorn
configurations, I have `boot-timeout` default to 0. One difference between
`boot-timeout` and `timeout` is that I have the arbiter interpret a
`boot-timeout` value of 0 as meaning it should fallback to the `timeout`
setting. This should mean this can be committed without changing any
existing behavior, though it does mean there is a difference between
what a value of 0 means for `timeout` vs `boot-timeout`. Let me know what
you think the right trade-off here is.

I tried to adhere to the contribution guidelines here. I have not added
unit tests, but can look into that if this seems like a change you'd
want to merge. I also ran the command to update `settings.rst` but it
seemed to generate other changes as well to things I hadn't touched, so
I left that out for now, but can also add that in assuming the other changes
 are things which would be included once someone else ran that command.
I did run the existing test suite and confirmed they passed after this change.

Relevant Issue: #2196

Test Plan: Added `print` statements to `murder_workers` to print whether
or not the worker was considered booted, and what timeout was applied.
Used that along with a `print` statement in `post_worker_init` to confirm
that the worker was correctly considered booted after it was
initialized.

First, tried a config where `timeout` was set to a non-zero value but
`boot-timeout` was 0 (the default) and confirmed that we used the
`timeout` value before and after the worker was booted.

Next, tried a config where `timeout` was set to a non-zero value and
`boot-timeout` was also set to a non-zero value. Confirmed we used the
`boot-timeout` value during worker initialization, and `timeout`
afterwards.

Finally, tried a config where `timeout` was set to 0 and
`boot-timeout` was set to a non-zero value. Confirmed we used the
`boot-timeout` value during worker initialization, and did not apply a
timeout afterwards. (This seems like it would be an odd configuration, 
but just wanted to check it behaved as expected).