### PR TITLE
2747-Replace pkg_resources.parse_version with packaging.version.parse

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -168,6 +168,7 @@ Stephen DiCato <Locker537@gmail.com>
 Stephen Holsapple <sholsapp@gmail.com>
 Steven Cummings <estebistec@gmail.com>
 Sébastien Fievet <zyegfryed@gmail.com>
+Tal Einat <532281+taleinat@users.noreply.github.com>
 Talha Malik <talham7391@hotmail.com>
 TedWantsMore <TedWantsMore@gmx.com>
 Teko012 <112829523+Teko012@users.noreply.github.com>

--- a/gunicorn/workers/geventlet.py
+++ b/gunicorn/workers/geventlet.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     raise RuntimeError("eventlet worker requires eventlet 0.24.1 or higher")
 else:
-    from pkg_resources import parse_version
+    from packaging.version import parse as parse_version
     if parse_version(eventlet.__version__) < parse_version('0.24.1'):
         raise RuntimeError("eventlet worker requires eventlet 0.24.1 or higher")
 

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     raise RuntimeError("gevent worker requires gevent 1.4 or higher")
 else:
-    from pkg_resources import parse_version
+    from packaging.version import parse as parse_version
     if parse_version(gevent.__version__) < parse_version('1.4'):
         raise RuntimeError("gevent worker requires gevent 1.4 or higher")
 

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ install_requires = [
     # is the first version to support Python 3.4 which we require as a
     # floor.
     'setuptools>=3.0',
+    'packaging',
 ]
 
 extras_require = {


### PR DESCRIPTION
This is a step towards removing the dependency on pkg_resources, which is part of setuptools, and thus makes setuptools a runtime dependency.

Note the addition of the [packaging](https://packaging.pypa.io/) library as a dependency.

See: #2747