### PR TITLE
refactor: remove python 2 new-style classes as only python 3.5+ is supported now

### DIFF
--- a/examples/frameworks/cherryapp.py
+++ b/examples/frameworks/cherryapp.py
@@ -1,7 +1,7 @@
 import cherrypy
 
 
-class Root(object):
+class Root:
     @cherrypy.expose
     def index(self):
         return 'Hello World!'

--- a/examples/frameworks/django/testing/testing/apps/someapp/middleware.py
+++ b/examples/frameworks/django/testing/testing/apps/someapp/middleware.py
@@ -8,7 +8,7 @@ def child_process(queue):
         requests.get('http://requestb.in/15s95oz1')
 
 
-class GunicornSubProcessTestMiddleware(object):
+class GunicornSubProcessTestMiddleware:
     def __init__(self):
         super().__init__()
         self.queue = Queue()

--- a/examples/longpoll.py
+++ b/examples/longpoll.py
@@ -7,7 +7,7 @@
 import sys
 import time
 
-class TestIter(object):
+class TestIter:
 
     def __iter__(self):
         lines = [b'line 1\n', b'line 2\n']

--- a/examples/multiapp.py
+++ b/examples/multiapp.py
@@ -25,7 +25,7 @@ from test import app as app1
 from test import app as app2
 
 
-class Application(object):
+class Application:
     def __init__(self):
         self.map = Mapper()
         self.map.connect('app1', '/app1url', app=app1)

--- a/examples/websocket/gevent_websocket.py
+++ b/examples/websocket/gevent_websocket.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 WS_KEY = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
-class WebSocketWSGI(object):
+class WebSocketWSGI:
     def __init__(self, handler):
         self.handler = handler
 
@@ -118,7 +118,7 @@ class WebSocketWSGI(object):
         # doesn't barf on the fact that we didn't call start_response
         return ALREADY_HANDLED
 
-class WebSocket(object):
+class WebSocket:
     """A websocket object that handles the details of
     serialization/deserialization to the socket.
 

--- a/examples/websocket/websocket.py
+++ b/examples/websocket/websocket.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 WS_KEY = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
-class WebSocketWSGI(object):
+class WebSocketWSGI:
     def __init__(self, handler):
         self.handler = handler
 
@@ -119,7 +119,7 @@ class WebSocketWSGI(object):
         # doesn't barf on the fact that we didn't call start_response
         return ALREADY_HANDLED
 
-class WebSocket(object):
+class WebSocket:
     """A websocket object that handles the details of
     serialization/deserialization to the socket.
 

--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -14,7 +14,7 @@ from gunicorn.config import Config, get_default_config_file
 from gunicorn import debug
 
 
-class BaseApplication(object):
+class BaseApplication:
     """
     An application interface for configuring and loading
     the various necessities for any given web framework.

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -18,7 +18,7 @@ from gunicorn import sock, systemd, util
 from gunicorn import __version__, SERVER_SOFTWARE
 
 
-class Arbiter(object):
+class Arbiter:
     """
     Arbiter maintain the workers processes alive. It launches or
     kills them if needed. It also manages application reloading

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -43,7 +43,7 @@ def auto_int(_, x):
     return int(x, 0)
 
 
-class Config(object):
+class Config:
 
     def __init__(self, usage=None, prog=None):
         self.settings = make_settings()
@@ -253,7 +253,7 @@ class SettingMeta(type):
         setattr(cls, "short", desc.splitlines()[0])
 
 
-class Setting(object):
+class Setting:
     name = None
     value = None
     section = None

--- a/gunicorn/debug.py
+++ b/gunicorn/debug.py
@@ -16,7 +16,7 @@ __all__ = ['spew', 'unspew']
 _token_spliter = re.compile(r'\W+')
 
 
-class Spew(object):
+class Spew:
 
     def __init__(self, trace_names=None, show_values=True):
         self.trace_names = trace_names

--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -163,7 +163,7 @@ def parse_syslog_address(addr):
     return (socktype, (host, port))
 
 
