### PR TITLE
Improve access-log-format documentation section

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -200,7 +200,7 @@ Identifier   Description
 ===========  ===========
 h            remote address
 l            ``'-'``
-u            user name
+u            user name (if HTTP Basic auth used)
 t            date of the request
 r            status line (e.g. ``GET / HTTP/1.1``)
 m            request method


### PR DESCRIPTION
Added more clearly info about user name identifier (u). That will save a bit of time for developers due log configuration, like this guy https://stackoverflow.com/questions/51660511/gunicorn-access-logs-shows-empty-user