### PR TITLE
Implement a metric that records the queuing time…

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -266,7 +266,14 @@ class ThreadWorker(base.Worker):
         try:
             start_time = time.monotonic()
             queued_time_ms = round((start_time - enqueue_time) * 1000)
-            self.log.histogram("gunicorn.request_queued_time_ms", queued_time_ms)
+            self.log.debug(
+                "request was queued for %s ms", queued_time_ms,
+                extra={
+                    "mtype": "histogram",
+                    "metric": "gunicorn.request_queued_time_ms",
+                    "value": queued_time_ms,
+                }
+            )
             req = next(conn.parser)
             if not req:
                 return (False, conn)


### PR DESCRIPTION
… between when we accept a connection and when a thread picks it up. This can detect situations where requests are backed up with thread starvation.

Fixes #2555 