### PR TITLE
fix LevelLog in Arbiter.run()

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -230,8 +230,8 @@ class Arbiter(object):
         except SystemExit:
             raise
         except Exception:
-            self.log.info("Unhandled exception in main loop",
-                          exc_info=True)
+            self.log.error("Unhandled exception in main loop",
+                           exc_info=True)
             self.stop(False)
             if self.pidfile is not None:
                 self.pidfile.unlink()


### PR DESCRIPTION
There should be an "error" or "critical" log level here.