### PR TITLE
Fix username parsing for basic auth

### DIFF
--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -469,10 +469,7 @@ class Logger(object):
                     # so we need to convert it to a byte string
                     auth = base64.b64decode(auth[1].strip().encode('utf-8'))
                     # b64decode returns a byte string
-                    auth.split(b":", 1)[0].decode("UTF-8", "replace")
+                    user = auth.split(b":", 1)[0].decode("UTF-8")
                 except (TypeError, binascii.Error, UnicodeDecodeError) as exc:
                     self.debug("Couldn't get username: %s", exc)
-                    return user
-                if len(auth) == 2:
-                    user = auth[0]
         return user


### PR DESCRIPTION
This PR fixes issue with basic auth header parsing that was introduced when fixing https://github.com/benoitc/gunicorn/issues/2625.  After applying, test case `test_get_username_from_basic_auth_header` does not fail anymore.

Fixes #2990