### PR TITLE
Log exception when worker booting has failed

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -590,8 +590,11 @@ class Arbiter(object):
             print("%s" % e, file=sys.stderr)
             sys.stderr.flush()
             sys.exit(self.APP_LOAD_ERROR)
-        except Exception:
-            self.log.exception("Exception in worker process")
+        except Exception as e:
+            self.log.exception("Exception in worker process",
+                               exc_info=e)
+            print("%s" % e, file=sys.stderr)
+            sys.stderr.flush()
             if not worker.booted:
                 sys.exit(self.WORKER_BOOT_ERROR)
             sys.exit(-1)


### PR DESCRIPTION
It will help to find out what is going wrong with the worker booting. As for now I see such a records in the log:
```
[INFO] Booting worker with pid: 1592805
[ERROR] Exception in worker process
[INFO] Worker exiting (pid: 1592805)
```

Which is not much informative.