### PR TITLE
Add Python 3.12 to test matrix and add classifiers

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest] # All OSes pass except Windows because tests need Unix-only fcntl, grp, pwd, etc.
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.8" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8" ]
     steps:
       - uses: actions/checkout@v4
       - name: Using Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3 :: Only',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311,py3}, lint, docs-lint, pycodestyle
+envlist = py{37,38,39,310,311,312,py3}, lint, docs-lint, pycodestyle
 skipsdist = false
 ; Can't set skipsdist and use_develop in tox v4 to true due to https://github.com/tox-dev/tox/issues/2730
 


### PR DESCRIPTION
This PR adds Python 3.12 to the github actions. 

It seems like Gunicorn itself doesn't need any modifications but eventlet has some work to do: https://github.com/eventlet/eventlet/pull/797