### PR TITLE
Update wsgi.py

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -180,7 +180,11 @@ def create(req, sock, client, server, cfg):
     # set the path and script name
     path_info = req.path
     if script_name:
-        path_info = path_info.split(script_name, 1)[1]
+        try:
+            path_info = path_info.split(script_name, 1)[1]
+        except IndexError:
+            pass     # If script_name not part of path_info leave path_info alone
+        
     environ['PATH_INFO'] = util.unquote_to_wsgi_str(path_info)
     environ['SCRIPT_NAME'] = script_name
 


### PR DESCRIPTION
Fix issue when gunicorn throw exception when it using as application server for pgadmin4 v6.4. Issue present because on some url script name not present in gequesting path

Description of issue
--------------------------

On runing gunicorn for pgadmin with:
```
gunicorn -b 0.0.0.0:8080 --log-syslog --chdir "$pgadmin_app" "pgadmin_wsgi:application"
```
When tring to get access to site error is rising:

```
       Traceback (most recent call last):
         File "/opt/pgadmin/.e/lib/python3.8/site-packages/gunicorn/workers/sync.py", line 136, in handle
           self.handle_request(listener, req, client, addr)
         File "/opt/pgadmin/.e/lib/python3.8/site-packages/gunicorn/workers/sync.py", line 169, in handle_request
           resp, environ = wsgi.create(req, client, addr,
         File "/opt/pgadmin/.e/lib/python3.8/site-packages/gunicorn/http/wsgi.py", line 183, in create
           path_info = path_info.split(script_name, 1)[1]
       IndexError: list index out of range
```
Variables values:
* `path_info`: `'/'`
* `script_name`: `'/pgadmin4'`
   
Purpose of the change
------------------------------

Leave `path_info` as-is if it is not contain `script_name` 