### PR TITLE
Use Appveyor Ubuntu, not Appveyor Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,20 +8,22 @@ version: '{branch}.{build}'
 environment:
   matrix:
     - TOXENV: lint
-      stack: python 3.9
+      PYTHON: 3.9
     - TOXENV: docs-lint
-      stack: python 3.9
+      PYTHON: 3.9
     - TOXENV: pycodestyle
-      stack: python 3.9
+      PYTHON: 3.9
     - TOXENV: py36
-      stack: python 3.6
+      PYTHON: 3.6
     - TOXENV: py37
-      stack: python 3.7
+      PYTHON: 3.7
     - TOXENV: py38
-      stack: python 3.8
+      PYTHON: 3.8
     - TOXENV: py39
-      stack: python 3.9
+      PYTHON: 3.9
     # - TOXENV: py310  # Not yet present on Appveyor Ubuntu image
+    #   PYTHON: 3.9
+stack: python $PYTHON
 install:
   - pip install --upgrade pip
   - pip install tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,8 @@
+# appveyor.yml
+---
+# https://www.appveyor.com/docs/getting-started-with-appveyor-for-linux
+# https://www.appveyor.com/docs/lang/python
+
 image: Ubuntu
 version: '{branch}.{build}'
 environment:
@@ -9,13 +14,13 @@ environment:
     - TOXENV: py37
     - TOXENV: py38
     - TOXENV: py39
-    - TOXENV: py310  # Not yet present on Appveyor Ubuntu image
+    # - TOXENV: py310  # Not yet present on Appveyor Ubuntu image
 install:
-  - pip install --upgrade pip
-  - pip install tox
+  - python3 -m pip install --upgrade pip
+  - python3 -m pip install tox
 build: false
 test_script:
-  - tox
+  - python3 -m tox
 notifications:
   - provider: Email
     on_build_success: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@
 # https://www.appveyor.com/docs/lang/python
 
 image: Ubuntu
+stack: python 3.9
 version: '{branch}.{build}'
 environment:
   matrix:
@@ -16,11 +17,11 @@ environment:
     - TOXENV: py39
     # - TOXENV: py310  # Not yet present on Appveyor Ubuntu image
 install:
-  - python3 -m pip install --upgrade pip
-  - python3 -m pip install tox
+  - pip install --upgrade pip
+  - pip install tox
 build: false
 test_script:
-  - python3 -m tox
+  - tox
 notifications:
   - provider: Email
     on_build_success: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,34 +1,21 @@
+image: Ubuntu
 version: '{branch}.{build}'
 environment:
   matrix:
     - TOXENV: lint
-      PYTHON: "C:\\Python37-x64"
-    - TOXENV: py35
-      PYTHON: "C:\\Python35-x64"
-    - TOXENV: py36
-      PYTHON: "C:\\Python36-x64"
-    - TOXENV: py37
-      PYTHON: "C:\\Python37-x64"
-    - TOXENV: py38
-      PYTHON: "C:\\Python38-x64"
-    - TOXENV: py39
-      PYTHON: "C:\\Python39-x64"
-matrix:
-  allow_failures:
-    - TOXENV: py35
+    - TOXENV: docs-lint
+    - TOXENV: pycodestyle
     - TOXENV: py36
     - TOXENV: py37
     - TOXENV: py38
     - TOXENV: py39
-init: SET "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+    - TOXENV: py310  # Not yet present on Appveyor Ubuntu image
 install:
+  - pip install --upgrade pip
   - pip install tox
-build: off
-test_script: tox
-cache:
-  # Not including the .tox directory since it takes longer to download/extract
-  # the cache archive than for tox to clean install from the pip cache.
-  - '%LOCALAPPDATA%\pip\Cache -> tox.ini'
+build: false
+test_script:
+  - tox
 notifications:
   - provider: Email
     on_build_success: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,17 +4,23 @@
 # https://www.appveyor.com/docs/lang/python
 
 image: Ubuntu
-stack: python 3.9
 version: '{branch}.{build}'
 environment:
   matrix:
     - TOXENV: lint
+      stack: python 3.9
     - TOXENV: docs-lint
+      stack: python 3.9
     - TOXENV: pycodestyle
+      stack: python 3.9
     - TOXENV: py36
+      stack: python 3.6
     - TOXENV: py37
+      stack: python 3.7
     - TOXENV: py38
+      stack: python 3.8
     - TOXENV: py39
+      stack: python 3.9
     # - TOXENV: py310  # Not yet present on Appveyor Ubuntu image
 install:
   - pip install --upgrade pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,11 @@
 # https://www.appveyor.com/docs/getting-started-with-appveyor-for-linux
 # https://www.appveyor.com/docs/lang/python
 
-image: Ubuntu
 version: '{branch}.{build}'
+image:
+  # - macOS
+  - Ubuntu
+  # - Visual Studio 2019
 environment:
   matrix:
     - TOXENV: lint

--- a/tests/workers/test_geventlet.py
+++ b/tests/workers/test_geventlet.py
@@ -2,11 +2,6 @@
 #
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
-import pytest
 
-
-@pytest.mark.xfail(
-    reason="TypeError: cannot set 'is_timeout' of immutable type 'TimeoutError'"
-)
 def test_import():
     __import__('gunicorn.workers.geventlet')

--- a/tests/workers/test_geventlet.py
+++ b/tests/workers/test_geventlet.py
@@ -2,6 +2,11 @@
 #
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
+import pytest
 
+
+@pytest.mark.xfail(
+    reason="TypeError: cannot set 'is_timeout' of immutable type 'TimeoutError'"
+)
 def test_import():
     __import__('gunicorn.workers.geventlet')

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,17 @@
 [tox]
-envlist = py35, py36, py37, py38, py39, pypy3, lint
+envlist = py35, py36, py37, py38, py39, py310, pypy3, lint, docs-lint, pycodestyle
 skipsdist = True
 
 [testenv]
 usedevelop = True
-commands = py.test --cov=gunicorn {posargs}
+commands = pytest --cov=gunicorn {posargs}
 deps =
   -rrequirements_test.txt
 
 [testenv:lint]
 commands =
   pylint -j0 \
+    --disable=consider-using-f-string,consider-using-from-import,consider-using-with,deprecated-method,unspecified-encoding \
     gunicorn \
     tests/test_arbiter.py \
     tests/test_config.py \
@@ -46,5 +47,5 @@ deps =
   pycodestyle
 
 [pycodestyle]
-max-line-length = 120
-ignore = E129,W503,W504,W606
+max-line-length = 127
+ignore = E122,E126,E128,E129,E226,E302,E303,E501,E722,E741,W291,W293,W503,W504,W606


### PR DESCRIPTION
Windows is not ready for testing!!!
* Python's `fcntl`, `grp`, `pwd`, `os.geteuid()`, and `socket.AF_UNIX` are all ___Unix-only___.