### PR TITLE
add attribute remote_addr to req object

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -31,6 +31,7 @@ class Message(object):
         self.cfg = cfg
         self.unreader = unreader
         self.peer_addr = peer_addr
+        self.remote_addr = peer_addr
         self.version = None
         self.headers = []
         self.trailers = []

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -31,7 +31,7 @@ class Message(object):
         self.cfg = cfg
         self.unreader = unreader
         self.peer_addr = peer_addr
-        self.remote_addr = peer_addr
+        self.remote_addr = peer_addr[0]
         self.version = None
         self.headers = []
         self.trailers = []


### PR DESCRIPTION
Hi benotic: 
    as I come from uvicorn, and we are running gunicorn + django behind nginx,so I think it is more convenient for people to get the remote address with request.remote_addr than the raw REMOTE_ADDR.I hope you consider my suggestions and approve it.
   PS: I use the pre_request to add some request headers based on the remote address.Uvicorn also have a request object,I can get the client ip with request.client.host.