-class Logger(object):
+class Logger:
 
     LOG_LEVELS = {
         "critical": logging.CRITICAL,

--- a/gunicorn/http/body.py
+++ b/gunicorn/http/body.py
@@ -10,7 +10,7 @@ from gunicorn.http.errors import (NoMoreData, ChunkMissingTerminator,
                                   InvalidChunkSize)
 
 
-class ChunkedReader(object):
+class ChunkedReader:
     def __init__(self, req, unreader):
         self.req = req
         self.parser = self.parse_chunked(unreader)
@@ -106,7 +106,7 @@ class ChunkedReader(object):
         buf.write(data)
 
 
-class LengthReader(object):
+class LengthReader:
     def __init__(self, unreader, length):
         self.unreader = unreader
         self.length = length
@@ -136,7 +136,7 @@ class LengthReader(object):
         return ret
 
 
-class EOFReader(object):
+class EOFReader:
     def __init__(self, unreader):
         self.unreader = unreader
         self.buf = io.BytesIO()
@@ -174,7 +174,7 @@ class EOFReader(object):
         return ret
 
 
-class Body(object):
+class Body:
     def __init__(self, reader):
         self.reader = reader
         self.buf = io.BytesIO()

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -26,7 +26,7 @@ METH_RE = re.compile(r"[A-Z0-9$-_.]{3,20}")
 VERSION_RE = re.compile(r"HTTP/(\d+)\.(\d+)")
 
 
-class Message(object):
+class Message:
     def __init__(self, cfg, unreader, peer_addr):
         self.cfg = cfg
         self.unreader = unreader

--- a/gunicorn/http/parser.py
+++ b/gunicorn/http/parser.py
@@ -7,7 +7,7 @@ from gunicorn.http.message import Request
 from gunicorn.http.unreader import SocketUnreader, IterUnreader
 
 
-class Parser(object):
+class Parser:
 
     mesg_class = None
 

--- a/gunicorn/http/unreader.py
+++ b/gunicorn/http/unreader.py
@@ -10,7 +10,7 @@ import os
 # a given type of data source.
 
 
-class Unreader(object):
+class Unreader:
     def __init__(self):
         self.buf = io.BytesIO()
 

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -23,7 +23,7 @@ HEADER_VALUE_RE = re.compile(r'[\x00-\x1F\x7F]')
 log = logging.getLogger(__name__)
 
 
-class FileWrapper(object):
+class FileWrapper:
 
     def __init__(self, filelike, blksize=8192):
         self.filelike = filelike
@@ -190,7 +190,7 @@ def create(req, sock, client, server, cfg):
     return resp, environ
 
 
-class Response(object):
+class Response:
 
     def __init__(self, req, sock, cfg):
         self.req = req

--- a/gunicorn/pidfile.py
+++ b/gunicorn/pidfile.py
@@ -8,7 +8,7 @@ import os
 import tempfile
 
 
-class Pidfile(object):
+class Pidfile:
     """\
     Manage a PID file. If a specific name is provided
     it and '"%s.oldpid" % name' will be used. Otherwise

--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -117,7 +117,7 @@ if has_inotify:
 
 else:
 
-    class InotifyReloader(object):
+    class InotifyReloader:
         def __init__(self, callback=None):
             raise ImportError('You must have the inotify module installed to '
                               'use the inotify reloader')

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -13,7 +13,7 @@ import time
 from gunicorn import util
 
 
-class BaseSocket(object):
+class BaseSocket:
 
     def __init__(self, address, conf, log, fd=None):
         self.log = log

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -26,7 +26,7 @@ from gunicorn.reloader import reloader_engines
 from gunicorn.workers.workertmp import WorkerTmp
 
 
-class Worker(object):
+class Worker:
 
     SIGNALS = [getattr(signal, "SIG%s" % x) for x in (
         "ABRT HUP QUIT INT TERM USR1 USR2 WINCH CHLD".split()

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -146,7 +146,7 @@ class GeventWorker(AsyncWorker):
         super().init_process()
 
 
-class GeventResponse(object):
+class GeventResponse:
 
     status = None
     headers = None

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -30,7 +30,7 @@ from .. import util
 from ..http import wsgi
 
 
-class TConn(object):
+class TConn:
 
     def __init__(self, cfg, sock, client, server):
         self.cfg = cfg

--- a/gunicorn/workers/workertmp.py
+++ b/gunicorn/workers/workertmp.py
@@ -13,7 +13,7 @@ PLATFORM = platform.system()
 IS_CYGWIN = PLATFORM.startswith('CYGWIN')
 
 
-class WorkerTmp(object):
+class WorkerTmp:
 
     def __init__(self, cfg):
         old_umask = os.umask(cfg.umask)

--- a/tests/t.py
+++ b/tests/t.py
@@ -22,7 +22,7 @@ def data_source(fname):
         return buf
 
 
-class request(object):
+class request:
     def __init__(self, name):
         self.fname = os.path.join(dirname, "requests", name)
 
@@ -34,7 +34,7 @@ class request(object):
         return run
 
 
-class FakeSocket(object):
+class FakeSocket:
 
     def __init__(self, data):
         self.tmp = tempfile.TemporaryFile()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,7 +32,7 @@ def paster_ini():
     return os.path.join(dirname, "..", "examples", "frameworks", "pylonstest", "nose.ini")
 
 
-class AltArgs(object):
+class AltArgs:
     def __init__(self, args=None):
         self.args = args or []
         self.orig = sys.argv
@@ -98,7 +98,7 @@ def test_property_access():
     # Not a config property
     pytest.raises(AttributeError, getattr, c, "foo")
     # Force to be not an error
-    class Baz(object):
+    class Baz:
         def get(self):
             return 3.14
     c.settings["foo"] = Baz()

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -15,7 +15,7 @@ class StatsdTestException(Exception):
     pass
 
 
-class MockSocket(object):
+class MockSocket:
     "Pretend to be a UDP socket"
     def __init__(self, failp):
         self.failp = failp

--- a/tests/treq.py
+++ b/tests/treq.py
@@ -39,7 +39,7 @@ def load_py(fname):
     return vars(mod)
 
 
-class request(object):
+class request:
     def __init__(self, fname, expect):
         self.fname = fname
         self.name = os.path.basename(fname)
@@ -262,7 +262,7 @@ class request(object):
         assert req.trailers == exp.get("trailers", [])
 
 
-class badrequest(object):
+class badrequest:
     def __init__(self, fname):
         self.fname = fname
         self.name = os.path.basename(fname)


### PR DESCRIPTION
In Python 2, there were different ways to create classes: the old and new style. `gunicorn` uses the new-style of class creation, which inherits from `object`. This difference is described here: 

https://docs.python.org/2/reference/datamodel.html#new-style-and-classic-classes
https://www.python.org/download/releases/2.2.3/descrintro/

As `gunicorn` supports Python 3.5+ at this time, the use of new-style classes can be removed as all classes in Python 3 are new-style classes by default.