### PR TITLE
Fix `remote_addr` error

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -31,7 +31,7 @@ class Message(object):
         self.cfg = cfg
         self.unreader = unreader
         self.peer_addr = peer_addr
-        self.remote_addr = peer_addr[0]
+        self.remote_addr = peer_addr
         self.version = None
         self.headers = []
         self.trailers = []


### PR DESCRIPTION
Tests are currently failing with
`TypeError: 'NoneType' object is not subscriptable`

This commit fixes that by setting `remote_addr` equal to `peer_addr`.