### PR TITLE
Fix __init__ for dummy InotifyReloader

### DIFF
--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -118,7 +118,7 @@ if has_inotify:
 else:
 
     class InotifyReloader(object):
-        def __init__(self, callback=None):
+        def __init__(self, extra_files=None, callback=None):
             raise ImportError('You must have the inotify module installed to '
                               'use the inotify reloader')
 


### PR DESCRIPTION
To raise `ImportError` when `InotifyReloader` is not available,
init params for the dummy `InotifyReloader` should be the same
as params in the real one. 

Otherwise, when init the dummy `InotifyReloader` under `Worker.init_process()`,
`self.reloader = reloader_cls(extra_files=self.cfg.reload_extra_files, callback=changed)`,
it will raise `TypeError` but not the expected `ImportError`.

```diff
if has_inotify:

    class InotifyReloader(threading.Thread):
        def __init__(self, extra_files=None, callback=None):
            ...

else:

    class InotifyReloader(object):
-        def __init__(self, callback=None):
+        def __init__(self, extra_files=None, callback=None):
            raise ImportError('You must have the inotify module installed to '
                              'use the inotify reloader')
```