### PR TITLE
Fix reuse-port to balance requests across Gunicorn workers

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -10,6 +10,7 @@ import signal
 import sys
 import time
 import traceback
+import socket
 
 from gunicorn.errors import HaltServer, AppImportError
 from gunicorn.pidfile import Pidfile
@@ -152,7 +153,8 @@ class Arbiter(object):
                 for fd in os.environ.pop('GUNICORN_FD').split(','):
                     fds.append(int(fd))
 
-            self.LISTENERS = sock.create_sockets(self.cfg, self.log, fds)
+            if not (self.cfg.reuse_port and hasattr(socket, 'SO_REUSEPORT')):
+                self.LISTENERS = sock.create_sockets(self.cfg, self.log, fds)
 
         listeners_str = ",".join([str(lnr) for lnr in self.LISTENERS])
         self.log.debug("Arbiter booted")
@@ -579,6 +581,8 @@ class Arbiter(object):
         try:
             util._setproctitle("worker [%s]" % self.proc_name)
             self.log.info("Booting worker with pid: %s", worker.pid)
+            if self.cfg.reuse_port:
+                worker.sockets = sock.create_sockets(self.cfg, self.log)
             self.cfg.post_fork(self, worker)
             worker.init_process()
             sys.exit(0)

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -41,7 +41,7 @@ class GeventWorker(AsyncWorker):
         sockets = []
         for s in self.sockets:
             sockets.append(socket.socket(s.FAMILY, socket.SOCK_STREAM,
-                                         fileno=s.sock.fileno()))
+                                         fileno=s.sock.detach()))
         self.sockets = sockets
 
     def notify(self):


### PR DESCRIPTION
Hi,
As previously noted in issues #2100, #1984, #2465, #2095, #2192, and #2168 - Gunicorn isn't correctly load balancing requests across processes, even if you flip on reuse_port.

An aside to really spell out what the problem is:
As @tilgovi noted in #2101 and #2102, the root of the problem is that when the workers fork, the socket data structure from the master process is reused for each worker.  Fundamentally, this means SO_REUSEPORT doesn't work as designed, since there's really just one socket object being bound to the address.

We tried #2101 as a fix for this - but soon ran into a variety of bizarre crashes including “socket operation on non-socket” and “Bad file descriptor”.  After quite a bit of debugging, we found a use after free in Gunicorn's gevent worker https://github.com/benoitc/gunicorn/blob/master/gunicorn/workers/ggevent.py#L41-L45.  

In this code, the original objects in self.sockets (before line 45) are eventually garbage collected and thus closed, leading to "Bad file descriptor".  If the file descriptor gets reused, it can lead to "socket operation on non-socket".  If you call socket.detach as in this patch - the socket is preserved by the process and it doesn't matter if socket gets garbage collected.

I ran some experiments to quantify the effects of this patch - here are some results.
All these processes are running `gunicorn --workers=8 -k gevent --reuse-port test:app`.  
I collate the number of requests handled by each PID:

1 request at a time:
Before:
  | Request count | PID |
  ------ | ------
  | 6 |3917512 |
  | 132 |3917513 |
  | 1849 |3917514 |
  | 3013 |3917515 |
  | 0 | 3917516 |
 | 0 | 3917517 |
 | 0 | 3917518 |
 | 0 | 3917519 |

(4 processes didn't get any requests at all!) 

After:
  | Request count | PID |
  ------ | ------
  |  567 | 3949075 |
  |  627 | 3949076 |
  |  574 | 3949077 |
  |  615 | 3949078 |
  |  640 | 3949079 |
  |  691 | 3949080 |
  |  633 | 3949081 |
  |  653 | 3949082 |


100 requests at a time:

Before:
  | Request count | PID |
  ------ | ------
   | 719 | 3918594 |
   | 519 | 3918595 |
   | 601 | 3918596 |
   | 694 | 3918597 |
   | 592 | 3918598 |
   | 578 | 3918599 |
   | 743 | 3918600 |
   | 554 | 3918601 |

After:
  | Request count | PID |
  ------ | ------
   | 617 | 3953280 |
   | 631 | 3953281 |
   | 637 | 3953282 |
   | 608 | 3953283 |
   | 633 | 3953284 |
   | 595 | 3953285 |
   | 630 | 3953286 |
   | 649 | 3953287 |

I'm not sure how to adapt this patch to support Gunicorn's add and decrement worker functionality, or the USR2 signal, I would appreciate some guidance on that topic.

Lastly, thank ya'll for your work on Gunicorn - it's been powering our site for years!