### PR TITLE
restore, and from now on CI-test for entry point

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: lint
 on: [push, pull_request]
 permissions:
   contents: read # to fetch code (actions/checkout)
+env:
+  # note that some tools care only for the name, not the value
+  FORCE_COLOR: 1
 jobs:
   lint:
     name: tox-${{ matrix.toxenv }}
@@ -14,9 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Using Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -2,6 +2,9 @@ name: tox
 on: [push, pull_request]
 permissions:
   contents: read # to fetch code (actions/checkout)
+env:
+  # note that some tools care only for the name, not the value
+  FORCE_COLOR: 1
 jobs:
   tox:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
@@ -14,11 +17,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Using Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements_test.txt
+          check-latest: true
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install tox
+      - run: tox -e run-module
       - run: tox -e py

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -28,4 +28,5 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install tox
       - run: tox -e run-module
+      - run: tox -e run-entrypoint
       - run: tox -e py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,11 @@ environment:
       PYTHON: "C:\\Python38-x64"
     - TOXENV: pycodestyle
       PYTHON: "C:\\Python38-x64"
+    # Windows cannot even import the module when they unconditionally import, see below.
+    #- TOXENV: run-module
+    #  PYTHON: "C:\\Python38-x64"
+    #- TOXENV: run-entrypoint
+    #  PYTHON: "C:\\Python38-x64"
     # Windows is not ready for testing!!!
     # Python's fcntl, grp, pwd, os.geteuid(), and socket.AF_UNIX are all Unix-only.
     #- TOXENV: py35

--- a/gunicorn/__main__.py
+++ b/gunicorn/__main__.py
@@ -4,4 +4,8 @@
 # See the NOTICE for more information.
 
 from gunicorn.app.wsgiapp import run
-run()
+
+if __name__ == "__main__":
+    # see config.py - argparse defaults to basename(argv[0]) == "__main__.py"
+    # todo: let runpy.run_module take care of argv[0] rewriting
+    run(prog="gunicorn")

--- a/gunicorn/app/wsgiapp.py
+++ b/gunicorn/app/wsgiapp.py
@@ -58,13 +58,13 @@ class WSGIApplication(Application):
             return self.load_wsgiapp()
 
 
-def run():
+def run(prog=None):
     """\
     The ``gunicorn`` command line runner for launching Gunicorn with
     generic WSGI applications.
     """
     from gunicorn.app.wsgiapp import WSGIApplication
-    WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]").run()
+    WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]", prog=prog).run()
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,13 +57,13 @@ setproctitle = ["setproctitle"]
 testing = [
     "gevent",
     "eventlet",
-    "cryptography",
     "coverage",
     "pytest",
     "pytest-cov",
 ]
 
 [tool.pytest.ini_options]
+# # can override these: python -m pytest --override-ini="addopts="
 norecursedirs = ["examples", "lib", "local", "src"]
 testpaths = ["tests/"]
 addopts = "--assert=plain --cov=gunicorn --cov-report=xml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,14 @@ testing = [
     "pytest-cov",
 ]
 
+[project.scripts]
+# duplicates "python -m gunicorn" handling in __main__.py
+gunicorn = "gunicorn.app.wsgiapp:run"
+
+# note the quotes around "paste.server_runner" to escape the dot
+[project.entry-points."paste.server_runner"]
+main = "gunicorn.app.pasterapp:serve"
+
 [tool.pytest.ini_options]
 # # can override these: python -m pytest --override-ini="addopts="
 norecursedirs = ["examples", "lib", "local", "src"]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,9 @@
 -r requirements_test.txt
 
+# setuptools v68.0 fails hard on invalid pyproject.toml
+# which a developer would want to know
+# otherwise, oldest known-working version is 61.2
+setuptools>=68.0
+
 sphinx
 sphinx_rtd_theme

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,5 @@
 gevent
 eventlet
-cryptography
 coverage
 pytest
 pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311,py3}, lint, docs-lint, pycodestyle, run-module
+envlist = py{37,38,39,310,311,py3}, lint, docs-lint, pycodestyle, run-entrypoint, run-module
 skipsdist = false
 ; Can't set skipsdist and use_develop in tox v4 to true due to https://github.com/tox-dev/tox/issues/2730
 
@@ -9,8 +9,13 @@ commands = pytest --cov=gunicorn {posargs}
 deps =
   -rrequirements_test.txt
 
+[testenv:run-entrypoint]
+# entry point: console script (provided by setuptools from pyproject.toml)
+commands = python -c 'import subprocess; cmd_out = subprocess.check_output(["gunicorn", "--version"])[:79].decode("utf-8", errors="replace"); print(cmd_out); assert cmd_out.startswith("gunicorn ")'
+
 [testenv:run-module]
-commands = python3 -m gunicorn --version
+# runpy (provided by module.__main__)
+commands = python -c 'import sys,subprocess; cmd_out = subprocess.check_output([sys.executable, "-m", "gunicorn", "--version"])[:79].decode("utf-8", errors="replace"); print(cmd_out); assert cmd_out.startswith("gunicorn ")'
 
 [testenv:lint]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311,py3}, lint, docs-lint, pycodestyle
+envlist = py{37,38,39,310,311,py3}, lint, docs-lint, pycodestyle, run-module
 skipsdist = false
 ; Can't set skipsdist and use_develop in tox v4 to true due to https://github.com/tox-dev/tox/issues/2730
 
@@ -8,6 +8,9 @@ use_develop = true
 commands = pytest --cov=gunicorn {posargs}
 deps =
   -rrequirements_test.txt
+
+[testenv:run-module]
+commands = python3 -m gunicorn --version
 
 [testenv:lint]
 commands =


### PR DESCRIPTION
1. We want the built package to install a "gunicorn" script.
   * Tell setuptools, now it reads that from `pyproject.toml`
   * Fixes: https://github.com/benoitc/gunicorn/issues/3119
2. We want that script to work and reasonable output when called `gunicorn --help`
   * Have CI `assert` that
3. We want the entry point to work more or less interchangeably with `python3 -m gunicorn` (that is: `__main__.py`)
   * Have CI `assert` that

Driveby fixes:

4. GitHub actions finish faster when the setup-python knows which dependencies are reused
    * potentially unwanted effects for private dependencies - OK, we only use PyPi hosted (and occasionally public GitHub)
    * Verification: In section "Install Dependencies" logs will say "Using cached" in place of "Downloading"
5. Some python tools fail to agree with GitHub runners about console capabilities.
   * Enforce color output
   * Verification: I have seen it work.
6. Removed `cryptography` dependency *again*. 
   * commit 91cb3dc67cb3a711336de8f2bc1f18dfe9ad57bf does not justify including it, if it was indeed needed maybe it should be referenced elsewhere (somewhere not parsed by CI)
   * Verification: Removing it did not noticeably break or slow down CI
7. GitHub actions are versioned. If they improve things, we want that.
   * Since we do not depend on versioned features, we can just bump the major version and automatically use a recent release.
   * Verification: Did not noticeably break or slow down CI