### PR TITLE
Rectification: prefer the term 'main' for the co-ordinating process name

### DIFF
--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -11,18 +11,18 @@ Server Model
 ============
 
 Gunicorn is based on the pre-fork worker model. This means that there is a
-central master process that manages a set of worker processes. The master
-never knows anything about individual clients. All requests and responses are
-handled completely by worker processes.
+central main process that manages a set of worker processes. The main never
+knows anything about individual clients. All requests and responses are handled
+completely by worker processes.
 
 Master
 ------
 
-The master process is a simple loop that listens for various process signals
-and reacts accordingly. It manages the list of running workers by listening
-for signals like TTIN, TTOU, and CHLD. TTIN and TTOU tell the master to
+The main process is a simple loop that listens for various process signals and
+reacts accordingly. It manages the list of running workers by listening for
+signals like TTIN, TTOU, and CHLD. TTIN and TTOU tell the main process to
 increase or decrease the number of running workers. CHLD indicates that a child
-process has terminated, in this case the master process automatically restarts
+process has terminated, in this case the main process automatically restarts
 the failed worker.
 
 Sync Workers
@@ -133,7 +133,7 @@ How Many Threads?
 Since Gunicorn 19, a threads option can be used to process requests in multiple
 threads. Using threads assumes use of the gthread worker. One benefit from threads
 is that requests can take longer than the worker timeout while notifying the
-master process that it is not frozen and should not be killed. Depending on the
+main process that it is not frozen and should not be killed. Depending on the
 system, using multiple threads, multiple worker processes, or some mixture, may
 yield the best results. For example, CPython may not perform as well as Jython
 when using threads, as threading is implemented differently by each. Using
@@ -141,7 +141,7 @@ threads instead of processes is a good way to reduce the memory footprint of
 Gunicorn, while still allowing for application upgrades using the reload
 signal, as the application code will be shared among workers but loaded only in
 the worker processes (unlike when using the preload setting, which loads the
-code in the master process).
+code in the main process).
 
 .. note::
    Under Python 2.x, you need to install the 'futures' package to use this

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -22,7 +22,7 @@ How do I reload my application in Gunicorn?
 
 You can gracefully reload by sending HUP signal to gunicorn::
 
-    $ kill -HUP masterpid
+    $ kill -HUP mainpid
 
 How might I test a proxy configuration?
 ---------------------------------------
@@ -39,9 +39,9 @@ How can I name processes?
 
 If you install the Python package setproctitle_ Gunicorn will set the process
 names to something a bit more meaningful. This will affect the output you see
-in tools like ``ps`` and ``top``. This helps for distinguishing the master
-process as well as between masters when running more than one app on a single
-machine. See the proc_name_ setting for more information.
+in tools like ``ps`` and ``top``. This helps for distinguishing the main
+process as well as between main processes when running more than one app on a
+single machine. See the proc_name_ setting for more information.
 
 Why is there no HTTP Keep-Alive?
 --------------------------------
@@ -77,16 +77,16 @@ Here is our recommendation for tuning the `number of workers`_.
 How can I change the number of workers dynamically?
 ---------------------------------------------------
 
-TTIN and TTOU signals can be sent to the master to increase or decrease
+TTIN and TTOU signals can be sent to the main process to increase or decrease
 the number of workers.
 
 To increase the worker count by one::
 
-    $ kill -TTIN $masterpid
+    $ kill -TTIN $mainpid
 
 To decrease the worker count by one::
 
-    $ kill -TTOU $masterpid
+    $ kill -TTOU $mainpid
 
 Does Gunicorn suffer from the thundering herd problem?
 ------------------------------------------------------

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -671,7 +671,7 @@ Server Hooks
         def on_starting(server):
             pass
 
-Called just before the master process is initialized.
+Called just before the main process is initialized.
 
 The callable needs to accept a single instance variable for the Arbiter.
 
@@ -806,7 +806,7 @@ Worker.
         def pre_exec(server):
             pass
 
-Called just before a new master process is forked.
+Called just before a new main process is forked.
 
 The callable needs to accept a single instance variable for the Arbiter.
 
@@ -856,7 +856,7 @@ the Request.
         def child_exit(server, worker):
             pass
 
-Called just after a worker has been exited, in the master process.
+Called just after a worker has been exited, in the main process.
 
 The callable needs to accept two instance variables for the Arbiter and
 the just-exited Worker.

