### PR TITLE
Fix RuntimeError caused by logging in the SIGCHLD signal handler

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -508,6 +508,7 @@ class Arbiter(object):
         """\
         Reap workers to avoid zombie processes
         """
+        # Method is called by SIGCHLD signal handler; we cannot log anything
         try:
             while True:
                 wpid, status = os.waitpid(-1, os.WNOHANG)
@@ -526,12 +527,6 @@ class Arbiter(object):
                     if exitcode == self.APP_LOAD_ERROR:
                         reason = "App failed to load."
                         raise HaltServer(reason, self.APP_LOAD_ERROR)
-                    if os.WIFSIGNALED(status):
-                        self.log.warning(
-                            "Worker with pid %s was terminated due to signal %s",
-                            wpid,
-                            os.WTERMSIG(status)
-                        )
 
                     worker = self.WORKERS.pop(wpid, None)
                     if not worker:


### PR DESCRIPTION
This PR is to fix an issue introduced by b695b49. This issue is also described in #2564. The problem is that we are logging something in the signal handler, which is not reentrant.

The issue occurs if Gunicorn happens to be logging something (for example [here](https://github.com/benoitc/gunicorn/blob/master/gunicorn/arbiter.py#L501)) and gets interrupted by SIGCHLD at that moment. This invokes the signal handler handle_chld()  ([here](https://github.com/benoitc/gunicorn/blob/master/gunicorn/arbiter.py#L240])), which calls reap_workers().

reap_workers() however logs a warning [here](https://github.com/benoitc/gunicorn/blob/master/gunicorn/arbiter.py#L530-L534), causing the following RuntimeError:
`RuntimeError: reentrant call inside <_io.BufferedWriter name='<stderr>'>`

Operations on BufferedWriter are unfortunately not reentrant, so we can only fix this by (a) not logging in the signal handler or (b) only setting a flag in signal handler and do the processing later.

This PR fixes the problem by removing the log message in the signal handler.