### PR TITLE
Fix descriptions for Arbiter.murder_workers

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -485,7 +485,7 @@ class Arbiter(object):
 
     def murder_workers(self):
         """\
-        Kill unused/idle workers
+        Kill workers timed out
         """
         if not self.timeout:
             return

--- a/gunicorn/http/parser.py
+++ b/gunicorn/http/parser.py
@@ -20,7 +20,7 @@ class Parser(object):
         self.mesg = None
         self.source_addr = source_addr
 
-        # request counter (for keepalive connetions)
+        # request counter (for keepalive connections)
         self.req_count = 0
 
     def __iter__(self):


### PR DESCRIPTION
Changed the description for `Arbiter.murder_workers()`. 

In my understanding, this function is used to cleanup workers timed out, which indicates the workers fall into a bad state. Not for cleaning up idle workers. "idle" sounds like the workers have no requests to process and just run in a loop waiting for coming requests. When reading the source code, the original description did confuse me a while.