--- a/docs/source/signals.rst
+++ b/docs/source/signals.rst
@@ -21,8 +21,8 @@ Master process
 - ``TTOU``: Decrement the number of processes by one
 - ``USR1``: Reopen the log files
 - ``USR2``: Upgrade Gunicorn on the fly. A separate ``TERM`` signal should
-  be used to kill the old master process. This signal can also be used to use
-  the new versions of pre-loaded applications. See :ref:`binary-upgrade` for
+  be used to kill the old main process. This signal can also be used to use the
+  new versions of pre-loaded applications. See :ref:`binary-upgrade` for
   more information.
 - ``WINCH``: Gracefully shutdown the worker processes when Gunicorn is
   daemonized.
@@ -31,7 +31,7 @@ Worker process
 ==============
 
 Sending signals directly to the worker processes should not normally be
-needed.  If the master process is running, any exited worker will be
+needed.  If the main process is running, any exited worker will be
 automatically respawned.
 
 - ``QUIT``, ``INT``: Quick shutdown
@@ -76,44 +76,44 @@ do it without any service downtime - no incoming requests will be
 lost. Preloaded applications will also be reloaded.
 
 First, replace the old binary with a new one, then send a ``USR2`` signal to
-the current master process. It executes a new binary whose PID file is
-postfixed with ``.2`` (e.g. ``/var/run/gunicorn.pid.2``),
-which in turn starts a new master process and new worker processes::
+the current main process. It executes a new binary whose PID file is postfixed
+with ``.2`` (e.g. ``/var/run/gunicorn.pid.2``), which in turn starts a new main
+process and new worker processes::
 
       PID USER      PR  NI  VIRT  RES  SHR S  %CPU %MEM    TIME+  COMMAND
-    20844 benoitc   20   0 54808  11m 3352 S   0.0  0.1   0:00.36 gunicorn: master [test:app]
+    20844 benoitc   20   0 54808  11m 3352 S   0.0  0.1   0:00.36 gunicorn: main [test:app]
     20849 benoitc   20   0 54808 9.9m 1500 S   0.0  0.1   0:00.02 gunicorn: worker [test:app]
     20850 benoitc   20   0 54808 9.9m 1500 S   0.0  0.1   0:00.01 gunicorn: worker [test:app]
     20851 benoitc   20   0 54808 9.9m 1500 S   0.0  0.1   0:00.01 gunicorn: worker [test:app]
-    20854 benoitc   20   0 55748  12m 3348 S   0.0  0.2   0:00.35 gunicorn: master [test:app]
+    20854 benoitc   20   0 55748  12m 3348 S   0.0  0.2   0:00.35 gunicorn: main [test:app]
     20859 benoitc   20   0 55748  11m 1500 S   0.0  0.1   0:00.01 gunicorn: worker [test:app]
     20860 benoitc   20   0 55748  11m 1500 S   0.0  0.1   0:00.00 gunicorn: worker [test:app]
     20861 benoitc   20   0 55748  11m 1500 S   0.0  0.1   0:00.01 gunicorn: worker [test:app]
 
 At this point, two instances of Gunicorn are running, handling the
 incoming requests together. To phase the old instance out, you have to
-send a ``WINCH`` signal to the old master process, and its worker
-processes will start to gracefully shut down.
+send a ``WINCH`` signal to the old main process, and its worker processes will
+start to gracefully shut down.
 
 At this point you can still revert to the old process since it hasn't closed
 its listen sockets yet, by following these steps:
 
-- Send a ``HUP`` signal to the old master process - it will start the worker
+- Send a ``HUP`` signal to the old main process - it will start the worker
   processes without reloading a configuration file
-- Send a ``TERM`` signal to the new master process to gracefully shut down its
+- Send a ``TERM`` signal to the new main process to gracefully shut down its
   worker processes
-- Send a ``QUIT`` signal to the new master process to force it quit
+- Send a ``QUIT`` signal to the new main process to force it quit
 
 If for some reason the new worker processes do not quit, send a ``KILL`` signal
-to them after the new master process quits, and everything will back to exactly
+to them after the new main process quits, and everything will back to exactly
 as before the upgrade attempt.
 
-If the update is successful and you want to keep the new master process, send a
-``TERM`` signal to the old master process to leave only the new server
+If the update is successful and you want to keep the new main process, send a
+``TERM`` signal to the old main process to leave only the new server
 running::
 
       PID USER      PR  NI  VIRT  RES  SHR S  %CPU %MEM    TIME+  COMMAND
