### PR TITLE
Add config: buf_read_size

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -20,6 +20,20 @@ for reference on setting at the command line.
 
     .. versionadded:: 19.7
 
+
+
+
+.. _buf-read-size:
+
+``buf_read_size``
+~~~~~~~~~~~~~~~~~
+
+**Command line:** ``--buf-read-size``
+
+**Default:** ``1024``
+
+Buffer read size from request data
+
 Config File
 -----------
 

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -20,20 +20,6 @@ for reference on setting at the command line.
 
     .. versionadded:: 19.7
 
-
-
-
-.. _buf-read-size:
-
-``buf_read_size``
-~~~~~~~~~~~~~~~~~
-
-**Command line:** ``--buf-read-size``
-
-**Default:** ``1024``
-
-Buffer read size from request data
-
 Config File
 -----------
 
@@ -1390,6 +1376,17 @@ Front-end's IPs from which allowed accept proxy requests (comma separate).
 Set to ``*`` to disable checking of Front-end IPs (useful for setups
 where you don't know in advance the IP address of Front-end, but
 you still trust the environment)
+
+.. _buf-read-size:
+
+``buf_read_size``
+~~~~~~~~~~~~~~~~~
+
+**Command line:** ``--buf-read-size``
+
+**Default:** ``1024``
+
+Buffer read size from request data
 
 .. _raw-paste-global-conf:
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -209,6 +209,14 @@ class Config(object):
         return True
 
     @property
+    def buf_read_size(self):
+        buf_read_size = self.settings['buf_read_size'].get()
+        if buf_read_size is None:
+            return 1024
+
+        return int(buf_read_size)
+
+    @property
     def reuse_port(self):
         return self.settings['reuse_port'].get()
 
@@ -2158,6 +2166,15 @@ class CertReqs(Setting):
     ===========  ===========================
     """
 
+class BufReadSize(Setting):
+    name = "buf_read_size"
+    section = "Server Mechanics"
+    cli = ["--buf-read-size"]
+    validator = validate_pos_int
+    default = 1024
+    desc = """\
+    Buffer read size from request data
+    """
 
 class CACerts(Setting):
     name = "ca_certs"

--- a/gunicorn/http/body.py
+++ b/gunicorn/http/body.py
@@ -175,7 +175,8 @@ class EOFReader(object):
 
 
 class Body(object):
-    def __init__(self, reader):
+    def __init__(self, cfg, reader):
+        self.cfg = cfg
         self.reader = reader
         self.buf = io.BytesIO()
 
@@ -212,7 +213,7 @@ class Body(object):
             return ret
 
         while size > self.buf.tell():
-            data = self.reader.read(1024)
+            data = self.reader.read(self.cfg.buf_read_size)
             if not data:
                 break
             self.buf.write(data)

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -136,7 +136,7 @@ class Message(object):
                     chunked = True
 
         if chunked:
-            self.body = Body(ChunkedReader(self, self.unreader))
+            self.body = Body(self.cfg, ChunkedReader(self, self.unreader))
         elif content_length is not None:
             try:
                 if str(content_length).isnumeric():
@@ -149,9 +149,9 @@ class Message(object):
             if content_length < 0:
                 raise InvalidHeader("CONTENT-LENGTH", req=self)
 
-            self.body = Body(LengthReader(self.unreader, content_length))
+            self.body = Body(self.cfg, LengthReader(self.unreader, content_length))
         else:
-            self.body = Body(EOFReader(self.unreader))
+            self.body = Body(self.cfg, EOFReader(self.unreader))
 
     def should_close(self):
         for (h, v) in self.headers:
@@ -357,4 +357,4 @@ class Request(Message):
     def set_body_reader(self):
         super().set_body_reader()
         if isinstance(self.body.reader, EOFReader):
-            self.body = Body(LengthReader(self.unreader, 0))
+            self.body = Body(self.cfg, LengthReader(self.unreader, 0))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -467,6 +467,16 @@ def test_bind_fd():
     assert app.cfg.bind == ["fd://42"]
 
 
+def test_buf_read_size():
+    with AltArgs(["prog_name"]):
+        app = NoConfigApp()
+    assert app.cfg.buf_read_size == 1024
+
+    with AltArgs(["prog_name", "--buf-read-size", "1048576"]):
+        app = NoConfigApp()
+    assert app.cfg.buf_read_size == 1048576
+
+
 def test_repr():
     c = config.Config()
     c.set("workers", 5)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -5,7 +5,7 @@ import t
 import pytest
 from unittest import mock
 
-from gunicorn import util
+from gunicorn import config, util
 from gunicorn.http.body import Body, LengthReader, EOFReader
 from gunicorn.http.wsgi import Response
 from gunicorn.http.unreader import Unreader, IterUnreader, SocketUnreader
@@ -13,7 +13,7 @@ from gunicorn.http.errors import InvalidHeader, InvalidHeaderName
 
 
 def assert_readline(payload, size, expected):
-    body = Body(io.BytesIO(payload))
+    body = Body(config.Config(), io.BytesIO(payload))
     assert body.readline(size) == expected
 
 
@@ -28,21 +28,21 @@ def test_readline_zero_size():
 
 
 def test_readline_new_line_before_size():
-    body = Body(io.BytesIO(b"abc\ndef"))
+    body = Body(config.Config(), io.BytesIO(b"abc\ndef"))
     assert body.readline(4) == b"abc\n"
     assert body.readline() == b"def"
 
 
 def test_readline_new_line_after_size():
-    body = Body(io.BytesIO(b"abc\ndef"))
+    body = Body(config.Config(), io.BytesIO(b"abc\ndef"))
     assert body.readline(2) == b"ab"
     assert body.readline() == b"c\n"
 
 
 def test_readline_no_new_line():
-    body = Body(io.BytesIO(b"abcdef"))
+    body = Body(config.Config(), io.BytesIO(b"abcdef"))
     assert body.readline() == b"abcdef"
-    body = Body(io.BytesIO(b"abcdef"))
+    body = Body(config.Config(), io.BytesIO(b"abcdef"))
     assert body.readline(2) == b"ab"
     assert body.readline(2) == b"cd"
     assert body.readline(2) == b"ef"
@@ -50,7 +50,7 @@ def test_readline_no_new_line():
 
 def test_readline_buffer_loaded():
     reader = io.BytesIO(b"abc\ndef")
-    body = Body(reader)
+    body = Body(config.Config(), reader)
     body.read(1) # load internal buffer
     reader.write(b"g\nhi")
     reader.seek(7)
@@ -60,7 +60,7 @@ def test_readline_buffer_loaded():
 
 
 def test_readline_buffer_loaded_with_size():
-    body = Body(io.BytesIO(b"abc\ndef"))
+    body = Body(config.Config(), io.BytesIO(b"abc\ndef"))
     body.read(1)  # load internal buffer
     assert body.readline(2) == b"bc"
     assert body.readline(2) == b"\n"


### PR DESCRIPTION
Resolves #2596.

Add the `--buf-read-size` option to set the block size when reading request body.