### PR TITLE
replace pkg_resources.load_entry_point

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -168,6 +168,7 @@ Stephen DiCato <Locker537@gmail.com>
 Stephen Holsapple <sholsapp@gmail.com>
 Steven Cummings <estebistec@gmail.com>
 Sébastien Fievet <zyegfryed@gmail.com>
+Tal Einat <532281+taleinat@users.noreply.github.com>
 Talha Malik <talham7391@hotmail.com>
 TedWantsMore <TedWantsMore@gmx.com>
 Teko012 <112829523+Teko012@users.noreply.github.com>

--- a/gunicorn/workers/geventlet.py
+++ b/gunicorn/workers/geventlet.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     raise RuntimeError("eventlet worker requires eventlet 0.24.1 or higher")
 else:
-    from pkg_resources import parse_version
+    from packaging.version import parse as parse_version
     if parse_version(eventlet.__version__) < parse_version('0.24.1'):
         raise RuntimeError("eventlet worker requires eventlet 0.24.1 or higher")
 

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     raise RuntimeError("gevent worker requires gevent 1.4 or higher")
 else:
-    from pkg_resources import parse_version
+    from packaging.version import parse as parse_version
     if parse_version(gevent.__version__) < parse_version('1.4'):
         raise RuntimeError("gevent worker requires gevent 1.4 or higher")
 

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ install_requires = [
     # is the first version to support Python 3.4 which we require as a
     # floor.
     'setuptools>=3.0',
+    'packaging',
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -70,11 +70,7 @@ class PyTestCommand(TestCommand):
 
 
 install_requires = [
-    # We depend on functioning pkg_resources.working_set.add_entry() and
-    # pkg_resources.load_entry_point(). These both work as of 3.0 which
-    # is the first version to support Python 3.4 which we require as a
-    # floor.
-    'setuptools>=3.0',
+    'importlib_metadata; python_version<"3.8"',
     'packaging',
 ]
 


### PR DESCRIPTION
pkg_resources is deprecated. Use the corresponding importlib.metadata interface instead. Use the stdlib version on python >= 3.8 and use the importlib_metadata backport on older versions.

Relates: https://github.com/benoitc/gunicorn/issues/2747
Closes: https://github.com/benoitc/gunicorn/pull/2958