### PR TITLE
Move init/wrap_socket to handle phase

### DIFF
--- a/docs/source/2021-news.rst
+++ b/docs/source/2021-news.rst
@@ -10,8 +10,8 @@ Changelog - 2021
 ===================
 
 - document WEB_CONCURRENCY is set by, at least, Heroku
-- capture peername from accept: Avoid calls to getpeername by capturing the peer name returned by
-  accept
+- | capture peername from accept: Avoid calls to getpeername by capturing the peer name returned by
+  | accept
 - log a warning when a worker was terminated due to a signal
 - fix tornado usage with latest versions of Django 
 - add support for python -m gunicorn
@@ -30,11 +30,11 @@ Changelog - 2021
 - added PIP requirements to be used for example
 - remove version from the Server header
 - fix sendfile: use `socket.sendfile` instead of `os.sendfile`
-- reloader: use  absolute path to prevent empty to prevent0 `InotifyError` when a file 
-  is added to the working directory
+- | reloader: use  absolute path to prevent empty to prevent0 `InotifyError` when a file 
+  | is added to the working directory
 - Add --print-config option to print the resolved settings at startup.
-- remove the `--log-dict-config` CLI flag because it never had a working format
-  (the `logconfig_dict` setting in configuration files continues to work)
+- | remove the `--log-dict-config` CLI flag because it never had a working format
+  | (the `logconfig_dict` setting in configuration files continues to work)
 
 
 ** Breaking changes **

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -46,6 +46,8 @@ class TConn(object):
 
     def init(self):
         self.sock.setblocking(True)
+
+    def wrap(self):
         if self.parser is None:
             # wrap the socket if needed
             if self.cfg.is_ssl:
@@ -260,6 +262,7 @@ class ThreadWorker(base.Worker):
             fs.conn.close()
 
     def handle(self, conn):
+        conn.wrap()
         keepalive = False
         req = None
         try:


### PR DESCRIPTION
Proposed to move the ssl wrap_socket to the handle phase so a
misbehaving SSL client only blocks a single thread.
Could happen when handshake is not happening on time or at all
and the client keeps the connection open. Multiple misbehaving
clients can still cause thread exhaustion through blocking and
so a worker timeout.
The sync worker is subject to the same problem
(causing a worker timeout), but there is no simple
improvement for that.