### PR TITLE
feat: Replace `select()` usage with `poll()`

### DIFF
--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -34,11 +34,11 @@ class SyncWorker(base.Worker):
     def wait(self, timeout):
         try:
             self.notify()
-            ret = select.select(self.wait_fds, [], [], timeout)
-            if ret[0]:
-                if self.PIPE[0] in ret[0]:
+            events = self.poller.poll(timeout)
+            if len(events) > 0:
+                if any(self.PIPE[0] == fd for fd, _ in events):
                     os.read(self.PIPE[0], 1)
-                return ret[0]
+                return events
 
         except select.error as e:
             if e.args[0] == errno.EINTR:


### PR DESCRIPTION
Replaces `select()` calls with `poll()` in order to resolve #2994  where the server fails to start if the pipe created by `arbiter.py` has a file descriptor number past `FD_SETSIZE` (a limitation of `poll()`). Tested by running the test app (`gunicorn --workers=2 test:app`) and verifying that gunicorn's behavior with respect to signal handling was the same as the master branch.