### PR TITLE
GitHub Action to run tox

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,42 @@
+name: tox
+on: [push, pull_request]
+jobs:
+  tox-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install --upgrade pip
+      - run: tox -e lint
+
+  tox-docs-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install --upgrade pip
+      - run: tox -e docs-lint
+
+  tox-pycodestyle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install --upgrade pip
+      - run: tox -e pycodestyle
+
+  tox:
+    strategy:
+      fail-fast: false
+      matrix:  # All OSes pass except Windows because tests need Unix-only fcntl, grp, pwd, etc.
+        os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
+        python: ['3.10']  # ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.7']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - run: pip install --upgrade pip
+      - run: pip install tox
+      - run: tox -e py

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -7,6 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: pip install --upgrade pip
+      - run: pip install tox
       - run: tox -e lint
 
   tox-docs-lint:
@@ -15,6 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: pip install --upgrade pip
+      - run: pip install tox
       - run: tox -e docs-lint
 
   tox-pycodestyle:
@@ -23,6 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: pip install --upgrade pip
+      - run: pip install tox
       - run: tox -e pycodestyle
 
   tox:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,17 +2,23 @@ version: '{branch}.{build}'
 environment:
   matrix:
     - TOXENV: lint
-      PYTHON: "C:\\Python37-x64"
-    - TOXENV: py35
-      PYTHON: "C:\\Python35-x64"
-    - TOXENV: py36
-      PYTHON: "C:\\Python36-x64"
-    - TOXENV: py37
-      PYTHON: "C:\\Python37-x64"
-    - TOXENV: py38
       PYTHON: "C:\\Python38-x64"
-    - TOXENV: py39
-      PYTHON: "C:\\Python39-x64"
+    - TOXENV: docs-lint
+      PYTHON: "C:\\Python38-x64"
+    - TOXENV: pycodestyle
+      PYTHON: "C:\\Python38-x64"
+    # Windows is not ready for testing!!!
+    # Python's fcntl, grp, pwd, os.geteuid(), and socket.AF_UNIX are all Unix-only.
+    #- TOXENV: py35
+    #  PYTHON: "C:\\Python35-x64"
+    #- TOXENV: py36
+    #  PYTHON: "C:\\Python36-x64"
+    #- TOXENV: py37
+    #  PYTHON: "C:\\Python37-x64"
+    #- TOXENV: py38
+    #  PYTHON: "C:\\Python38-x64"
+    #- TOXENV: py39
+    #  PYTHON: "C:\\Python39-x64"
 matrix:
   allow_failures:
     - TOXENV: py35
@@ -20,11 +26,13 @@ matrix:
     - TOXENV: py37
     - TOXENV: py38
     - TOXENV: py39
-init: SET "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+init:
+  - SET "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 install:
   - pip install tox
-build: off
-test_script: tox
+build: false
+test_script:
+  - tox
 cache:
   # Not including the .tox directory since it takes longer to download/extract
   # the cache archive than for tox to clean install from the pip cache.

--- a/tests/workers/test_geventlet.py
+++ b/tests/workers/test_geventlet.py
@@ -2,11 +2,6 @@
 #
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
-import pytest
 
-
-@pytest.mark.xfail(
-    reason="TypeError: cannot set 'is_timeout' of immutable type 'TimeoutError'"
-)
 def test_import():
     __import__('gunicorn.workers.geventlet')

--- a/tests/workers/test_geventlet.py
+++ b/tests/workers/test_geventlet.py
@@ -2,6 +2,11 @@
 #
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
+import pytest
 
+
+@pytest.mark.xfail(
+    reason="TypeError: cannot set 'is_timeout' of immutable type 'TimeoutError'"
+)
 def test_import():
     __import__('gunicorn.workers.geventlet')

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps =
 [testenv:lint]
 commands =
   pylint -j0 \
-    --disable=consider-using-f-string,consider-using-from-import,consider-using-with,deprecated-method,unspecified-encoding \
     gunicorn \
     tests/test_arbiter.py \
     tests/test_config.py \
@@ -48,4 +47,3 @@ deps =
 
 [pycodestyle]
 max-line-length = 127
-ignore = E122,E126,E128,E129,E226,E302,E303,E501,E722,E741,W291,W293,W503,W504,W606

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,17 @@
 [tox]
