### PR TITLE
Add prometheus

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -11,6 +11,8 @@ import sys
 import time
 import traceback
 
+from prometheus_client import multiprocess
+
 from gunicorn.errors import HaltServer, AppImportError
 from gunicorn.glogging import BaseLogger
 from gunicorn.pidfile import Pidfile
@@ -533,6 +535,10 @@ class Arbiter(object):
                         continue
                     worker.tmp.close()
                     self.cfg.child_exit(self, worker)
+
+                    if self.cfg.prometheus_bind is not None:
+                        multiprocess.mark_process_dead(wpid)
+
         except OSError as e:
             if e.errno != errno.ECHILD:
                 raise

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -12,6 +12,7 @@ import time
 import traceback
 
 from gunicorn.errors import HaltServer, AppImportError
+from gunicorn.glogging import BaseLogger
 from gunicorn.pidfile import Pidfile
 from gunicorn import sock, systemd, util
 
@@ -554,9 +555,8 @@ class Arbiter(object):
         if self._last_logged_active_worker_count != active_worker_count:
             self._last_logged_active_worker_count = active_worker_count
             self.log.debug("{0} workers".format(active_worker_count),
-                           extra={"metric": "gunicorn.workers",
-                                  "value": active_worker_count,
-                                  "mtype": "gauge"})
+                           extra={**BaseLogger.WORKERS_COUNT_EXTRA,
+                                  "value": active_worker_count})
 
     def spawn_worker(self):
         self.worker_age += 1

--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -163,9 +163,17 @@ def parse_syslog_address(addr):
 
 
 class BaseLogger(object):
+    # Instrumentation constants
+    METRIC_VAR = "metric"
+    VALUE_VAR = "value"
+    MTYPE_VAR = "mtype"
+    GAUGE_TYPE = "gauge"
+    COUNTER_TYPE = "counter"
+    HISTOGRAM_TYPE = "histogram"
+
     WORKERS_COUNT_EXTRA = {
         "metric": "gunicorn.workers",
-        "mtype": "gauge"
+        "mtype": GAUGE_TYPE
     }
 
     def critical(self, msg, *args, **kwargs):
@@ -497,7 +505,7 @@ class Logger(BaseLogger):
 class LoggersChain(BaseLogger):
     def __init__(self, loggers):
         self.loggers = loggers
-    
+
     def setup(self, cfg):
         for logger in self.loggers:
             logger.setup(logger)

