### PR TITLE
Update irc channel docs

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -26,6 +26,7 @@ Bartosz Oler <bartosz@bzimage.us>
 Ben Cochran <bcochran@gmail.com>
 Ben Oswald <ben.oswald@root-space.de>
 Benjamin Gilbert <bgilbert@backtick.net>
+Benny Mei <meibenny@gmail.com>
 Benoit Chesneau <bchesneau@gmail.com>
 Berker Peksag <berker.peksag@gmail.com>
 bninja <andrew@poundpay.com>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -120,9 +120,9 @@
         </ul>
         <p>Project maintenance guidelines are available on the <a href="https://github.com/benoitc/gunicorn/wiki/Project-management">wiki</a></p>
         
-        <h1>Irc</h1>
-        <p>The Gunicorn channel is on the <a href="http://freenode.net/">Freenode</a> IRC
-          network. You can chat with the community on the <a href="http://webchat.freenode.net/?channels=gunicorn">#gunicorn channel</a>.</p>
+        <h1>IRC</h1>
+        <p>The Gunicorn channel is on the <a href="https://libera.chat/">Libera Chat</a> IRC
+          network. You can chat with the community on the <a href="https://web.libera.chat/?channels=#gunicorn">#gunicorn channel</a>.</p>
 
         <h1>Issue Tracking</h1>
         <p>Bug reports, enhancement requests and tasks generally go in the <a  href="http://github.com/benoitc/gunicorn/issues">Github


### PR DESCRIPTION
Update the IRC channel information on the community page on gunicorn.org. The IRC channel is updated in the github readme, but the community page on gunicorn.org doesn't reflect the fact that the chat has moved to libera.chat from freenode.

This pull request aims to ensure that the correct IRC channel is listed on https://gunicorn.org/#community .