### PR TITLE
Update docs to acknowledge Gthread worker_connections

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -1417,7 +1417,7 @@ This setting only affects the Gthread worker type.
 
 The maximum number of simultaneous clients.
 
-This setting only affects the Eventlet and Gevent worker types.
+This setting only affects the Eventlet, Gthread, and Gevent worker types.
 
 .. _max-requests:
 


### PR DESCRIPTION
The Gthread worker does use `worker_connections`: https://github.com/benoitc/gunicorn/blob/master/gunicorn/workers/gthread.py#L198

However, the docs currently say it doesn't.

This PR updates the docs to reflect the current code.