### PR TITLE
Docs: Forum closed

### DIFF
--- a/docs/source/community.rst
+++ b/docs/source/community.rst
@@ -8,7 +8,7 @@ Project Management & Discussions
 ================================
 
 Gunicorn uses `GitHub for the project management <https://github.com/benoitc/gunicorn/projects>`_. GitHub issues are used
-for 3 different purposes:
+for different purposes:
 
   * `Bug tracker <https://github.com/benoitc/gunicorn/projects/2>`_ : to check latest bug 
   * `Mailing list <https://github.com/benoitc/gunicorn/projects/3>`_ : Discussion of Gunicorn development, new features


### PR DESCRIPTION
I noticed that the GitHub projects at `https://github.com/benoitc/gunicorn/projects/4` are closed with no other open GH Projects. 

If there are any newer alternatives please let me know, I'll be happy to help update the docs to include them as well.