### PR TITLE
Fix HTTP status code for Request Header Fields Too Large

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -168,6 +168,7 @@ Steven Cummings <estebistec@gmail.com>
 Sébastien Fievet <zyegfryed@gmail.com>
 Talha Malik <talham7391@hotmail.com>
 TedWantsMore <TedWantsMore@gmx.com>
+Teko012 <112829523+Teko012@users.noreply.github.com>
 Thomas Grainger <tagrain@gmail.com>
 Thomas Steinacher <tom@eggdrop.ch>
 Travis Cline <travis.cline@gmail.com>

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -230,7 +230,9 @@ class Worker(object):
             elif isinstance(exc, LimitRequestLine):
                 mesg = "%s" % str(exc)
             elif isinstance(exc, LimitRequestHeaders):
+                reason = "Request Header Fields Too Large"
                 mesg = "Error parsing headers: '%s'" % str(exc)
+                status_int = 431
             elif isinstance(exc, InvalidProxyLine):
                 mesg = "'%s'" % str(exc)
             elif isinstance(exc, ForbiddenProxyRequest):


### PR DESCRIPTION
This change makes sure that a proper HTTP status code is returned for Request Header Fields Too Large, which fixes #2878.