### PR TITLE
fix gthread worker

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -180,6 +180,9 @@ class ThreadWorker(base.Worker):
                     except KeyError:
                         # already removed by the system, continue
                         pass
+                    except ValueError:
+                        # already removed by the system continue
+                        pass
 
                 # close the socket
                 conn.close()


### PR DESCRIPTION
under Python 3.8 and sup exception is ValueError when fd has already been cleared by the system.

fix #3029