### PR TITLE
Add a Dependabot config to keep GitHub action versions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This PR introduces a Dependabot configuration that will keep GitHub action versions updated. When merged, Dependabot will watch for updates to e.g. `actions/checkout@v3` and will submit PRs when newer versions are detected (like `@v4`, whenever that's released).

The action versions in `lint.yml` and `tox.yml` are currently up-to-date due to a recent manual update, so Dependabot will not submit any PRs immediately after this merges.

I've reviewed the contributing guidelines, but if I missed something that needs to be addressed, please let me know! Thanks for your work on gunicorn!