### PR TITLE
Platform-independent inter-process communication

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -33,6 +33,7 @@ Bob Hagemann <bob+code@twilio.com>
 Bobby Beckmann <bobby@macs-MacBook-Pro.local>
 Brett Randall <javabrett@gmail.com>
 Brian Rosner <brosner@gmail.com>
+Bryan A. Jones <bjones@ece.msstate.edu>
 Bruno Bigras <bigras.bruno@gmail.com>
 Caleb Brown <git@calebbrown.id.au>
 Chris Adams <chris@improbable.org>

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -179,7 +179,7 @@ class Arbiter(object):
             os.close(p)
 
         # initialize the pipe
-        self.PIPE = util.get_ipc_pipes()
+        self.PIPE = util.InterProcessCommunicator()
 
         self.log.close_on_exec()
 
@@ -331,7 +331,7 @@ class Arbiter(object):
         """\
         Wake up the arbiter by writing to the PIPE
         """
-        util.ipc_pipe_write(self.PIPE, b'.', allow_again=True)
+        self.PIPE.write(b'.', allow_again=True)
 
     def halt(self, reason=None, exit_status=0):
         """ halt arbiter """
@@ -350,10 +350,10 @@ class Arbiter(object):
         A readable PIPE means a signal occurred.
         """
         try:
-            ready = util.ipc_pipe_wait([util.ipc_pipe_wait_fd(self.PIPE)], 1.0)
+            ready = self.PIPE.wait([self.PIPE.wait_fd()], 1.0)
             if not ready[0]:
                 return
-            while util.ipc_pipe_read(self.PIPE, 1):
+            while self.PIPE.read(1):
                 pass
         except (select.error, OSError) as e:
             # TODO: select.error is a subclass of OSError since Python 3.3.

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -41,8 +41,11 @@ class Arbiter(object):
 
     # I love dynamic languages
     SIG_QUEUE = []
-    SIGNALS = [getattr(signal, "SIG%s" % x)
-               for x in "HUP QUIT INT TERM TTIN TTOU USR1 USR2 WINCH".split()]
+    SIGNALS = []
+    for x in "HUP QUIT INT TERM TTIN TTOU USR1 USR2 WINCH".split():
+        signal = getattr(signal, "SIG%s" % x, None)
+        if signal:
+            SIGNALS.append(signal)
     SIG_NAMES = dict(
         (getattr(signal, name), name[3:].lower()) for name in dir(signal)
         if name[:3] == "SIG" and name[3] != "_"

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1065,19 +1065,20 @@ class Chdir(Setting):
         """
 
 
-class Daemon(Setting):
-    name = "daemon"
-    section = "Server Mechanics"
-    cli = ["-D", "--daemon"]
-    validator = validate_bool
-    action = "store_true"
-    default = False
-    desc = """\
-        Daemonize the Gunicorn process.
+if not util.is_win:
+    class Daemon(Setting):
+        name = "daemon"
+        section = "Server Mechanics"
+        cli = ["-D", "--daemon"]
+        validator = validate_bool
+        action = "store_true"
+        default = False
+        desc = """\
+            Daemonize the Gunicorn process.
 
-        Detaches the server from the controlling terminal and enters the
-        background.
-        """
+            Detaches the server from the controlling terminal and enters the
+            background.
+            """
 
 
 class Env(Setting):
@@ -1279,69 +1280,69 @@ class ForwardedAllowIPS(Setting):
 
         By default, the value of the ``FORWARDED_ALLOW_IPS`` environment
         variable. If it is not defined, the default is ``"127.0.0.1"``.
-        
+
         .. note::
-        
+
             The interplay between the request headers, the value of ``forwarded_allow_ips``, and the value of
-            ``secure_scheme_headers`` is complex. Various scenarios are documented below to further elaborate. In each case, we 
+            ``secure_scheme_headers`` is complex. Various scenarios are documented below to further elaborate. In each case, we
             have a request from the remote address 134.213.44.18, and the default value of ``secure_scheme_headers``:
-            
+
             .. code::
-            
+
                 secure_scheme_headers = {
                     'X-FORWARDED-PROTOCOL': 'ssl',
                     'X-FORWARDED-PROTO': 'https',
                     'X-FORWARDED-SSL': 'on'
                 }
-            
-        
-            .. list-table:: 
+
+
+            .. list-table::
                 :header-rows: 1
                 :align: center
                 :widths: auto
-                
+
                 * - ``forwarded-allow-ips``
                   - Secure Request Headers
                   - Result
                   - Explanation
-                * - .. code:: 
-                    
+                * - .. code::
+
                         ["127.0.0.1"]
                   - .. code::
-                  
+
                         X-Forwarded-Proto: https
-                  - .. code:: 
-                    
+                  - .. code::
+
                         wsgi.url_scheme = "http"
                   - IP address was not allowed
-                * - .. code:: 
-                    
+                * - .. code::
+
                         "*"
                   - <none>
-                  - .. code:: 
-                    
+                  - .. code::
+
                         wsgi.url_scheme = "http"
                   - IP address allowed, but no secure headers provided
