### PR TITLE
Fix compatibility with latest eventlet

### DIFF
--- a/gunicorn/workers/geventlet.py
+++ b/gunicorn/workers/geventlet.py
@@ -17,7 +17,13 @@ else:
 
 from eventlet import hubs, greenthread
 from eventlet.greenio import GreenSocket
-from eventlet.wsgi import ALREADY_HANDLED as EVENTLET_ALREADY_HANDLED
+
+try:
+    from eventlet.wsgi import ALREADY_HANDLED as EVENTLET_ALREADY_HANDLED
+except ImportError:
+    # Since eventlet 0.30.3
+    from eventlet.wsgi import WSGI_LOCAL as EVENTLET_ALREADY_HANDLED
+
 import greenlet
 
 from gunicorn.workers.base_async import AsyncWorker


### PR DESCRIPTION
Fix issue with import error while using latest eventlet (>=0.30.3).

Changes made in eventlet: https://github.com/benoitc/gunicorn/pull/2581