### PR TITLE
Prevent unnecessary setuid call

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -145,7 +145,7 @@ def set_owner_process(uid, gid, initgroups=False):
         elif gid != os.getgid():
             os.setgid(gid)
 
-    if uid:
+    if uid and uid != os.getuid():
         os.setuid(uid)
 
 


### PR DESCRIPTION
Prevent `setuid` call if the uid is already the right one. In my use case, that allows me starting `gunicorn` with `systemd` straight with the right user, without the permission to do `setuid` syscalls, for some more security.