### PR TITLE
Replace deprecated unittest alias

### DIFF
--- a/examples/frameworks/django/testing/testing/apps/someapp/tests.py
+++ b/examples/frameworks/django/testing/testing/apps/someapp/tests.py
@@ -12,7 +12,7 @@ class SimpleTest(TestCase):
         """
         Tests that 1 + 1 always equals 2.
         """
-        self.failUnlessEqual(1 + 1, 2)
+        self.assertEqual(1 + 1, 2)
 
 __test__ = {"doctest": """
 Another way to test that 1 + 1 is equal to 2.


### PR DESCRIPTION
> *Deprecated since version 3.1:* The fail* aliases listed in the second column have been deprecated.

https://docs.python.org/3/library/unittest.html#deprecated-aliases
