### PR TITLE
Docs: add link to configuration file

### DIFF
--- a/docs/source/configure.rst
+++ b/docs/source/configure.rst
@@ -65,6 +65,7 @@ usual::
 There is also a ``--version`` flag available to the command line scripts that
 isn't mentioned in the list of :ref:`settings <settings>`.
 
+.. _configuration_file:
 
 Configuration File
 ==================

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -548,7 +548,7 @@ class ConfigFile(Setting):
     validator = validate_string
     default = "./gunicorn.conf.py"
     desc = """\
-        The Gunicorn config file.
+        :ref:`The Gunicorn config file<configuration_file>`.
 
         A string of the form ``PATH``, ``file:PATH``, or ``python:MODULE_NAME``.
 


### PR DESCRIPTION
See #2136 (not a full solution, but at least one more path to understanding added)

I didn't manage to figure out how to add a section description for the "Server Hooks" section (which would be a more complete solution)