--- a/gunicorn/instrument/prometheus.py
+++ b/gunicorn/instrument/prometheus.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+import logging
+import os
+import tempfile
+
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, multiprocess
+
+from gunicorn.glogging import BaseLogger, Logger
+
+
+class Prometheus(Logger):
+    """prometheus-based instrumentation, that passes as a logger
+    """
+    def __init__(self, cfg):
+        super().__init__(cfg)
+
+        self.prefix = cfg.prometheus_prefix.rstrip("_")
+
+        fdir = cfg.worker_tmp_dir
+        if fdir and not os.path.isdir(fdir):
+            raise RuntimeError("%s doesn't exist. Can't create prometheustmp." % fdir)
+        path = tempfile.mkdtemp(prefix="gunicorn-prometheus-", dir=fdir)
+
+        registry = CollectorRegistry()
+        multiprocess.MultiProcessCollector(registry, path=path)
+
+        self.ERROR_COUNTER = Counter('gunicorn_error_total', 'How many warning, error, '
+                                     'exception or critical logs occured',
+                                     labelnames=['level'], registry=registry,
+                                     namespace=self.prefix)
+        self.REQUESTS_COUNTER = Counter('gunicorn_requests_total', 'How many HTTP requests '
+                                        'processed, partitioned by status code and method.',
+                                        labelnames=['code', 'method'], registry=registry,
+                                        namespace=self.prefix)
+        self.REQUESTS_HISTOGRAM = Histogram('gunicorn_request_duration_seconds', 'How long it '
+                                            'took to process the request, partitioned by '
+                                            'status code and method.',
+                                            labelnames=['code', 'method'], registry=registry,
+                                            namespace=self.prefix)
+        self.WORKERS_GAUGE = Gauge('gunicorn_workers', 'How many active workers'
+                                   ' processing requests',
+                                   registry=registry, namespace=self.prefix)
+
+        self.REGISTERED_METRICS = {
+            (
+                BaseLogger.WORKERS_COUNT_EXTRA['metric'],
+                BaseLogger.WORKERS_COUNT_EXTRA['mtype']
+            ): self.WORKERS_GAUGE,
+        }
+
+    # Log errors and warnings
+    def critical(self, msg, *args, **kwargs):
+        self.ERROR_COUNTER.labels(level='critical').inc()
+
+    def error(self, msg, *args, **kwargs):
+        self.ERROR_COUNTER.labels(level='error').inc()
+
+    def warning(self, msg, *args, **kwargs):
+        self.ERROR_COUNTER.labels(level='warning').inc()
+
+    def exception(self, msg, *args, **kwargs):
+        self.ERROR_COUNTER.labels(level='exception').inc()
+
+    # Special treatment for info, the most common log level
+    def info(self, msg, *args, **kwargs):
+        self.log(logging.INFO, msg, *args, **kwargs)
+
+    # skip the run-of-the-mill logs
+    def debug(self, msg, *args, **kwargs):
+        self.log(logging.DEBUG, msg, *args, **kwargs)
+
+    def log(self, lvl, msg, *args, **kwargs):
+        """Log a given statistic if metric, value and type are present
+        """
+        try:
+            extra = kwargs.get("extra", None)
+            if extra is not None:
+                metric = extra.get(BaseLogger.METRIC_VAR, None)
+                value = extra.get(BaseLogger.VALUE_VAR, None)
+                typ = extra.get(BaseLogger.MTYPE_VAR, None)
+                if metric and typ and value:
+                    prometheus_metric = self.REGISTERED_METRICS.get((metric, typ))
+                    if prometheus_metric:
+                        if typ == BaseLogger.GAUGE_TYPE:
+                            prometheus_metric.set(value)
+                        elif typ == BaseLogger.COUNTER_TYPE:
+                            prometheus_metric.inc(value)
+                        elif typ == BaseLogger.HISTOGRAM_TYPE:
+                            prometheus_metric.observe(value)
+                        else:
+                            pass
+                    else:
+                        super().warning(
+                            'Unsupported metric name and type: {}, {}'.format(metric, typ)
+                        )
+        except Exception:
+            super().warning("Failed capture log for prometheus", exc_info=True)
+
+    # access logging
+    def access(self, resp, req, environ, request_time):
+        """Measure request duration
+        request_time is a datetime.timedelta
+        """
+        duration_in_seconds = request_time.total_seconds()
+        status = resp.status
+        if isinstance(status, str):
+            status = int(status.split(None, 1)[0])
+        self.REQUESTS_COUNTER.labels(code=str(status), method=str(req.method)).inc()
+        self.REQUESTS_HISTOGRAM.labels(code=str(status), method=str(req.method)) \
+            .observe(duration_in_seconds)

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -26,7 +26,7 @@ class Statsd(Logger):
     def __init__(self, cfg):
         """host, port: statsD server
         """
-        Logger.__init__(self, cfg)
+        super().__init__(cfg)
         self.prefix = sub(r"^(.+[^.]+)\.*$", "\\g<1>.", cfg.statsd_prefix)
         try:
             host, port = cfg.statsd_host
@@ -39,19 +39,15 @@ class Statsd(Logger):
 
     # Log errors and warnings
     def critical(self, msg, *args, **kwargs):
-        Logger.critical(self, msg, *args, **kwargs)
         self.increment("gunicorn.log.critical", 1)
 
     def error(self, msg, *args, **kwargs):
-        Logger.error(self, msg, *args, **kwargs)
         self.increment("gunicorn.log.error", 1)
 
     def warning(self, msg, *args, **kwargs):
-        Logger.warning(self, msg, *args, **kwargs)
         self.increment("gunicorn.log.warning", 1)
 
     def exception(self, msg, *args, **kwargs):
-        Logger.exception(self, msg, *args, **kwargs)
         self.increment("gunicorn.log.exception", 1)
 
     # Special treatment for info, the most common log level
@@ -81,18 +77,14 @@ class Statsd(Logger):
                     else:
                         pass
 
