### PR TITLE
Prevent gthread connection reset on max-requests restart

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -118,6 +118,9 @@ class ThreadWorker(base.Worker):
         self._wrap_future(fs, conn)
 
     def accept(self, server, listener):
+        if not self.alive:
+            return
+
         try:
             sock, client = listener.accept()
             # initialize the connection object


### PR DESCRIPTION
**Problem**

The `while self.alive` in `ThreadWorker.run()` doesn't protect against `ThreadWorker.accept()` being called, which can cause a connection reset when the gthread worker type is combined with the `max_requests` setting.

**Solution**

Add a guard clause to protect against this. It's very possible that there's a better way to solve this, but this is my first stab at the problem.

---

Fixes: #3038 