### PR TITLE
ci: fix CI failures due to grp import on windows

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -7,7 +7,6 @@
 
 import argparse
 import copy
-import grp
 import inspect
 import os
 import pwd
@@ -481,8 +480,9 @@ def validate_group(val):
         return int(val)
     else:
         try:
+            import grp
             return grp.getgrnam(val).gr_gid
-        except KeyError:
+        except (ImportError, KeyError):
             raise ConfigError("No such group: '%s'" % val)
 
 


### PR DESCRIPTION
Example failing build: https://ci.appveyor.com/project/benoitc/gunicorn/builds/40090320/job/5vy7s88qiu0dlv0n