### PR TITLE
Efficient response processing

### DIFF
--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -112,8 +112,7 @@ class AsyncWorker(base.Worker):
                 if isinstance(respiter, environ['wsgi.file_wrapper']):
                     resp.write_file(respiter)
                 else:
-                    for item in respiter:
-                        resp.write(item)
+                    resp.write(b''.join(respiter))
                 resp.close()
                 request_time = datetime.now() - request_start
                 self.log.access(resp, req, environ, request_time)


### PR DESCRIPTION
If the returned response contains a lot of data, it makes many unnecessary calls to resp.write.