### PR TITLE
pyproject.toml: fix embedding of the LICENSE file in the package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ addopts = "--assert=plain --cov=gunicorn --cov-report=xml"
 [tool.setuptools]
 zip-safe = false
 include-package-data = true
-license-files = ["['LICENSE']"]
+license-files = ["LICENSE"]
 
 [tool.setuptools.packages]
 find = {namespaces = false}


### PR DESCRIPTION
Sorry, an incorectness slept-in in #3063: the `LICENSE` file won't be properly embedded in the package. I tested this fix locally, you can merge with confidence.
Sorry again 😬 