### PR TITLE
docs: add examples for cert-reqs

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -540,6 +540,16 @@ TLS_SERVER    Auto-negotiate the highest protocol version like TLS,
 
 Whether client certificate is required (see stdlib ssl module's)
 
+**Options:** 
+
+`--cert-reqs=0` --- no client veirifcation
+
+`--cert-reqs=1` --- ssl.CERT_OPTIONAL
+
+`--cert-reqs=2` --- ssl.CERT_REQUIRED
+
+
+
 .. _ca-certs:
 
 ``ca_certs``

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -2088,6 +2088,13 @@ class CertReqs(Setting):
     default = ssl.CERT_NONE
     desc = """\
     Whether client certificate is required (see stdlib ssl module's)
+    ==============  ===========================
+    `--cert-reqs=0` --- no client veirifcation
+
+    `--cert-reqs=1` --- ssl.CERT_OPTIONAL
+
+    `--cert-reqs=2` --- ssl.CERT_REQUIRED
+    ==============  ===========================
     """
 
 


### PR DESCRIPTION
Closes https://github.com/benoitc/gunicorn/issues/1198

I spent quite a lot of time to figure out what flag/validator value I should use for `cert-reqs` when I was trying to make the client verification optional - the request can be accepted by my server regardless the client provides a certificate or not. During the research process, I find [the SSL section of the documentation](https://docs.gunicorn.org/en/stable/settings.html#cert-reqs) could use some improvement here as new users like me would not be able to think of which number (0, 1, 2) stands for which verification mode on the spot. 

I find an open issue https://github.com/benoitc/gunicorn/issues/1198 raised in 2016 mentioning the same ambiguity about the `cert-reqs` flag in the docs that I am also facing. There wasn't a PR raised back then, so I am raising this one to address this issue now.