### PR TITLE
Fix sendfile.py example

### DIFF
--- a/examples/sendfile.py
+++ b/examples/sendfile.py
@@ -9,7 +9,7 @@ import os
 from wsgiref.validate import validator
 
 
-@validator
+# @validator  # breaks sendfile
 def app(environ, start_response):
     """Simplest possible application object"""
     status = '200 OK'


### PR DESCRIPTION
because of `@validator` decorator, the fn returns `wsgiref.validate.IteratorWrapper` instead of `gunicorn.http.wsgi.FileWrapper` which breaks sendfile

https://github.com/benoitc/gunicorn/blob/69c508ac6e4b301045d3ce21acce8b416415d4c5/gunicorn/workers/sync.py#L181-L182