### PR TITLE
Defer import of pkg_resources until it is actually required

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -22,7 +22,6 @@ import time
 import traceback
 import warnings
 
-import pkg_resources
 
 from gunicorn.errors import AppImportError
 from gunicorn.workers import SUPPORTED_WORKERS
@@ -54,6 +53,11 @@ except ImportError:
         pass
 
 
+def _load_entry_point(dist, section, name):
+    import pkg_resources
+    return pkg_resources.load_entry_point(dist, section, name)
+
+
 def load_class(uri, default="gunicorn.workers.sync.SyncWorker",
                section="gunicorn.workers"):
     if inspect.isclass(uri):
@@ -68,7 +72,7 @@ def load_class(uri, default="gunicorn.workers.sync.SyncWorker",
             name = default
 
         try:
-            return pkg_resources.load_entry_point(dist, section, name)
+            return _load_entry_point(dist, section, name)
         except Exception:
             exc = traceback.format_exc()
             msg = "class uri %r invalid or not found: \n\n[%s]"
@@ -85,7 +89,7 @@ def load_class(uri, default="gunicorn.workers.sync.SyncWorker",
                     break
 
                 try:
-                    return pkg_resources.load_entry_point(
+                    return _load_entry_point(
                         "gunicorn", section, uri
                     )
                 except Exception:


### PR DESCRIPTION
Import performance of pkg_resources is slow due to path enumeration
done during the import.

See the issue https://github.com/pypa/setuptools/issues/510

To avoid unnecessary work we only discover entrypoints once we
know that worker uri specified with "egg:" prefix

For my particular case import takes ~1s with this patch it's 60ms