### PR TITLE
Fix access logging of interrupted and late-throwing requests

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -302,12 +302,14 @@ class ThreadWorker(base.Worker):
     def handle_request(self, req, conn):
         environ = {}
         resp = None
+        want_log = False
         try:
             self.cfg.pre_request(self, req)
             request_start = datetime.now()
             resp, environ = wsgi.create(req, conn.sock, conn.client,
                                         conn.server, self.cfg)
             environ["wsgi.multithread"] = True
+            want_log = True
             self.nr += 1
             if self.nr >= self.max_requests:
                 if self.alive:
@@ -329,8 +331,6 @@ class ThreadWorker(base.Worker):
                         resp.write(item)
 
                 resp.close()
-                request_time = datetime.now() - request_start
-                self.log.access(resp, req, environ, request_time)
             finally:
                 if hasattr(respiter, "close"):
                     respiter.close()
@@ -352,8 +352,18 @@ class ThreadWorker(base.Worker):
                 except EnvironmentError:
                     pass
                 raise StopIteration()
-            raise
+            else:
+                # Don't log it here. The exception will be caught in handle()
+                # and a HTTP 500 response will be logged in handle_error().
+                want_log = False
+                raise
         finally:
+            if want_log:
+                try:
+                    request_time = datetime.now() - request_start
+                    self.log.access(resp, req, environ, request_time)
+                except Exception:
+                    self.log.exception("Error logging to access log")
             try:
                 self.cfg.post_request(self, req, environ, resp)
             except Exception:


### PR DESCRIPTION
This PR fixes some cases where Gunicorn did not write a request to the access log:

- If the client closes the connection during the request
- If the WSGI app raises an exception after the initial HTTP response code was sent
- If the worker times out and is killed by the master (at least for sync workers)

I get the impression Gunicorn maintenance is mostly dead, so I don't have high expectations of getting any reply, but I'll hold out hope that somebody will review this PR one day. :)

### How it works

*tfw the explanation is much longer than the patch.........*

Look at handle() and handle_request() in sync.py and gthread.py, and handle_error() in base.py.

To see why this code change is correct, let's analyze these cases:

1. Normal success
    - The same things happen as before, in a slightly different order.
2. An error is raised before handle_request() is called
    - No change in this PR.
    - Some types of errors are logged when handle() calls handle_error().
    - Some types of errors aren't logged (e.g. connection closed while parsing the request URL).
3. An error is raised before handle_request() calls `resp, environ = wsgi.create(...)`
    - No change in this PR. Some types of errors are logged, some are not.
    - We can't call log.access() in handle_request anyway, because it needs a valid resp object.
4. An error is raised before response headers were sent (`if resp and not resp.headers_sent`)
    1. OSError?
        - handle_request() reraises it.
        - NEW: handle_request() writes to the access log in the finally block.
        - handle() catches the OSError and closes the connection.
        - (Gunicorn assumes that OSError always means it's pointless to try writing a response. I'm not so sure, but this PR doesn't change the assumption.)
    2. Exception?
        - handle_request() reraises it.
        - handle_request() doesn't write it to the access log. Same as before.
        - handle() catches it and calls handle_error().
        - handle_error() writes a e.g. HTTP 500 response to the client and writes e.g. code 500 to the access log. Same as before.
    3. BaseException?
        - (E.g.: worker times out -> master sends SIGABRT -> handle_abort calls sys.exit(1) -> SystemExit is thrown on main thread -> the call stack unwinds and runs finally blocks)
        - NEW: handle_request() writes to the access log in the finally block.
        - handle_request() and handle() don't catch it.
5. An error is raised after response headers were sent (`if resp and resp.headers_sent`)
    1. OSError? Same as above.
    2. Exception?
        - handle_request() logs the exception to the error log and raises StopIteration.
        - NEW: handle_request() writes to the access log in the finally block.
        - handle() catches the StopIteration and closes the connection.
    3. BaseException? Same as above.

This was tricky to get right. One big obstacle was that log.access() can be called in two places -- handle_request and handle_error. It's important not to log a request twice, hence handle_request() should call log.access() only if it knows that handle() won't call handle_error() for this error type.

There are some edge cases where I gave up (e.g. SSLError, or StopIteration thrown by the WSGI app itself).

It might be better to rewrite it all, but in this PR I optimized for a reasonably small patch.

Note that in cases 4.i and 4.iii, if there isn't any start_response call, the access log line will contain the string `None` instead of a HTTP status number. This could be easily changed if you don't like it.

### Testing

You can use this script to manually test the behavior before vs after the PR.

```console
$ cat testapp.py
import errno
import time
def application(environ, start_response):
    path = environ['PATH_INFO']
    if environ['PATH_INFO'] == '/a': raise ValueError("Hello A")
    if environ['PATH_INFO'] == '/b': raise OSError("Hello B")
    if environ['PATH_INFO'] == '/c': raise OSError(errno.EPIPE, "Hello C")
    if environ['PATH_INFO'] == '/d': time.sleep(100)
    write = start_response('200 OK', {})
    write(b'Hi\n')
    if environ['PATH_INFO'] == '/e': raise ValueError("Hello E")
    if environ['PATH_INFO'] == '/f': time.sleep(100)
    return [b'Env %s\n' % repr(environ).encode('utf-8')]

$ python3 -m gunicorn --access-logfile access.log testapp

$ curl -v http://localhost:8000/
$ curl -v http://localhost:8000/a
$ curl -v http://localhost:8000/b
$ curl -v http://localhost:8000/c
$ curl -v http://localhost:8000/d  # interrupt the request with Ctrl+C
$ curl -v http://localhost:8000/d  # wait 30 seconds for worker timeout
$ curl -v http://localhost:8000/e
$ curl -v http://localhost:8000/f  # interrupt the request with Ctrl+C
$ curl -v http://localhost:8000/f  # wait 30 seconds for worker timeout
```
