### PR TITLE
Split gh-actions into main/test + lint workflows, replace Travis badges

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: lint
+on: [push, pull_request]
+jobs:
+  tox-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install --upgrade pip
+      - run: pip install tox
+      - run: tox -e lint
+
+  tox-docs-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install --upgrade pip
+      - run: pip install tox
+      - run: tox -e docs-lint
+
+  tox-pycodestyle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install --upgrade pip
+      - run: pip install tox
+      - run: tox -e pycodestyle

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,33 +1,6 @@
 name: tox
 on: [push, pull_request]
 jobs:
-  tox-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - run: pip install --upgrade pip
-      - run: pip install tox
-      - run: tox -e lint
-
-  tox-docs-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - run: pip install --upgrade pip
-      - run: pip install tox
-      - run: tox -e docs-lint
-
-  tox-pycodestyle:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - run: pip install --upgrade pip
-      - run: pip install tox
-      - run: tox -e pycodestyle
-
   tox:
     strategy:
       fail-fast: false

--- a/README.rst
+++ b/README.rst
@@ -9,9 +9,13 @@ Gunicorn
     :alt: Supported Python versions
     :target: https://pypi.python.org/pypi/gunicorn
 
-.. image:: https://travis-ci.org/benoitc/gunicorn.svg?branch=master
+.. image:: https://github.com/benoitc/gunicorn/actions/workflows/tox.yml/badge.svg
     :alt: Build Status
-    :target: https://travis-ci.org/benoitc/gunicorn
+    :target: https://github.com/benoitc/gunicorn/actions/workflows/tox.yml
+
+.. image:: https://github.com/benoitc/gunicorn/actions/workflows/lint.yml/badge.svg
+    :alt: Lint Status
+    :target: https://github.com/benoitc/gunicorn/actions/workflows/lint.yml
 
 Gunicorn 'Green Unicorn' is a Python WSGI HTTP Server for UNIX. It's a pre-fork
 worker model ported from Ruby's Unicorn_ project. The Gunicorn server is broadly


### PR DESCRIPTION
This PR splits the new GitHub Actions workflow into two for now - main tox CI/test and linting, since linting currently produces errors, and GH Actions doesn't yet support muting those in any meaningful way for status.

This will provide a clean build badge like so, plus a lint warning badge:

![Screen Shot 2022-02-07 at 13 47 17](https://user-images.githubusercontent.com/1103477/152716866-663f488d-f6b0-4e27-b6cc-b8e7418b7506.png)

@cclauss ^^ in case you can provide feedback or review.