### PR TITLE
Ensure fd 0 stdin </dev/null is always inheritable

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -109,6 +109,7 @@ Kyle Mulka <repalviglator@yahoo.com>
 Lars Hansson <romabysen@gmail.com>
 Leonardo Santagada <santagada@gmail.com>
 Levi Gross <levi@levigross.com>
+licunlong <shenxiaogll@163.com>
 Łukasz Kucharski <lkucharski@leon.pl>
 Mahmoud Hashemi <mahmoudrhashemi@gmail.com>
 Malthe Borch <mborch@gmail.com>

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -486,7 +486,10 @@ def daemonize(enable_stdio_inheritance=False):
             closerange(0, 3)
 
             fd_null = os.open(REDIRECT_TO, os.O_RDWR)
+            # PEP 446, make fd for /dev/null inheritable
+            os.set_inheritable(fd_null, True)
 
+            # expect fd_null to be always 0 here, but in-case not ...
             if fd_null != 0:
                 os.dup2(fd_null, 0)
 
@@ -494,13 +497,17 @@ def daemonize(enable_stdio_inheritance=False):
             os.dup2(fd_null, 2)
 
         else:
-            fd_null = os.open(REDIRECT_TO, os.O_RDWR)
-
             # Always redirect stdin to /dev/null as we would
             # never expect to need to read interactive input.
 
+            os.close(0)
+
+            fd_null = os.open(REDIRECT_TO, os.O_RDWR)
+            # PEP 446, make fd for /dev/null inheritable
+            os.set_inheritable(fd_null, True)
+
+            # expect fd_null to be always 0 here, but in-case not ...
             if fd_null != 0:
-                os.close(0)
                 os.dup2(fd_null, 0)
 
             # If stdout and stderr are still connected to

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -497,17 +497,13 @@ def daemonize(enable_stdio_inheritance=False):
             os.dup2(fd_null, 2)
 
         else:
+            fd_null = os.open(REDIRECT_TO, os.O_RDWR)
+
             # Always redirect stdin to /dev/null as we would
             # never expect to need to read interactive input.
 
-            os.close(0)
-
-            fd_null = os.open(REDIRECT_TO, os.O_RDWR)
-            # PEP 446, make fd for /dev/null inheritable
-            os.set_inheritable(fd_null, True)
-
-            # expect fd_null to be always 0 here, but in-case not ...
             if fd_null != 0:
+                os.close(0)
                 os.dup2(fd_null, 0)
 
             # If stdout and stderr are still connected to

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -472,6 +472,19 @@ def daemonize(enable_stdio_inheritance=False):
 
         os.umask(0o22)
 
+        # Always redirect stdin to /dev/null as we would
+        # never expect to need to read interactive input.
+
+        os.close(0)
+
+        fd_null = os.open(REDIRECT_TO, os.O_RDWR)
+        # PEP 446, make fd for /dev/null inheritable
+        os.set_inheritable(fd_null, True)
+
+        # expect fd_null to be always 0 here, but in-case not ...
+        if fd_null != 0:
+            os.dup2(fd_null, 0)
+
         # In both the following any file descriptors above stdin
         # stdout and stderr are left untouched. The inheritance
         # option simply allows one to have output go to a file
@@ -479,37 +492,17 @@ def daemonize(enable_stdio_inheritance=False):
         # to use --error-log option.
 
         if not enable_stdio_inheritance:
-            # Remap all of stdin, stdout and stderr on to
+            # Remap remaining fds stdout and stderr on to
             # /dev/null. The expectation is that users have
             # specified the --error-log option.
 
-            closerange(0, 3)
-
-            fd_null = os.open(REDIRECT_TO, os.O_RDWR)
-            # PEP 446, make fd for /dev/null inheritable
-            os.set_inheritable(fd_null, True)
-
-            # expect fd_null to be always 0 here, but in-case not ...
-            if fd_null != 0:
-                os.dup2(fd_null, 0)
+            # 1/stdout, 2/stderr - 0/stdin already done above
+            closerange(1, 3)
 
             os.dup2(fd_null, 1)
             os.dup2(fd_null, 2)
 
         else:
-            # Always redirect stdin to /dev/null as we would
-            # never expect to need to read interactive input.
-
-            os.close(0)
-
-            fd_null = os.open(REDIRECT_TO, os.O_RDWR)
-            # PEP 446, make fd for /dev/null inheritable
-            os.set_inheritable(fd_null, True)
-
-            # expect fd_null to be always 0 here, but in-case not ...
-            if fd_null != 0:
-                os.dup2(fd_null, 0)
-
             # If stdout and stderr are still connected to
             # their original file descriptors we check to see
             # if they are associated with terminal devices.


### PR DESCRIPTION
Alternative to #2727 , see discussion there.

When `gunicorn --daemon` daemonizes the process, prior to this change it was
noted that in the general case (without `-R` / `--enable-stdio-inheritance`), when fd 0
was replaced with /dev/null, the dup2 copy is skipped, and per PEP 446
"Make newly created file descriptors non-inheritable", the result was a stdio
fd </dev/null which was non-inheritable.  As a result, any launched subprocess
did not have an open 0/stdin fd, which can cause problems in some applications.

This change retains the behaviour of opening /dev/null with fd 0, but adds a call
to os.set_inheritable(..) to ensure the fd is inheritable.

The -R branch had different logic but has now been standardised with the general
case.  It was previously opening /dev/null as fd 3 and the dup2() copy made it
inheritable as fd 0.  This branch now applies the same logic: open as fd 0
(i.e. after close(0)), then set_inheritable.  As a result, an extra fd 3 </dev/null
previously left open is no longer left open.

Test Flask application good for manual testing on any platform with `dd` or any other program that will read stdin:

`flaskt.py`

```
import os
import sys

# save as flaskt.py
from flask import Flask
import subprocess
import time
app = Flask(__name__)

@app.route('/')
def index():
    ret, out = subprocess.getstatusoutput("dd of=/dev/null")
    return '<h1>fd 0 is Inheritable: {}, ret: {}, out: {}</h1>'.format(str(os.get_inheritable(0)), ret, out)

if __name__ == '__main__':
    app.run()
```

Results from http://localhost:8080 ... `gunicorn -b 0.0.0.0:8000 --daemon --error-logfile err.txt flaskt:app`

master:
> fd 0 is Inheritable: False, ret: 1, out: dd: stdin: Bad file descriptor

PR:
> fd 0 is Inheritable: True, ret: 0, out: 0+0 records in 0+0 records out 0 bytes transferred in 0.000017 secs (0 bytes/sec)