-            # Log to parent logger only if there is something to say
-            if msg:
-                Logger.log(self, lvl, msg, *args, **kwargs)
         except Exception:
-            Logger.warning(self, "Failed to log to statsd", exc_info=True)
+            super().warning("Failed to log to statsd", exc_info=True)
 
     # access logging
     def access(self, resp, req, environ, request_time):
         """Measure request duration
         request_time is a datetime.timedelta
         """
-        Logger.access(self, resp, req, environ, request_time)
         duration_in_ms = request_time.seconds * 1000 + float(request_time.microseconds) / 10 ** 3
         status = resp.status
         if isinstance(status, str):
@@ -127,4 +119,4 @@ class Statsd(Logger):
             if self.sock:
                 self.sock.send(msg)
         except Exception:
-            Logger.warning(self, "Error sending message to statsd", exc_info=True)
+            super().warning("Error sending message to statsd", exc_info=True)

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -9,15 +9,15 @@ import logging
 import socket
 from re import sub
 
-from gunicorn.glogging import Logger
+from gunicorn.glogging import BaseLogger, Logger
 
-# Instrumentation constants
-METRIC_VAR = "metric"
-VALUE_VAR = "value"
-MTYPE_VAR = "mtype"
-GAUGE_TYPE = "gauge"
-COUNTER_TYPE = "counter"
-HISTOGRAM_TYPE = "histogram"
+# For backward compatibility
+METRIC_VAR = BaseLogger.METRIC_VAR
+VALUE_VAR = BaseLogger.VALUE_VAR
+MTYPE_VAR = BaseLogger.MTYPE_VAR
+GAUGE_TYPE = BaseLogger.GAUGE_TYPE
+COUNTER_TYPE = BaseLogger.COUNTER_TYPE
+HISTOGRAM_TYPE = BaseLogger.HISTOGRAM_TYPE
 
 
 class Statsd(Logger):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,7 +78,7 @@ def test_property_access():
     assert c.worker_class == SyncWorker
 
     # logger class was loaded
-    assert c.logger_class == glogging.Logger
+    assert glogging.Logger in c.logger_class.classes
 
     # Workers defaults to 1
     assert c.workers == 1
@@ -320,9 +320,10 @@ def test_nworkers_changed():
 
 def test_statsd_changes_logger():
     c = config.Config()
-    assert c.logger_class == glogging.Logger
+    assert glogging.Logger in c.logger_class.classes
     c.set('statsd_host', 'localhost:12345')
-    assert c.logger_class == statsd.Statsd
+    assert glogging.Logger in c.logger_class.classes
+    assert statsd.Statsd in c.logger_class.classes
 
 
 class MyLogger(glogging.Logger):
@@ -330,13 +331,14 @@ class MyLogger(glogging.Logger):
     pass
 
 
-def test_always_use_configured_logger():
+def test_use_both_configured_logger():
     c = config.Config()
     c.set('logger_class', __name__ + '.MyLogger')
-    assert c.logger_class == MyLogger
+    assert MyLogger in c.logger_class.classes
     c.set('statsd_host', 'localhost:12345')
-    # still uses custom logger over statsd
-    assert c.logger_class == MyLogger
+    # now uses both custom logger and statsd
+    assert MyLogger in c.logger_class.classes
+    assert statsd.Statsd in c.logger_class.classes
 
 
 def test_load_enviroment_variables_config(monkeypatch):


### PR DESCRIPTION
This is a try to fix #2738 and add prometheus metrics for gunicorn

My Ideas/Checklist:
 - [x] Allow to use more than one logger and run all of them for logging. It can allow us to use both statsd, prometheus and custom logger.
 - [ ] Add prometheus to requirements - Should it be added as `extras_require`? for example, use `pip install gunicorn[prometheus]` to have prometheus metrics
 - [x] Write a chainLogger class to do above line.
 - [x] Write a custom logger for prometheus instrument
 - [x] Use prometheus in multiprocess mode
 - [ ] Somehow run prometheus metrics server as a special worker
   - I think it can run with worker_class in arbiter, but I don't know how to do it clean and maintainable.
 - [ ] Write unit tests
 - [ ] prometheus multiprocess path argument on collector doesn't work!! find another way :(
