### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10

### DIFF
--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -17,7 +17,7 @@ COMPILED_EXT_RE = re.compile(r'py[co]$')
 class Reloader(threading.Thread):
     def __init__(self, extra_files=None, interval=1, callback=None):
         super().__init__()
-        self.setDaemon(True)
+        self.daemon = True
         self._extra_files = set(extra_files or ())
         self._interval = interval
         self._callback = callback
@@ -74,7 +74,7 @@ if has_inotify:
 
         def __init__(self, extra_files=None, callback=None):
             super().__init__()
-            self.setDaemon(True)
+            self.daemon = True
             self._callback = callback
             self._dirs = set()
             self._watcher = Inotify()


### PR DESCRIPTION
Fixes #2569 