-envlist = py35, py36, py37, py38, py39, pypy3, lint
+envlist = py35, py36, py37, py38, py39, py310, pypy3, lint, docs-lint, pycodestyle
 skipsdist = True
 
 [testenv]
 usedevelop = True
-commands = py.test --cov=gunicorn {posargs}
+commands = pytest --cov=gunicorn {posargs}
 deps =
   -rrequirements_test.txt
 
 [testenv:lint]
 commands =
   pylint -j0 \
+    --disable=consider-using-f-string,consider-using-from-import,consider-using-with,deprecated-method,unspecified-encoding \
     gunicorn \
     tests/test_arbiter.py \
     tests/test_config.py \
@@ -46,5 +47,5 @@ deps =
   pycodestyle
 
 [pycodestyle]
-max-line-length = 120
-ignore = E129,W503,W504,W606
+max-line-length = 127
+ignore = E122,E126,E128,E129,E226,E302,E303,E501,E722,E741,W291,W293,W503,W504,W606

--- a/tox.ini
+++ b/tox.ini
@@ -46,4 +46,5 @@ deps =
   pycodestyle
 
 [pycodestyle]
-max-line-length = 127
+max-line-length = 120
+ignore = E129,W503,W504,W606


### PR DESCRIPTION
___GitHub Actions test results:___ https://github.com/cclauss/gunicorn/actions

Because Travis CI seems to be on vacation... https://travis-ci.org/github/benoitc/gunicorn

___TypeError: cannot set 'is_timeout' attribute of immutable type 'TimeoutError'___
```
============================= test session starts ==============================
platform linux -- Python 3.10.0, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
cachedir: .tox/py/.pytest_cache
rootdir: /home/runner/work/gunicorn/gunicorn, configfile: setup.cfg, testpaths: tests/
plugins: cov-3.0.0
collected 224 items

[ ... ]
tests/workers/test_geventlet.py F                                        [ 99%]
tests/workers/test_ggevent.py .                                          [100%]

=================================== FAILURES ===================================
_________________________________ test_import __________________________________

    def test_import():
>       __import__('gunicorn.workers.geventlet')

tests/workers/test_geventlet.py:7: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
gunicorn/workers/geventlet.py:10: in <module>
    import eventlet
.tox/py/lib/python3.10/site-packages/eventlet/__init__.py:17: in <module>
    from eventlet import convenience
.tox/py/lib/python3.10/site-packages/eventlet/convenience.py:7: in <module>
    from eventlet.green import socket
.tox/py/lib/python3.10/site-packages/eventlet/green/socket.py:4: in <module>
    __import__('eventlet.green._socket_nodns')
.tox/py/lib/python3.10/site-packages/eventlet/green/_socket_nodns.py:11: in <module>
    from eventlet import greenio
.tox/py/lib/python3.10/site-packages/eventlet/greenio/__init__.py:3: in <module>
    from eventlet.greenio.base import *  # noqa
.tox/py/lib/python3.10/site-packages/eventlet/greenio/base.py:32: in <module>
    socket_timeout = eventlet.timeout.wrap_is_timeout(socket.timeout)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

base = <class 'TimeoutError'>

    def wrap_is_timeout(base):
        '''Adds `.is_timeout=True` attribute to objects returned by `base()`.
    
        When `base` is class, attribute is added as read-only property. Returns `base`.
        Otherwise, it returns a function that sets attribute on result of `base()` call.
    
        Wrappers make best effort to be transparent.
        '''
        if inspect.isclass(base):
>           base.is_timeout = property(lambda _: True)
E           TypeError: cannot set 'is_timeout' attribute of immutable type 'TimeoutError'

.tox/py/lib/python3.10/site-packages/eventlet/timeout.py:166: TypeError
=============================== warnings summary ===============================
tests/workers/test_geventlet.py::test_import
  /home/runner/work/gunicorn/gunicorn/.tox/py/lib/python3.10/site-packages/eventlet/support/greenlets.py:1: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    import distutils.version

-- Docs: https://docs.pytest.org/en/stable/warnings.html

---------- coverage: platform linux, python 3.10.0-final-0 -----------
Coverage XML written to file coverage.xml

=========================== short test summary info ============================
FAILED tests/workers/test_geventlet.py::test_import - TypeError: cannot set '...
=================== 1 failed, 223 passed, 1 warning in 7.99s ===================
```