### PR TITLE
feat: add py.typed marker

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE
 include NOTICE
 include README.rst
 include THANKS
+include gunicorn/py.typed
 include requirements_dev.txt
 include requirements_test.txt
 recursive-include tests *


### PR DESCRIPTION
This merge request adds the `py.typed` marker as required by PEP561.

This is required to complete #2833. This is being handled separate from the initial type hints to avoid combining unrelated changes.