### PR TITLE
Fix sendfile behaviour for open files with non-zero offset

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -372,7 +372,7 @@ class Response(object):
             chunk_size = "%X\r\n" % nbytes
             self.sock.sendall(chunk_size.encode('utf-8'))
 
-        self.sock.sendfile(respiter.filelike, count=nbytes)
+        self.sock.sendfile(respiter.filelike, offset=offset, count=nbytes)
 
         if self.is_chunked():
             self.sock.sendall(b"\r\n")


### PR DESCRIPTION
Closes #2669

This issue was caused by Gunicorn not passing the _offset_ parameter to [`socket.sendfile()`](https://docs.python.org/3/library/socket.html#socket.socket.sendfile), which is in turned caused by a deeper issue of the latter being a sloppy wrapper around the [`sendfile`](https://linux.die.net/man/2/sendfile) syscall, which takes an offset pointer parameter, and the default `NULL` values indicates that the current offset should be preserved; however Python's default of 0 means to spool back to the first byte of the file.

@benoitc I don't know what is the best way of adding a test for this -- the majority of current tests run by `tox` seem to be quite simple unit tests, whereas in this case it would probably make more sense to write a system test by spinning up a real Gunicorn process. If you pointed to a good way of adding such a test, I could add it. I didn't find any references to `sendfile` in the current test suite.