### PR TITLE
2295: export worker utilization to StatsD

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -556,13 +556,15 @@ class Arbiter(object):
             (pid, _) = workers.pop(0)
             self.kill_worker(pid, signal.SIGTERM)
 
+        busy_workers = sum([ 1 for worker in workers if worker[1].busy ])
+
         active_worker_count = len(workers)
         if self._last_logged_active_worker_count != active_worker_count:
             self._last_logged_active_worker_count = active_worker_count
-            self.log.debug("{0} workers".format(active_worker_count),
-                           extra={"metric": "gunicorn.workers",
-                                  "value": active_worker_count,
-                                  "mtype": "gauge"})
+            self.log.debug("{0} workers".format(active_worker_count))
+
+        self.log.gauge("gunicorn.workers", active_worker_count)
+        self.log.gauge("gunicorn.busy_workers", busy_workers)
 
     def spawn_worker(self):
         self.worker_age += 1

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -556,7 +556,7 @@ class Arbiter(object):
             (pid, _) = workers.pop(0)
             self.kill_worker(pid, signal.SIGTERM)
 
-        busy_workers = sum([ 1 for worker in workers if worker[1].busy.value == 1 ])
+        busy_workers = sum([ 1 for worker in workers if worker[1].busy.value ])
 
         active_worker_count = len(workers)
         if self._last_logged_active_worker_count != active_worker_count:

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -556,7 +556,7 @@ class Arbiter(object):
             (pid, _) = workers.pop(0)
             self.kill_worker(pid, signal.SIGTERM)
 
-        busy_workers = sum([ 1 for worker in workers if worker[1].busy ])
+        busy_workers = sum([ 1 for worker in workers if worker[1].busy.value == 1 ])
 
         active_worker_count = len(workers)
         if self._last_logged_active_worker_count != active_worker_count:

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -60,6 +60,7 @@ class Worker(object):
             self.max_requests = sys.maxsize
 
         self.alive = True
+        self.busy = False
         self.log = log
         self.tmp = WorkerTmp(cfg)
 

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from random import randint
 from ssl import SSLError
 from multiprocessing import Value
+import ctypes
 
 from gunicorn import util
 from gunicorn.http.errors import (
@@ -61,7 +62,7 @@ class Worker(object):
             self.max_requests = sys.maxsize
 
         self.alive = True
-        self.busy = Value('i', 0)
+        self.busy = Value(ctypes.c_bool, False)
         self.log = log
         self.tmp = WorkerTmp(cfg)
 

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -12,6 +12,7 @@ import traceback
 from datetime import datetime
 from random import randint
 from ssl import SSLError
+from multiprocessing import Value
 
 from gunicorn import util
 from gunicorn.http.errors import (
@@ -60,7 +61,7 @@ class Worker(object):
             self.max_requests = sys.maxsize
 
         self.alive = True
-        self.busy = False
+        self.busy = Value('i', 0)
         self.log = log
         self.tmp = WorkerTmp(cfg)
 

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -165,7 +165,7 @@ class SyncWorker(base.Worker):
         resp = None
         try:
             self.cfg.pre_request(self, req)
-            self.busy = True
+            self.busy.value = 1
             request_start = datetime.now()
             resp, environ = wsgi.create(req, client, addr,
                                         listener.getsockname(), self.cfg)
@@ -207,7 +207,7 @@ class SyncWorker(base.Worker):
             raise
         finally:
             try:
-                self.busy = False
+                self.busy.value = 0
                 self.cfg.post_request(self, req, environ, resp)
             except Exception:
                 self.log.exception("Exception in post_request hook")

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -165,7 +165,7 @@ class SyncWorker(base.Worker):
         resp = None
         try:
             self.cfg.pre_request(self, req)
-            self.busy.value = 1
+            self.busy.value = True
             request_start = datetime.now()
             resp, environ = wsgi.create(req, client, addr,
                                         listener.getsockname(), self.cfg)
@@ -207,7 +207,7 @@ class SyncWorker(base.Worker):
             raise
         finally:
             try:
-                self.busy.value = 0
+                self.busy.value = False
                 self.cfg.post_request(self, req, environ, resp)
             except Exception:
                 self.log.exception("Exception in post_request hook")

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -165,6 +165,7 @@ class SyncWorker(base.Worker):
         resp = None
         try:
             self.cfg.pre_request(self, req)
+            self.busy = True
             request_start = datetime.now()
             resp, environ = wsgi.create(req, client, addr,
                                         listener.getsockname(), self.cfg)
@@ -206,6 +207,7 @@ class SyncWorker(base.Worker):
             raise
         finally:
             try:
+                self.busy = False
                 self.cfg.post_request(self, req, environ, resp)
             except Exception:
                 self.log.exception("Exception in post_request hook")


### PR DESCRIPTION
Closes #2295 

This is a very early draft of a proof of concept on how to expose worker utilization in statsd. It still has a lot of work ahead of it, but I wanted to share it early to know if the concept is viable and if it is worth pursuing the idea 😄 

### Why?

The use case is the same as in #2295, we use gunicorn extensively in our web services, and we want to automatically scale up and down based on how many of the workers are busy handling a request.

Having this metric would allow us to make a query in our HPAs that would somewhat resemble this:

```
(gunicorn.busy_workers / gunicorn.workers) * 100
```

And then set the target to a certain percentage of workers to scale up or down automatically.

### How?

I've noticed the `manage_workers` method in the arbiter is the one responsible for keeping track of workers, and it already seemed to send absolute worker values too.

The first thing I did was ensure the workers metric was sent periodically instead of only when there is a change, as the HPAs will only evaluate a short timespan, and so they need this metric to be re-sent often, otherwise it is considered missing data.

Then, the second thing I did was add to the sync workers information on whether they were busy processing a request or not, and to have the arbiter fetch that information.

Given the arbiter spawns subprocesses for the workers, to ensure they could read the information I used [multiprocessing's Values](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Value), that allocate the given object in shared memory between the parent and the child process. This allows the arbiter to read the information that the workers write in there, currently just a single boolean.

### Considered alternatives

A quick Google will show many people suggesting the use of the `pre_request` and `post_request` hooks to send and `increment` and a `decrement`. We've tried that, but multiple times we had problems with the resulting values when trying to interpret them in Datadog. Every time the number of busy workers would become negative. I think this is related to the way Datadog parses and implements counters, but we weren't able to reach the bottom of the cause.

### Next steps

This little PoC is already functional, but it is still far from being in mergeable conditions. If you agree that the idea and the implementation are viable, the next steps would be to:

- [ ] Ensure the metrics are sent to statsd at a lower rate (around every 5 or 10 seconds)
- [ ] Ensure the arbiter continues working even when the logging agent isn't the Statsd instrumentation logger
- [ ] Possibly implement this for more workers, if it makes sense in their case
- [ ] Add unit tests

So that's the whole idea. If you agree that this is a good solution and that it is useful for the project, I'd like to continue working on this PR to get it up to shape to merge 😄 