### PR TITLE
Make loggers function atomic

### DIFF
--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -90,7 +90,7 @@ CONFIG_DEFAULTS = dict(
 def loggers():
     """ get list of all loggers """
     root = logging.root
-    existing = root.manager.loggerDict.keys()
+    existing = list(root.manager.loggerDict.keys())
     return [logging.getLogger(name) for name in existing]
 
 


### PR DESCRIPTION
Fixes https://github.com/benoitc/gunicorn/issues/2784:
```
Traceback (most recent call last):
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/gunicorn/arbiter.py", line 589, in spawn_worker
    worker.init_process()
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/uvicorn/workers.py", line 66, in init_process
    super(UvicornWorker, self).init_process()
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/gunicorn/workers/base.py", line 116, in init_process
    self.log.close_on_exec()
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/gunicorn/glogging.py", line 381, in close_on_exec
    for log in loggers():
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/gunicorn/glogging.py", line 94, in loggers
    return [logging.getLogger(name) for name in existing]
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/gunicorn/glogging.py", line 94, in <listcomp>
    return [logging.getLogger(name) for name in existing]
RuntimeError: dictionary changed size during iteration
```