### PR TITLE
Deprecate ssl_version option

### DIFF
--- a/docs/gunicorn_ext.py
+++ b/docs/gunicorn_ext.py
@@ -48,7 +48,9 @@ def format_settings(app):
 
 
 def fmt_setting(s):
-    if callable(s.default):
+    if hasattr(s, "default_doc"):
+        val = s.default_doc
+    elif callable(s.default):
         val = inspect.getsource(s.default)
         val = "\n".join("    %s" % line for line in val.splitlines())
         val = "\n\n.. code-block:: python\n\n" + val

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -213,13 +213,11 @@ def close_sockets(listeners, unlink=True):
 
 def ssl_context(conf):
     def default_ssl_context_factory():
-        context = ssl.SSLContext(conf.ssl_version)
+        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH, cafile=conf.ca_certs)
         context.load_cert_chain(certfile=conf.certfile, keyfile=conf.keyfile)
         context.verify_mode = conf.cert_reqs
         if conf.ciphers:
             context.set_ciphers(conf.ciphers)
-        if conf.ca_certs:
-            context.load_verify_locations(cafile=conf.ca_certs)
         return context
 
     return conf.ssl_context(conf, default_ssl_context_factory)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -453,41 +453,6 @@ def test_umask_config(options, expected):
     assert app.cfg.umask == expected
 
 
-@pytest.mark.parametrize("options, expected", [
-    (["--ssl-version", "SSLv23"], 2),
-    (["--ssl-version", "TLSv1"], 3),
-    (["--ssl-version", "2"], 2),
-    (["--ssl-version", "3"], 3),
-])
-def test_ssl_version_named_constants_python3(options, expected):
-    _test_ssl_version(options, expected)
-
-
-@pytest.mark.skipif(sys.version_info < (3, 6),
-    reason="requires python3.6+")
-@pytest.mark.parametrize("options, expected", [
-    (["--ssl-version", "TLS"], 2),
-    (["--ssl-version", "TLSv1_1"], 4),
-    (["--ssl-version", "TLSv1_2"], 5),
-    (["--ssl-version", "TLS_SERVER"], 17),
-])
-def test_ssl_version_named_constants_python36(options, expected):
-    _test_ssl_version(options, expected)
-
-
-@pytest.mark.parametrize("ssl_version", [
-    "FOO",
-    "-99",
-    "99991234"
-])
-def test_ssl_version_bad(ssl_version):
-    c = config.Config()
-    with pytest.raises(ValueError) as exc:
-        c.set("ssl_version", ssl_version)
-    assert 'Valid options' in str(exc.value)
-    assert "TLSv" in str(exc.value)
-
-
 def _test_ssl_version(options, expected):
     cmdline = ["prog_name"]
     cmdline.extend(options)

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -32,14 +32,6 @@ def test_certfile():
     assert CertFile.default is None
 
 
-def test_ssl_version():
-    assert issubclass(SSLVersion, Setting)
-    assert SSLVersion.name == 'ssl_version'
-    assert SSLVersion.section == 'SSL'
-    assert SSLVersion.cli == ['--ssl-version']
-    assert SSLVersion.default == ssl.PROTOCOL_SSLv23
-
-
 def test_cacerts():
     assert issubclass(CACerts, Setting)
     assert CACerts.name == 'ca_certs'


### PR DESCRIPTION
This change defaults `SSLContext` to Python's `ssl.create_default_context()` and marks `ssl_version` option as deprecated. The option value will be ignored, and warning will be printed in stderr. The reason for deprecation is that `ssl_version` option was depending on old method of setting TLS min/max version. Rationale for ignoring the given value is that the method has not worked well anymore with modern Python versions. See discussion thread https://github.com/benoitc/gunicorn/pull/2649#discussion_r1190801170.

As an alternative, config file can be used to set the min/max values, for example:

```python
def ssl_context(conf, default_ssl_context_factory):
    import ssl
    context = default_ssl_context_factory()
    context.minimum_version = ssl.TLSVersion.TLSv1_3
    context.maximum_version = ssl.TLSVersion.TLSv1_3
    return context
```

Additionally, this PR fixes some documentation discrepancies by regenerating `settings.rst` from `config.py`. The PR also suggests small modification to `docs/gunicorn_ext.py` that makes it possible to get sane defaults generated to `settings.rst` for `user`, `group` and `chdir` options, which otherwise will reset to whatever was effective for the user who regenerated the documentation.