-    20854 benoitc   20   0 55748  12m 3348 S   0.0  0.2   0:00.45 gunicorn: master [test:app]
+    20854 benoitc   20   0 55748  12m 3348 S   0.0  0.2   0:00.45 gunicorn: main [test:app]
     20859 benoitc   20   0 55748  11m 1500 S   0.0  0.1   0:00.02 gunicorn: worker [test:app]
     20860 benoitc   20   0 55748  11m 1500 S   0.0  0.1   0:00.02 gunicorn: worker [test:app]
     20861 benoitc   20   0 55748  11m 1500 S   0.0  0.1   0:00.01 gunicorn: worker [test:app]

--- a/examples/example_config.py
+++ b/examples/example_config.py
@@ -49,7 +49,7 @@ backlog = 2048
 #
 #       A positive integer generally set to around 1000.
 #
-#   timeout - If a worker does not notify the master process in this
+#   timeout - If a worker does not notify the main process in this
 #       number of seconds it is killed and a new worker is spawned
 #       to replace it.
 #
@@ -177,8 +177,8 @@ proc_name = None
 #
 #       A callable that accepts the same arguments as after_fork
 #
-#   pre_exec - Called just prior to forking off a secondary
-#       master process during things like config reloading.
+#   pre_exec - Called just prior to forking off a secondary main
+#       process during things like config reloading.
 #
 #       A callable that takes a server instance as the sole argument.
 #

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -194,7 +194,7 @@ class Arbiter(object):
             self.wakeup()
 
     def run(self):
-        "Main master loop."
+        "Main loop."
         self.start()
         util._setproctitle("master [%s]" % self.proc_name)
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1718,7 +1718,7 @@ class OnStarting(Setting):
         pass
     default = staticmethod(on_starting)
     desc = """\
-        Called just before the master process is initialized.
+        Called just before the main process is initialized.
 
         The callable needs to accept a single instance variable for the Arbiter.
         """
@@ -1856,7 +1856,7 @@ class PreExec(Setting):
         pass
     default = staticmethod(pre_exec)
     desc = """\
-        Called just before a new master process is forked.
+        Called just before a new main process is forked.
 
         The callable needs to accept a single instance variable for the Arbiter.
         """
@@ -1906,7 +1906,7 @@ class ChildExit(Setting):
         pass
     default = staticmethod(child_exit)
     desc = """\
-        Called just after a worker has been exited, in the master process.
+        Called just after a worker has been exited, in the main process.
 
         The callable needs to accept two instance variables for the Arbiter and
         the just-exited Worker.

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -78,7 +78,7 @@ class Worker(object):
         """\
         This is the mainloop of a worker process. You should override
         this method in a subclass to provide the intended behaviour
-        for your particular evil schemes.
+        for your particular use cases.
         """
         raise NotImplementedError()
 

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -70,7 +70,7 @@ class Worker(object):
         """\
         Your worker subclass must arrange to have this method called
         once every ``self.timeout`` seconds. If you fail in accomplishing
-        this task, the master process will murder your workers.
+        this task, the main process will stop your workers.
         """
         self.tmp.notify()
 

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -48,7 +48,7 @@ def test_arbiter_stop_child_does_not_unlink_listeners(close_sockets):
 @mock.patch('gunicorn.sock.close_sockets')
 def test_arbiter_stop_parent_does_not_unlink_listeners(close_sockets):
     arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
-    arbiter.master_pid = os.getppid()
+    arbiter.main_pid = os.getppid()
     arbiter.stop()
     close_sockets.assert_called_with([], False)
 
@@ -115,7 +115,7 @@ def test_arbiter_reexec_limit_parent(fork):
 @mock.patch('os.fork')
 def test_arbiter_reexec_limit_child(fork):
     arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
-    arbiter.master_pid = ~os.getpid()
+    arbiter.main_pid = ~os.getpid()
     arbiter.reexec()
     assert fork.called is False, "should not fork when arbiter is a child"
 


### PR DESCRIPTION
Seemed worthwhile after noticing some redundancy in a comment during review of #2871 (addressed by 37b5599c7d0eaa21fd867a2ca2e29bf70a473f51).

Also includes a tangential edit to remove the word `evil` from the codebase (please discontinue use of `gunicorn` if you previously relied on this).