### PR TITLE
gthread: only read sockets when they are readable (#2917)

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -40,12 +40,15 @@ class TConn(object):
 
         self.timeout = None
         self.parser = None
+        self.initialized = False
 
         # set the socket to non blocking
         self.sock.setblocking(False)
 
     def init(self):
+        self.initialized = True
         self.sock.setblocking(True)
+
         if self.parser is None:
             # wrap the socket if needed
             if self.cfg.is_ssl:
@@ -120,23 +123,28 @@ class ThreadWorker(base.Worker):
             # initialize the connection object
             conn = TConn(self.cfg, sock, client, server)
             self.nr_conns += 1
-            # enqueue the job
-            self.enqueue_req(conn)
+
+            # wait until socket is readable
+            with self._lock:
+                self.poller.register(conn.sock, selectors.EVENT_READ,
+                                     partial(self.on_client_socket_readable, conn))
         except EnvironmentError as e:
             if e.errno not in (errno.EAGAIN, errno.ECONNABORTED,
                                errno.EWOULDBLOCK):
                 raise
 
-    def reuse_connection(self, conn, client):
+    def on_client_socket_readable(self, conn, client):
         with self._lock:
             # unregister the client from the poller
             self.poller.unregister(client)
-            # remove the connection from keepalive
-            try:
-                self._keep.remove(conn)
-            except ValueError:
-                # race condition
-                return
+
+            if conn.initialized:
+                # remove the connection from keepalive
+                try:
+                    self._keep.remove(conn)
+                except ValueError:
+                    # race condition
+                    return
 
         # submit the connection to a worker
         self.enqueue_req(conn)
@@ -249,7 +257,7 @@ class ThreadWorker(base.Worker):
 
                     # add the socket to the event loop
                     self.poller.register(conn.sock, selectors.EVENT_READ,
-                                         partial(self.reuse_connection, conn))
+                                         partial(self.on_client_socket_readable, conn))
             else:
                 self.nr_conns -= 1
                 conn.close()


### PR DESCRIPTION
This PR solves issue #2917

It changes the behaviour of the gthread workers. Instead of always reading from tcp sockets opened by a client, the worker only does so when the socket is readable. The main thread does not immediately enqueue new connections anymore to the worker thread queue. Instead it adds new connections to the poller, these connections will be added to the worker thread queue when they are readable.

Please let me know if there are any questions or suggestions for this PR!