-                * - .. code:: 
-                    
+                * - .. code::
+
                         "*"
                   - .. code::
-                  
+
                         X-Forwarded-Proto: https
-                  - .. code:: 
-                    
+                  - .. code::
+
                         wsgi.url_scheme = "https"
                   - IP address allowed, one request header matched
-                * - .. code:: 
-                    
+                * - .. code::
+
                         ["134.213.44.18"]
                   - .. code::
-                  
+
                         X-Forwarded-Ssl: on
                         X-Forwarded-Proto: http
                   - ``InvalidSchemeHeaders()`` raised
                   - IP address allowed, but the two secure headers disagreed on if HTTPS was used
-                
+
 
         """
 
@@ -1592,21 +1593,22 @@ class SyslogFacility(Setting):
     """
 
 
-class EnableStdioInheritance(Setting):
-    name = "enable_stdio_inheritance"
-    section = "Logging"
-    cli = ["-R", "--enable-stdio-inheritance"]
-    validator = validate_bool
-    default = False
-    action = "store_true"
-    desc = """\
-    Enable stdio inheritance.
+if not util.is_win:
+    class EnableStdioInheritance(Setting):
+        name = "enable_stdio_inheritance"
+        section = "Logging"
+        cli = ["-R", "--enable-stdio-inheritance"]
+        validator = validate_bool
+        default = False
+        action = "store_true"
+        desc = """\
+        Enable stdio inheritance.
 
-    Enable inheritance for stdio file descriptors in daemon mode.
+        Enable inheritance for stdio file descriptors in daemon mode.
 
-    Note: To disable the Python stdout buffering, you can to set the user
-    environment variable ``PYTHONUNBUFFERED`` .
-    """
+        Note: To disable the Python stdout buffering, you can to set the user
+        environment variable ``PYTHONUNBUFFERED`` .
+        """
 
 
 # statsD monitoring

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -100,7 +100,7 @@ class TCP6Socket(TCPSocket):
 
 class UnixSocket(BaseSocket):
 
-    FAMILY = socket.AF_UNIX
+    FAMILY = None if util.is_win else socket.AF_UNIX
 
     def __init__(self, addr, conf, log, fd=None):
         if fd is None:
@@ -132,7 +132,7 @@ def _sock_type(addr):
             sock_type = TCP6Socket
         else:
             sock_type = TCPSocket
-    elif isinstance(addr, (str, bytes)):
+    elif isinstance(addr, (str, bytes)) and not util.is_win:
         sock_type = UnixSocket
     else:
         raise TypeError("Unable to create socket from: %r" % addr)

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -5,14 +5,12 @@
 import ast
 import email.utils
 import errno
-import fcntl
 import html
 import importlib
 import inspect
 import io
 import logging
 import os
-import pwd
 import random
 import re
 import socket
@@ -27,6 +25,11 @@ import pkg_resources
 from gunicorn.errors import AppImportError
 from gunicorn.workers import SUPPORTED_WORKERS
 import urllib.parse
+
+is_win = sys.platform.startswith("win")
+if not is_win:
+    import fcntl
+    import pwd
 
 REDIRECT_TO = getattr(os, 'devnull', '/dev/null')
 
@@ -244,9 +247,7 @@ def parse_address(netloc, default_port='8000'):
 
 
 def close_on_exec(fd):
-    flags = fcntl.fcntl(fd, fcntl.F_GETFD)
-    flags |= fcntl.FD_CLOEXEC
-    fcntl.fcntl(fd, fcntl.F_SETFD, flags)
+    os.set_inheritable(fd, False)
 
 
 def set_non_blocking(fd):

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -13,6 +13,7 @@ import logging
 import os
 import random
 import re
+import select
 import socket
 import sys
 import textwrap
@@ -250,9 +251,36 @@ def close_on_exec(fd):
     os.set_inheritable(fd, False)
 
 
-def set_non_blocking(fd):
-    flags = fcntl.fcntl(fd, fcntl.F_GETFL) | os.O_NONBLOCK
-    fcntl.fcntl(fd, fcntl.F_SETFL, flags)
+# Return a tuple ``(read_pipe, write_pipe)`` capable of performing non-blocking communication between processes.
+def get_ipc_pipes():
+    pipes = os.pipe()
+    for pipe in pipes:
+        close_on_exec(pipe)
+        # Make this pipe non-blocking.
+        flags = fcntl.fcntl(pipe, fcntl.F_GETFL) | os.O_NONBLOCK
+        fcntl.fcntl(pipe, fcntl.F_SETFL, flags)
+    return pipes
+
+
+def ipc_pipe_write(pipes, data, allow_again=False):
+    try:
+        os.write(pipes[1], data)
+    except IOError as e:
+        if allow_again and e.errno not in [errno.EAGAIN, errno.EINTR]:
+            raise
+
+
+def ipc_pipe_read(pipes, bytes):
+    return os.read(pipes[0], bytes)
+
+
+# Waits only make sense on a read.
+def ipc_pipe_wait_fd(pipes):
+    return pipes[0]
+
+
+def ipc_pipe_wait(fd_list, timeout):
+    return select.select(fd_list, [], [], timeout)
 
 
 def close(sock):

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -101,17 +101,14 @@ class Worker(object):
         util.seed()
 
         # For waking ourselves up
