### PR TITLE
CI Improvements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,29 +3,22 @@ on: [push, pull_request]
 permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
-  tox-lint:
+  lint:
+    name: tox-${{ matrix.toxenv }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toxenv: [lint, docs-lint, pycodestyle]
+        python-version: [ "3.10" ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - run: pip install --upgrade pip
-      - run: pip install tox
-      - run: tox -e lint
-
-  tox-docs-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - run: pip install --upgrade pip
-      - run: pip install tox
-      - run: tox -e docs-lint
-
-  tox-pycodestyle:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - run: pip install --upgrade pip
-      - run: pip install tox
-      - run: tox -e pycodestyle
+      - uses: actions/checkout@v3
+      - name: Using Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+      - run: tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,18 +4,21 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
   tox:
+    name: ${{ matrix.os }} / ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix:  # All OSes pass except Windows because tests need Unix-only fcntl, grp, pwd, etc.
-        os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
-        python: ['3.10']  # ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.7']
-    runs-on: ${{ matrix.os }}
+      matrix:
+        os: [ubuntu-latest, macos-latest] # All OSes pass except Windows because tests need Unix-only fcntl, grp, pwd, etc.
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.7", "pypy-3.8" ]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - name: Using Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}
-      - run: pip install --upgrade pip
-      - run: pip install tox
-      - run: pip install -e .
+          python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
       - run: tox -e py

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -31,7 +31,7 @@ class Message(object):
         self.cfg = cfg
         self.unreader = unreader
         self.peer_addr = peer_addr
-        self.remote_addr = peer_addr[0]
+        self.remote_addr = peer_addr
         self.version = None
         self.headers = []
         self.trailers = []

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = py35, py36, py37, py38, py39, py310, pypy3, lint, docs-lint, pycodestyle
-skipsdist = True
+envlist = py{37,38,39,310,311,py3}, lint, docs-lint, pycodestyle
+skipsdist = false
+; Can't set skipsdist and use_develop in tox v4 to true due to https://github.com/tox-dev/tox/issues/2730
 
 [testenv]
-usedevelop = True
+use_develop = true
 commands = pytest --cov=gunicorn {posargs}
 deps =
   -rrequirements_test.txt
@@ -25,10 +26,10 @@ commands =
     tests/test_util.py \
     tests/test_valid_requests.py
 deps =
-  pylint
+  pylint<2.7
 
 [testenv:docs-lint]
-whitelist_externals =
+allowlist_externals =
   rst-lint
   bash
   grep


### PR DESCRIPTION
### Summary of changes

1. Updated the CI as part of #2641 to use full matrix for Linux/OSX as well as non-eol python versions
2. Cherry picked c04a30f15546a139d855509b26da6086127dec77 to get tests working
3. Fixed some tox issues preventing tox from working due to v4 changes discussed [here](https://github.com/tox-dev/tox/issues/2730)
4. Adjusted linting to use pylint version where it used to pass (back in travis CI days), if we want to use latest and correct the linting issues as they come we can revert the pylint version lock

I realized a bit too late that you were already working on #2920, so I apologize if you think this seems duplicative.

[🔗 to workflows on my fork](https://github.com/samypr100/gunicorn/actions?query=branch%3Aci-improvements) for this branch

### Failing CI Issues Left

1. pycodestyle doesn't seem to pass in any version I tested, so maybe that should be a separate PR?
