### PR TITLE
fix: log access log when a client closed the connection

### DIFF
--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -115,9 +115,9 @@ class AsyncWorker(base.Worker):
                     for item in respiter:
                         resp.write(item)
                 resp.close()
+            finally:
                 request_time = datetime.now() - request_start
                 self.log.access(resp, req, environ, request_time)
-            finally:
                 if hasattr(respiter, "close"):
                     respiter.close()
             if resp.should_close():

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -329,9 +329,9 @@ class ThreadWorker(base.Worker):
                         resp.write(item)
 
                 resp.close()
+            finally:
                 request_time = datetime.now() - request_start
                 self.log.access(resp, req, environ, request_time)
-            finally:
                 if hasattr(respiter, "close"):
                     respiter.close()
 

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -184,9 +184,9 @@ class SyncWorker(base.Worker):
                     for item in respiter:
                         resp.write(item)
                 resp.close()
+            finally:
                 request_time = datetime.now() - request_start
                 self.log.access(resp, req, environ, request_time)
-            finally:
                 if hasattr(respiter, "close"):
                     respiter.close()
         except EnvironmentError:


### PR DESCRIPTION
When a client closed the connection, resp.write(item) would raised a BrokenPipeError which prevents the access from being logged.

Fixes #1060.