### PR TITLE
De-duplicate and parameterize exit error logging.

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -524,7 +524,8 @@ class Arbiter(object):
                     # infinite start/stop cycles.
                     exitcode = status >> 8
                     if exitcode != 0:
-                        self.log.error('Worker (pid:%s) exited with code %s', wpid, exitcode)
+                        self.log.error("Worker (pid:%s) exited with code %s",
+                                       wpid, exitcode)
                     if exitcode == self.WORKER_BOOT_ERROR:
                         reason = "Worker failed to boot."
                         raise HaltServer(reason, self.WORKER_BOOT_ERROR)
@@ -532,12 +533,7 @@ class Arbiter(object):
                         reason = "App failed to load."
                         raise HaltServer(reason, self.APP_LOAD_ERROR)
 
-                    if exitcode > 0:
-                        # If the exit code of the worker is greater than 0,
-                        # let the user know.
-                        self.log.error("Worker (pid:%s) exited with code %s.",
-                                       wpid, exitcode)
-                    elif status > 0:
+                    if exitcode == 0 and status > 0:
                         # If the exit code of the worker is 0 and the status
                         # is greater than 0, then it was most likely killed
                         # via a signal.
@@ -545,13 +541,12 @@ class Arbiter(object):
                             sig_name = signal.Signals(status).name
                         except ValueError:
                             sig_name = "code {}".format(status)
-                        msg = "Worker (pid:{}) was sent {}!".format(
-                            wpid, sig_name)
+                        msg = "Worker (pid:%s) was sent %s!"
 
                         # Additional hint for SIGKILL
                         if status == signal.SIGKILL:
                             msg += " Perhaps out of memory?"
-                        self.log.error(msg)
+                        self.log.error(msg, wpid, sig_name)
 
                     worker = self.WORKERS.pop(wpid, None)
                     if not worker:


### PR DESCRIPTION
The signal log message had the PID and signal in the message format string, which makes each message unique. This is awkward in log processing with for example Sentry, where you want to see similar messages grouped together.

The exit message was emitted twice, from the "if exitcode != 0" and the "if exitcode > 0" clause. You would be seeing things like:

[2023-08-17 09:50:10 +0200] [66450] [ERROR] Worker (pid:66451) exited with code 1 [2023-08-17 09:50:10 +0200] [66450] [ERROR] Worker (pid:66451) exited with code 1.

See issue #3056 