### PR TITLE
Step 1 of 2 in enabling gunicorn to run on Windows

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -33,6 +33,7 @@ Bob Hagemann <bob+code@twilio.com>
 Bobby Beckmann <bobby@macs-MacBook-Pro.local>
 Brett Randall <javabrett@gmail.com>
 Brian Rosner <brosner@gmail.com>
+Bryan A. Jones <bjones@ece.msstate.edu>
 Bruno Bigras <bigras.bruno@gmail.com>
 Caleb Brown <git@calebbrown.id.au>
 Chris Adams <chris@improbable.org>

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -41,8 +41,11 @@ class Arbiter(object):
 
     # I love dynamic languages
     SIG_QUEUE = []
-    SIGNALS = [getattr(signal, "SIG%s" % x)
-               for x in "HUP QUIT INT TERM TTIN TTOU USR1 USR2 WINCH".split()]
+    SIGNALS = []
+    for x in "HUP QUIT INT TERM TTIN TTOU USR1 USR2 WINCH".split():
+        signal = getattr(signal, "SIG%s" % x, None)
+        if signal:
+            SIGNALS.append(signal)
     SIG_NAMES = dict(
         (getattr(signal, name), name[3:].lower()) for name in dir(signal)
         if name[:3] == "SIG" and name[3] != "_"

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -100,7 +100,7 @@ class TCP6Socket(TCPSocket):
 
 class UnixSocket(BaseSocket):
 
-    FAMILY = socket.AF_UNIX
+    FAMILY = None if util.is_win else socket.AF_UNIX
 
     def __init__(self, addr, conf, log, fd=None):
         if fd is None:
@@ -132,7 +132,7 @@ def _sock_type(addr):
             sock_type = TCP6Socket
         else:
             sock_type = TCPSocket
-    elif isinstance(addr, (str, bytes)):
+    elif isinstance(addr, (str, bytes)) and not util.is_win:
         sock_type = UnixSocket
     else:
         raise TypeError("Unable to create socket from: %r" % addr)

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -5,14 +5,12 @@
 import ast
 import email.utils
 import errno
-import fcntl
 import html
 import importlib
 import inspect
 import io
 import logging
 import os
-import pwd
 import random
 import re
 import socket
@@ -27,6 +25,11 @@ import pkg_resources
 from gunicorn.errors import AppImportError
 from gunicorn.workers import SUPPORTED_WORKERS
 import urllib.parse
+
+is_win = sys.platform.startswith("win")
+if not is_win:
+    import fcntl
+    import pwd
 
 REDIRECT_TO = getattr(os, 'devnull', '/dev/null')
 
@@ -244,9 +247,7 @@ def parse_address(netloc, default_port='8000'):
 
 
 def close_on_exec(fd):
-    flags = fcntl.fcntl(fd, fcntl.F_GETFD)
-    flags |= fcntl.FD_CLOEXEC
-    fcntl.fcntl(fd, fcntl.F_SETFD, flags)
+    os.set_inheritable(fd, False)
 
 
 def set_non_blocking(fd):


### PR DESCRIPTION
Per #524, this is the first step in enabling gunicorn to run on Windows.  The missing piece: getting a non-blocking `os.pipe` running on Windows (see notes below). My implementation decisions:
- In `arbiter.py`, only add signals supported by the current platform. (Windows doesn't support many of the Unix signals).
- In `config.py`, disallow setting `user` or `group` for Windows only.
- In `sock.py`, don't support Unix sockets on Windows. (While Windows 10 now supports `AF_UNIX`, [Python doesn't](https://bugs.python.org/issue33408)).
- In `utils.py`, use `os.set_inheritable` instead of direct calls to fcntl. The [underlying C code on Unix](https://github.com/python/cpython/blob/main/Python/fileutils.c#L1406) calls fcntl, so this should have no impact on Unix.

Based on the [contribution guidelines](https://github.com/benoitc/gunicorn/blob/master/CONTRIBUTING.md), I have:

- Named this branch `524-windows-1-of-2`, considering Windows support a feature rather than a bugfix.
- There are (not yet) relevant unit tests, since this doesn't (yet) run on Windows, and creation of a Windows test suite probably deserves some discussion.
- Wrote (IMHO) clean code.
- Provided a clear description and referenced #524.
- No documentation updates apply: it doesn't fully support Windows yet, and there's no mention I can find of Windows support in the docs to change.
- I ran tests using Ubuntu using Python 3.8, since the Appveyor tests fail (why do we have Appveyor CI for gunicorn?) and the Travis tests are disabled (???). In the master branch, all the tests in `tests/test_valid_request.py` failed on the master branch; these changes didn't produce any additional failures.
- Added my name to THANKS.

However, I haven't discussed the design. I'm a bit confused here -- the link to the mailing list took me to the [community](https://gunicorn.org/#community) page, where clicking on the mailing list link brings me to the [project page](https://github.com/benoitc/gunicorn/projects/3). I see the [card for Windows support](https://github.com/benoitc/gunicorn/projects/3#card-1863696), but this links to issue #524. Is that issue the location for the discussion?

# Non-blocking `os.pipe` for Windows
This is the most difficult part of the code. Here are my notes on what needs to be done:

The [Python implementation of os.pipe](https://github.com/python/cpython/blob/main/Modules/posixmodule.c#L10105) calls [CreatePipe](https://docs.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-createpipe). Unfortunately, `CreatePipe` [only provides blocking I/O](https://docs.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-createpipe#remarks).

However, [named pipes do allow non-blocking I/O](https://docs.microsoft.com/en-us/windows/win32/ipc/synchronous-and-overlapped-input-and-output). Windows-specific Python code using the win32 API should therefore provide a replacement for the current Unix-only approach. Several code snippets ([1](https://github.com/PeiSeng/Named_Pipe_Communication), [2](https://stackoverflow.com/questions/50040067/how-to-create-a-non-blocking-named-pipe-from-python)) might provide guidance on writing these routines.
