### PR TITLE
Log access even when connection is closed

### DIFF
--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -109,17 +109,15 @@ class AsyncWorker(base.Worker):
             if self.is_already_handled(respiter):
                 return False
             try:
-                try:
-                    if isinstance(respiter, environ['wsgi.file_wrapper']):
-                        resp.write_file(respiter)
-                    else:
-                        for item in respiter:
-                            resp.write(item)
-                    resp.close()
-                finally:
-                    request_time = datetime.now() - request_start
-                    self.log.access(resp, req, environ, request_time)
+                if isinstance(respiter, environ['wsgi.file_wrapper']):
+                    resp.write_file(respiter)
+                else:
+                    for item in respiter:
+                        resp.write(item)
+                resp.close()
             finally:
+                request_time = datetime.now() - request_start
+                self.log.access(resp, req, environ, request_time)
                 if hasattr(respiter, "close"):
                     respiter.close()
             if resp.should_close():

--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -109,14 +109,16 @@ class AsyncWorker(base.Worker):
             if self.is_already_handled(respiter):
                 return False
             try:
-                if isinstance(respiter, environ['wsgi.file_wrapper']):
-                    resp.write_file(respiter)
-                else:
-                    for item in respiter:
-                        resp.write(item)
-                resp.close()
-                request_time = datetime.now() - request_start
-                self.log.access(resp, req, environ, request_time)
+                try:
+                    if isinstance(respiter, environ['wsgi.file_wrapper']):
+                        resp.write_file(respiter)
+                    else:
+                        for item in respiter:
+                            resp.write(item)
+                    resp.close()
+                finally:
+                    request_time = datetime.now() - request_start
+                    self.log.access(resp, req, environ, request_time)
             finally:
                 if hasattr(respiter, "close"):
                     respiter.close()

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -333,15 +333,17 @@ class ThreadWorker(base.Worker):
 
             respiter = self.wsgi(environ, resp.start_response)
             try:
-                if isinstance(respiter, environ['wsgi.file_wrapper']):
-                    resp.write_file(respiter)
-                else:
-                    for item in respiter:
-                        resp.write(item)
+                try:
+                    if isinstance(respiter, environ['wsgi.file_wrapper']):
+                        resp.write_file(respiter)
+                    else:
+                        for item in respiter:
+                            resp.write(item)
 
-                resp.close()
-                request_time = datetime.now() - request_start
-                self.log.access(resp, req, environ, request_time)
+                    resp.close()
+                finally:
+                    request_time = datetime.now() - request_start
+                    self.log.access(resp, req, environ, request_time)
             finally:
                 if hasattr(respiter, "close"):
                     respiter.close()

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -333,18 +333,16 @@ class ThreadWorker(base.Worker):
 
             respiter = self.wsgi(environ, resp.start_response)
             try:
-                try:
-                    if isinstance(respiter, environ['wsgi.file_wrapper']):
-                        resp.write_file(respiter)
-                    else:
-                        for item in respiter:
-                            resp.write(item)
+                if isinstance(respiter, environ['wsgi.file_wrapper']):
+                    resp.write_file(respiter)
+                else:
+                    for item in respiter:
+                        resp.write(item)
 
-                    resp.close()
-                finally:
-                    request_time = datetime.now() - request_start
-                    self.log.access(resp, req, environ, request_time)
+                resp.close()
             finally:
+                request_time = datetime.now() - request_start
+                self.log.access(resp, req, environ, request_time)
                 if hasattr(respiter, "close"):
                     respiter.close()
 

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -177,14 +177,16 @@ class SyncWorker(base.Worker):
                 self.alive = False
             respiter = self.wsgi(environ, resp.start_response)
             try:
-                if isinstance(respiter, environ['wsgi.file_wrapper']):
-                    resp.write_file(respiter)
-                else:
-                    for item in respiter:
-                        resp.write(item)
-                resp.close()
-                request_time = datetime.now() - request_start
-                self.log.access(resp, req, environ, request_time)
+                try:
+                    if isinstance(respiter, environ['wsgi.file_wrapper']):
+                        resp.write_file(respiter)
+                    else:
+                        for item in respiter:
+                            resp.write(item)
+                    resp.close()
+                finally:
+                    request_time = datetime.now() - request_start
+                    self.log.access(resp, req, environ, request_time)
             finally:
                 if hasattr(respiter, "close"):
                     respiter.close()

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -177,17 +177,15 @@ class SyncWorker(base.Worker):
                 self.alive = False
             respiter = self.wsgi(environ, resp.start_response)
             try:
-                try:
-                    if isinstance(respiter, environ['wsgi.file_wrapper']):
-                        resp.write_file(respiter)
-                    else:
-                        for item in respiter:
-                            resp.write(item)
-                    resp.close()
-                finally:
-                    request_time = datetime.now() - request_start
-                    self.log.access(resp, req, environ, request_time)
+                if isinstance(respiter, environ['wsgi.file_wrapper']):
+                    resp.write_file(respiter)
+                else:
+                    for item in respiter:
+                        resp.write(item)
+                resp.close()
             finally:
+                request_time = datetime.now() - request_start
+                self.log.access(resp, req, environ, request_time)
                 if hasattr(respiter, "close"):
                     respiter.close()
         except EnvironmentError:


### PR DESCRIPTION
When a client disconnects, `resp.write(item)` would result in a `BrokenPipeError` which prevents the access from being logged.

Fixes #1060.