### PR TITLE
Opt into Github issue customization

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,47 @@
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests
+name: Bug Report
+description: Describe a defect or deviation from documentation.
+# could always prepend title, but that leads to odd titles when reporter is unaware
+# title: "[Bug]: "
+labels: ["- Bugs -"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a problem in Gunicorn.
+        As limited time can be spent on triaging, we would appreciate if you
+          * search for existing reports
+          * include relevant information before anyone even asks
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: And what did you expect to happen?
+      placeholder: A python traceback? An HTTP error returned?
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: gunicorn version
+    validations:
+      required: true
+  - type: dropdown
+    id: installation-method
+    attributes:
+      label: Installation Method
+      description: How did you install gunicorn?
+      options:
+        - pip (PyPI)
+        - apt (Debian/Ubuntu)
+        - Development version from GitHub
+        - I do not know how to tell.
+        - Something else
+      default: 0
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Python version
+      description: "If PyPy: please be specific!"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests
+
+blank_issues_enabled: true
+
+# hack: make GitHub hide the "no template" button, re-add as custom URL
+#  idea stolen from https://github.com/pypa/pip
+#blank_issues_enabled: false
+#contact_links:
+#  - name: "(maintainers only) let me file a report without template"
+#    url: "https://github.com/benoitc/gunicorn/issues/new"
+#    about: "Only maintainers can do this."

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,31 @@
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests
+name: Feature Request
+description: Request a new feature or modified default behaviour
+# could always prepend title, but that leads to odd titles when reporter is unaware
+# title: "[FR]: "
+# title: "[RFF]: "
+# need to cleanup existing labels before adding this
+# labels: ["- Features -"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest improvements for Gunicorn.
+        As limited time can be spent on triaging, we would appreciate if you
+          * look for existing requests that may match yours
+          * link references, if you are asking about internet standards
+          * include in your considerations about future maintenance
+  - type: textarea
+    id: what-problem
+    attributes:
+      label: What problem would like like to see solved
+      description: How is what you want to do not currently easily achieved with gunicorn?
+      placeholder: Currently returning baz is limited to one foo.
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: How would you like to see the problem solved
+      description: Please be specific. Explicitly mention what existing functionality that might be impacted.
+      placeholder: I would modify the X component to accept Y also for in the Z case. The B case for Y will remain untouched. The A case will stop working, but that could have never worked due to C anyway.

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,5 +1,12 @@
 name: tox
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - ".github/ISSUE_TEMPLATE/**"
+  pull_request:
+    paths-ignore:
+      - ".github/ISSUE_TEMPLATE/**"
+
 permissions:
   contents: read # to fetch code (actions/checkout)
 env:


### PR DESCRIPTION
Goal: Gracefully offload some work to reporter for as long as incoming reports exceed triage capacity.

**Current**: [New issue](https://github.com/benoitc/gunicorn/issues/new/choose) redirects directly to the [blank form](https://github.com/benoitc/gunicorn/issues/new )
**Suggested Change**: Clicking the "New issue" button offers choice
  * one of two predefined forms with guidance what to include in such a report
  * the (entirely optional) link to the blank form
  * and possibly also a 4th option for https://github.com/benoitc/gunicorn/security - pending #3106

**Alternative considered**: Close more issues #wontfix or #incomplete (often misunderstood as being unfriendly)

Reference: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests