### PR TITLE
Validate chunk sizes.

### DIFF
--- a/gunicorn/http/body.py
+++ b/gunicorn/http/body.py
@@ -86,10 +86,9 @@ class ChunkedReader(object):
         line, rest_chunk = data[:idx], data[idx + 2:]
 
         chunk_size = line.split(b";", 1)[0].strip()
-        try:
-            chunk_size = int(chunk_size, 16)
-        except ValueError:
+        if any(c not in b"0123456789abcdefABCDEF" for c in chunk_size):
             raise InvalidChunkSize(chunk_size)
+        chunk_size = int(chunk_size, 16)
 
         if chunk_size == 0:
             try:


### PR DESCRIPTION
Because of quirks of `int()` chunk sizes like `'+0x0'` are currently erroneously accepted by the HTTP parser. This patch checks that chunk sizes are valid (match the grammar in the RFC) before using them.