### PR TITLE
Typo fix for reexec related environ variables

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -93,7 +93,7 @@ class Arbiter(object):
             self.log = self.cfg.logger_class(app.cfg)
 
         # reopen files
-        if 'GUNICORN_FD' in os.environ:
+        if 'GUNICORN_PID' in os.environ:
             self.log.reopen_files()
 
         self.worker_class = self.cfg.worker_class


### PR DESCRIPTION
~~Commit 1 is a refactor. The others are reexec environ related.~~

~~### Commit 1~~
~~Moved `Arbiter.log.close_on_exec()` from `Arbiter.init_signals()` to `Arbiter.setup()`. Seem more appropriate.~~

~~### Commit 2~~
~~In `Arbiter.maybe_promote_master()`, cleanup more env variables passed from `Arbiter.reexec()` called in parent.~~

~~Considering whether to unset `LISTEN_PID`, `LISTEN_FDS` is handled by `systemd.listen_fds(unset_environment=True)` under `Arbiter.start()`. I leave these two env vars alone.~~

### Commit 3
In `Arbiter.reexec()`, `GUNICORN_FD` may not be passed to the new master process,

```python
    def reexec(self):
        ...
        self.cfg.pre_exec(self)
        # CO(lk): use env vars to pass pid, fds to the new `reexec`ed child process
        environ = self.cfg.env_orig.copy()
        environ['GUNICORN_PID'] = str(master_pid)

        if self.systemd:
            environ['LISTEN_PID'] = str(os.getpid())
            environ['LISTEN_FDS'] = str(len(self.LISTENERS))
        else:
            environ['GUNICORN_FD'] = ','.join(
                str(l.fileno()) for l in self.LISTENERS)

        os.chdir(self.START_CTX['cwd'])
        # exec the process using the original environment
        os.execvpe(self.START_CTX[0], self.START_CTX['args'], environ)
```

Replace `GUNICORN_FD` with `GUNICORN_PID` instead to detect whether a process is a `reexec`ed process.

```python
    def setup(self, app):
        # reopen files
        if 'GUNICORN_PID' in os.environ:
            self.log.reopen_files()
```

-----

