### PR TITLE
Update arbiter.py - log SIGTERM as info level message

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -524,7 +524,8 @@ class Arbiter(object):
                     # infinite start/stop cycles.
                     exitcode = status >> 8
                     if exitcode != 0:
-                        self.log.error('Worker (pid:%s) exited with code %s', wpid, exitcode)
+                        self.log.error('Worker (pid:%s) exited with code %s',
+                                       wpid, exitcode)
                     if exitcode == self.WORKER_BOOT_ERROR:
                         reason = "Worker failed to boot."
                         raise HaltServer(reason, self.WORKER_BOOT_ERROR)
@@ -537,21 +538,19 @@ class Arbiter(object):
                         # let the user know.
                         self.log.error("Worker (pid:%s) exited with code %s.",
                                        wpid, exitcode)
-                    elif status > 0:
-                        # If the exit code of the worker is 0 and the status
-                        # is greater than 0, then it was most likely killed
-                        # via a signal.
+                    elif status == signal.SIGTERM:
+                        self.log.info("Worker (pid:%s) gracefully killed", wpid)
+                    else:
                         try:
                             sig_name = signal.Signals(status).name
                         except ValueError:
                             sig_name = "code {}".format(status)
-                        msg = "Worker (pid:{}) was sent {}!".format(
-                            wpid, sig_name)
+                        msg = "Worker (pid:%s) was sent %s!"
 
                         # Additional hint for SIGKILL
                         if status == signal.SIGKILL:
                             msg += " Perhaps out of memory?"
-                        self.log.error(msg)
+                        self.log.error(msg, wpid, sig_name)
 
                     worker = self.WORKERS.pop(wpid, None)
                     if not worker:


### PR DESCRIPTION
I recently started to record gunicorn error messages and everytime I reloaded gunicorn, I received error log messages from every worker. SIGTERM should not generate an error log message. Info level is more appropriate since it is a graceful exit.