### PR TITLE
Re-add and improve the warning for workers terminated due to a signal

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -64,6 +64,8 @@ class Arbiter(object):
         self.master_pid = 0
         self.master_name = "Master"
 
+        self.signal_warnings = []
+
         cwd = util.getcwd()
 
         args = sys.argv[:]
@@ -203,6 +205,14 @@ class Arbiter(object):
 
             while True:
                 self.maybe_promote_master()
+
+                warnings, self.signal_warnings = self.signal_warnings, []
+                for (wpid, sig) in warnings:
+                    self.log.warning(
+                        "Worker with pid %s was terminated due to signal %s",
+                        wpid,
+                        sig,
+                    )
 
                 sig = self.SIG_QUEUE.pop(0) if self.SIG_QUEUE else None
                 if sig is None:
@@ -526,6 +536,12 @@ class Arbiter(object):
                     if exitcode == self.APP_LOAD_ERROR:
                         reason = "App failed to load."
                         raise HaltServer(reason, self.APP_LOAD_ERROR)
+                    if os.WIFSIGNALED(status):
+                        # Log it later. Not in the SIGCHLD handler. #2564
+                        # https://stackoverflow.com/q/45680378
+                        self.signal_warnings.append(
+                            (wpid, os.WTERMSIG(status))
+                        )
 
                     worker = self.WORKERS.pop(wpid, None)
                     if not worker:

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -563,8 +563,10 @@ class Arbiter(object):
         workers = self.WORKERS.items()
         workers = sorted(workers, key=lambda w: w[1].age)
         while len(workers) > self.num_workers:
-            (pid, _) = workers.pop(0)
-            self.kill_worker(pid, signal.SIGTERM)
+            (pid, worker) = workers.pop(0)
+            if not worker.sigtermed:
+                worker.sigtermed = True
+                self.kill_worker(pid, signal.SIGTERM)
 
         active_worker_count = len(workers)
         if self._last_logged_active_worker_count != active_worker_count:

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -49,6 +49,7 @@ class Worker(object):
         self.cfg = cfg
         self.booted = False
         self.aborted = False
+        self.sigtermed = False
         self.reloader = None
 
         self.nr = 0


### PR DESCRIPTION
1. Re-add the warning for workers terminated due to a signal

    The warnings are printed later in the main loop, not directly in the signal handler. This should fix the RuntimeError from #2564. See https://stackoverflow.com/q/45680378.

    The order of events in the log might be a bit different from before.

2. Fix false positive "terminated due to signal 15"

    During a reload (i.e. SIGHUP sent to master), gunicorn used to send multiple SIGTERMs to each worker. Every time the master got a SIGCHLD from one worker exiting, it sent a SIGTERM to all old workers who are still alive.

    If you send a worker another SIGTERM when it's just about to shut down and the Python interpreter is already deinitialized, the signal won't be caught. The process exit status will be WIFSIGNALED SIGTERM.

    Explanation:

    This PR limits it to sending max one SIGTERM per worker in manage_workers(). I believe this is safe because handle_exit() in workers/base.py just sets self.alive = False anyway. So sending multiple SIGTERMs is never helpful to get a worker "unstuck". If a worker doesn't react to the first SIGTERM because it's in some kind of infinite loop, murder_workers() will notice it eventually, and send it a SIGABRT and a SIGKILL.

    The SIGTERMs sent by handle_winch() and stop() are not changed in this PR.

I get the impression Gunicorn maintenance is mostly dead, so I don't have high expectations of getting any reply, but I'll hold out hope that somebody will review this PR one day. :)

### Testing

Compare what happens on these three commits. Use any WSGI app.

```console
$ git checkout 20.1.0   # you will see warnings about signal 15 and probably some log errors
$ git checkout 01cf8421511dd16405a09564931e4508168a8909  # you will see warnings about signal 15
$ git checkout 3fe47e6a3f1d3a2b4011020b284970efeffc1312  # you will see only INFO

$ python3 -m gunicorn -w 10 testapp

$ kill -HUP $THE_MAIN_PID
```

I got the warnings and errors on the first try, but if you can't reproduce the problem, increasing the number of workers might help.