-        self.PIPE = os.pipe()
-        for p in self.PIPE:
-            util.set_non_blocking(p)
-            util.close_on_exec(p)
+        self.PIPE = util.get_ipc_pipes()
 
         # Prevent fd inheritance. TODO: this is pointless. All newly-created sockets are non-inheritable per the `Python docs <https://docs.python.org/3/library/socket.html#socket.socket>`_. Likewise, per the `docs <https://docs.python.org/3/library/os.html#inheritance-of-file-descriptors>`_, "file descriptors created by Python are non-inheritable by default."
         for s in self.sockets:
             util.close_on_exec(s.fileno())
         util.close_on_exec(self.tmp.fileno())
 
-        self.wait_fds = self.sockets + [self.PIPE[0]]
+        self.wait_fds = self.sockets + [util.ipc_pipe_wait_fd(self.PIPE)]
 
         self.log.close_on_exec()
 
@@ -122,7 +119,7 @@ class Worker(object):
             def changed(fname):
                 self.log.info("Worker reloading: %s modified", fname)
                 self.alive = False
-                os.write(self.PIPE[1], b"1")
+                util.ipc_pipe_write(self.PIPE, b"1")
                 self.cfg.worker_int(self)
                 time.sleep(0.1)
                 sys.exit(0)
@@ -181,8 +178,9 @@ class Worker(object):
         signal.siginterrupt(signal.SIGTERM, False)
         signal.siginterrupt(signal.SIGUSR1, False)
 
-        if hasattr(signal, 'set_wakeup_fd'):
-            signal.set_wakeup_fd(self.PIPE[1])
+        # TODO: add this to the signal hanlders, if possible. There's no obvious equivalent to this.
+        ##if hasattr(signal, 'set_wakeup_fd'):
+            ##signal.set_wakeup_fd(self.PIPE[1])
 
     def handle_usr1(self, sig, frame):
         self.log.reopen_files()

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -106,9 +106,9 @@ class Worker(object):
             util.set_non_blocking(p)
             util.close_on_exec(p)
 
-        # Prevent fd inheritance
+        # Prevent fd inheritance. TODO: this is pointless. All newly-created sockets are non-inheritable per the `Python docs <https://docs.python.org/3/library/socket.html#socket.socket>`_. Likewise, per the `docs <https://docs.python.org/3/library/os.html#inheritance-of-file-descriptors>`_, "file descriptors created by Python are non-inheritable by default."
         for s in self.sockets:
-            util.close_on_exec(s)
+            util.close_on_exec(s.fileno())
         util.close_on_exec(self.tmp.fileno())
 
         self.wait_fds = self.sockets + [self.PIPE[0]]

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -27,7 +27,7 @@ class SyncWorker(base.Worker):
     def accept(self, listener):
         client, addr = listener.accept()
         client.setblocking(1)
-        util.close_on_exec(client)
+        util.close_on_exec(client.fileno())
         self.handle(listener, client, addr)
 
     def wait(self, timeout):

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -33,10 +33,10 @@ class SyncWorker(base.Worker):
     def wait(self, timeout):
         try:
             self.notify()
-            ret = util.ipc_pipe_wait(self.wait_fds, timeout)
+            ret = self.PIPE.wait(self.wait_fds, timeout)
             if ret[0]:
-                if self.PIPE[0] in ret[0]:
-                    util.ipc_pipe_read(self.PIPE, 1)
+                if self.PIPE.wait_fd() in ret[0]:
+                    self.PIPE.read(1)
                 return ret[0]
 
         except select.error as e:
@@ -96,7 +96,7 @@ class SyncWorker(base.Worker):
 
             if ready is not None:
                 for listener in ready:
-                    if listener == self.PIPE[0]:
+                    if listener == self.PIPE.wait_fd():
                         continue
 
                     try:

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -33,10 +33,10 @@ class SyncWorker(base.Worker):
     def wait(self, timeout):
         try:
             self.notify()
-            ret = select.select(self.wait_fds, [], [], timeout)
+            ret = util.ipc_pipe_wait(self.wait_fds, timeout)
             if ret[0]:
                 if self.PIPE[0] in ret[0]:
-                    os.read(self.PIPE[0], 1)
+                    util.ipc_pipe_read(self.PIPE, 1)
                 return ret[0]
 
         except select.error as e:


### PR DESCRIPTION
This PR follows #2636 in the process of enabling gunicorn to run on Windows. This draft PR provides an opportunity for others to view my progress. Expect force pushes/rebases/etc. while this is a draft.

Progress: all pipe-based IPC is now encapsulated in a class.
Plans: move this class to a [multi-platform approach](https://docs.python.org/3/library/multiprocessing.html#multiprocessing-listeners-clients).

Problems: `os.fork` is the core of gunicorn's multiprocessing approach, and should never be changed for Unix. For Windows only, we need to look for a nice way to start a new process then send all relevant data copied by `os.fork` to that new process. I propose completing this change then placing that work in a separate PR.