### PR TITLE
Typo and email address in Security.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 **Please note that public Github issues are open for everyone to see!**
 
-If you believe you are found a problem in Gunicorn software, examples or documentation, we encourage you to send your report privately via email, or via Github using the *Report a vulnerability* button in the [Security](https://github.com/benoitc/gunicorn/security) section.
+If you believe you are found a problem in Gunicorn software, examples or documentation, we encourage you to send your report privately via [email](mailto:security@gunicorn.org?subject=Security%20issue%20in%20Gunicorn), or via Github using the *Report a vulnerability* button in the [Security](https://github.com/benoitc/gunicorn/security) section.
 
 ## Supported Releases
 
@@ -19,4 +19,4 @@ At this time, **only the latest release** receives any security attention whatso
 
 ## Python Versions
 
-Gunicorn runs on Python 3.7+, we *highly recommend* the latest release of a [supported series](https://devguide.python.org/version/) and will not prioritize issues exclusively affecting in EoL environments.
+Gunicorn runs on Python 3.7+, we *highly recommend* the latest release of a [supported series](https://devguide.python.org/versions/) and will not prioritize issues exclusively affecting in EoL environments.


### PR DESCRIPTION
Typo was introduces by myself, sorry.
Mailbox **not verified**, merely duplicated from /docs/source/community.rst

* see #3122