### PR TITLE
[Tornado] Remove outdated condition

### DIFF
--- a/gunicorn/workers/gtornado.py
+++ b/gunicorn/workers/gtornado.py
@@ -105,12 +105,8 @@ class TornadoWorker(Worker):
         # instance of tornado.web.Application or is an
         # instance of tornado.wsgi.WSGIApplication
         app = self.wsgi
-
-        if tornado.version_info[0] < 6:
-            if not isinstance(app, tornado.web.Application) or \
-            isinstance(app, tornado.wsgi.WSGIApplication):
-                app = WSGIContainer(app)
-        elif not isinstance(app, WSGIContainer):
+        
+        if not isinstance(app, tornado.web.Application) or isinstance(app, WSGIContainer):
             app = WSGIContainer(app)
 
         # Monkey-patching HTTPConnection.finish to count the


### PR DESCRIPTION
Hi,

This `PR` simply removes a condition for tornado woker.

This condition was made for backward compatibility, but I think could be removed.

Could you confirm that this `PR` does not break your `django` app @duanhongyi  ?

Regards,