### PR TITLE
align license with OSI template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,4 @@
-2009-2018 (c) Benoît Chesneau <benoitc@e-engura.org>
-2009-2015 (c) Paul J. Davis <paul.joseph.davis@gmail.com>
+Copyright 2009-2018 (c) Benoît Chesneau <benoitc@e-engura.org>, 2009-2015 (c) Paul J. Davis <paul.joseph.davis@gmail.com>
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.rst
+++ b/README.rst
@@ -62,12 +62,6 @@ Contributing
 See `our complete contributor's guide <CONTRIBUTING.md>`_ for more details.
 
 
-License
--------
-
-Gunicorn is released under the MIT License. See the LICENSE_ file for more
-details.
-
 .. _Unicorn: https://bogomips.org/unicorn/
 .. _`#gunicorn`: https://web.libera.chat/?channels=#gunicorn
 .. _`Libera.chat`: https://libera.chat/


### PR DESCRIPTION
This will ensure that GitHub will properly detect the license.

```
licensee detect .
License:        MIT
Matched files:  LICENSE
LICENSE:
  Content hash:  4c2c763d64bbc7ef2e58b0ec6d06d90cee9755c9
  Attribution:   Copyright 2009-2018 (c) Benoît Chesneau <benoitc@e-engura.org>, 2009-2015 (c) Paul J. Davis <paul.joseph.davis@gmail.com>
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       MIT
```