### PR TITLE
refactor: prefer contextlib.suppress to ImportError: pass

### DIFF
--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -4,6 +4,7 @@
 # See the NOTICE for more information.
 # pylint: disable=no-else-continue
 
+import contextlib
 import os
 import os.path
 import re
@@ -56,12 +57,10 @@ class Reloader(threading.Thread):
 
 has_inotify = False
 if sys.platform.startswith('linux'):
-    try:
+    with contextlib.suppress(ImportError):
         from inotify.adapters import Inotify
         import inotify.constants
         has_inotify = True
-    except ImportError:
-        pass
 
 
 if has_inotify:


### PR DESCRIPTION
Use [contextlib](https://docs.python.org/3/library/contextlib.html)'s [suppress method](https://docs.python.org/3/library/contextlib.html#contextlib.suppress) to silence a specific error, instead of passing in an exception handler.

The context manager slightly shortens the code and significantly clarifies the author's intention to ignore the specific errors. The standard library feature was introduced following a [discussion](https://bugs.python.org/issue15806), where the consensus was that

> A key benefit here is in the priming effect for readers... The with statement form makes it clear before you start reading the code that certain exceptions won't propagate.

This feature was added in Python 3.4, as Gunicorn supports 3.5+, this is safe for use.