### PR TITLE
Use `utime` instead of `fchmod` in `WorkerTmp.notify`

### DIFF
--- a/gunicorn/workers/workertmp.py
+++ b/gunicorn/workers/workertmp.py
@@ -39,11 +39,8 @@ class WorkerTmp(object):
             os.close(fd)
             raise
 
-        self.spinner = 0
-
     def notify(self):
-        self.spinner = (self.spinner + 1) % 2
-        os.fchmod(self._tmp.fileno(), self.spinner)
+        os.utime(self._tmp.fileno())
 
     def last_update(self):
         return os.fstat(self._tmp.fileno()).st_ctime


### PR DESCRIPTION
This PR uses `utime` to update the "Changed" timestamp of the worker's temporary file, instead of calling `fchmod(fd, 0)` & `fchmod(fd, 1)` back-and-forth (which may be problematic in some restrictive environments).

This change was made possible in Python 3.3, which added support for calling `utime` with a file descriptor.