### PR TITLE
Update documentation for `worker-connections` setting

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -1415,7 +1415,7 @@ This setting only affects the Gthread worker type.
 
 The maximum number of simultaneous clients.
 
-This setting only affects the Eventlet and Gevent worker types.
+This setting only affects the Eventlet, Gevent, and Thread worker types.
 
 .. _max-requests:
 


### PR DESCRIPTION
The thread worker type is affected by the `worker_connections` setting so this updates the documentation to reflect that (see [here](https://github.com/benoitc/gunicorn/blob/master/gunicorn/workers/gthread.py#L198)).