### PR TITLE
CI: add CPython 3.12 and PyPy3.10, stop promising untested versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,7 +15,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest] # All OSes pass except Windows because tests need Unix-only fcntl, grp, pwd, etc.
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8" ]
+        python-version:
+         # CPython <= 3.7 is EoL since 2923-06-27
+         - "3.7"
+         - "3.8"
+         - "3.9"
+         - "3.10"
+         - "3.11"
+         - "3.12"
+         # PyPy <= 3.8 is EoL since 2023-06-16
+         - "pypy-3.8"
     steps:
       - uses: actions/checkout@v4
       - name: Using Python ${{ matrix.python-version }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest] # All OSes pass except Windows because tests need Unix-only fcntl, grp, pwd, etc.
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.8" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8" ]
     steps:
       - uses: actions/checkout@v4
       - name: Using Python ${{ matrix.python-version }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest] # All OSes pass except Windows because tests need Unix-only fcntl, grp, pwd, etc.
         python-version:
-         # CPython <= 3.7 is EoL since 2923-06-27
+         # CPython <= 3.7 is EoL since 2023-06-27
          - "3.7"
          - "3.8"
          - "3.9"
@@ -24,7 +24,8 @@ jobs:
          - "3.11"
          - "3.12"
          # PyPy <= 3.8 is EoL since 2023-06-16
-         - "pypy-3.8"
+         - "pypy-3.9"
+         - "pypy-3.10"
     steps:
       - uses: actions/checkout@v4
       - name: Using Python ${{ matrix.python-version }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,7 @@ jobs:
   tox:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -8,6 +8,8 @@ env:
 jobs:
   tox:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes
+    timeout-minutes: 10
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ The documentation is hosted at https://docs.gunicorn.org.
 Installation
 ------------
 
-Gunicorn requires **Python 3.x >= 3.5**.
+Gunicorn requires **Python 3.x >= 3.7**.
 
 Install from PyPI::
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,12 @@ environment:
     #  PYTHON: "C:\\Python38-x64"
     #- TOXENV: py39
     #  PYTHON: "C:\\Python39-x64"
+    #- TOXENV: py310
+    #  PYTHON: "C:\\Python310-x64"
+    #- TOXENV: py311
+    #  PYTHON: "C:\\Python311-x64"
+    #- TOXENV: py312
+    #  PYTHON: "C:\\Python312-x64"
 matrix:
   allow_failures:
     - TOXENV: py35

--- a/docs/source/2023-news.rst
+++ b/docs/source/2023-news.rst
@@ -10,9 +10,11 @@ Changelog - 2023
 - on HTTP versions < 1.1 support for chunked transfer is refused (only used in exploits)
 - requests conflicting configured or passed SCRIPT_NAME now produce a verbose error
 - Trailer fields are no longer inspected for headers indicating secure scheme
+- support Python 3.12
 
 ** Breaking changes **
 
+- minimum version is Python 3.7
 - the limitations on valid characters in the HTTP method have been bounded to Internet Standards
 - requests specifying unsupported transfer coding (order) are refused by default (rare)
 - HTTP methods are no longer casefolded by default (IANA method registry contains none affacted)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ Features
 * Simple Python configuration
 * Multiple worker configurations
 * Various server hooks for extensibility
-* Compatible with Python 3.x >= 3.5
+* Compatible with Python 3.x >= 3.7
 
 
 Contents

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -4,7 +4,7 @@ Installation
 
 .. highlight:: bash
 
-:Requirements: **Python 3.x >= 3.5**
+:Requirements: **Python 3.x >= 3.7**
 
 To install the latest released version of Gunicorn::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = ["setuptools>=61.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
+# see https://packaging.python.org/en/latest/specifications/pyproject-toml/
 name = "gunicorn"
 authors = [{name = "Benoit Chesneau", email = "benoitc@gunicorn.org"}]
 license = {text = "MIT"}
@@ -46,6 +47,7 @@ Homepage = "https://gunicorn.org"
 Documentation = "https://docs.gunicorn.org"
 "Issue tracker" = "https://github.com/benoitc/gunicorn/issues"
 "Source code" = "https://github.com/benoitc/gunicorn"
+Changelog = "https://docs.gunicorn.org/en/stable/news.html"
 
 [project.optional-dependencies]
 gevent = ["gevent>=1.4.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,6 @@ classifiers = [
     "Operating System :: POSIX",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -35,7 +33,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: WSGI :: Server",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
-requires-python = ">=3.5"
+requires-python = ">=3.7"
 dependencies = [
     'importlib_metadata; python_version<"3.8"',
     "packaging",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 gevent
 eventlet
 coverage
-pytest
+pytest>=7.2.0
 pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,0 @@
-[tool:pytest]
-norecursedirs = examples lib local src
-testpaths = tests/
-addopts = --assert=plain --cov=gunicorn --cov-report=xml

--- a/tests/workers/test_geventlet.py
+++ b/tests/workers/test_geventlet.py
@@ -3,5 +3,15 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
+import pytest
+import sys
+
 def test_import():
+
+    try:
+        import eventlet
+    except AttributeError:
+        if (3,13) > sys.version_info >= (3, 12):
+            pytest.skip("Ignoring eventlet failures on Python 3.12")
+        raise
     __import__('gunicorn.workers.geventlet')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311,py3}, lint, docs-lint, pycodestyle, run-entrypoint, run-module
+envlist = py{37,38,39,310,311,312,py3}, lint, docs-lint, pycodestyle, run-entrypoint, run-module
 skipsdist = false
 ; Can't set skipsdist and use_develop in tox v4 to true due to https://github.com/tox-dev/tox/issues/2730
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,11 @@
 [tox]
-envlist = py{37,38,39,310,311,312,py3}, lint, docs-lint, pycodestyle, run-entrypoint, run-module
+envlist =
+  py{37,38,39,310,311,312,py3},
+  lint,
+  docs-lint,
+  pycodestyle,
+  run-entrypoint,
+  run-module,
 skipsdist = false
 ; Can't set skipsdist and use_develop in tox v4 to true due to https://github.com/tox-dev/tox/issues/2730
 


### PR DESCRIPTION
Resubmitted smaller changeset. Intend to fix the remainder of #3110 later.
* pytest+mac+PyPy3.9 sometimes just hangs, so this one adds an overall timeout to cancel those test runs, deferring the decision of dropping PyPy3.9 early or figuring out why.
* Linting remains broken.. which is okay, this patch does not include any bump in the CPython 3.10 used for CI linting.

Issues:
* Fixes: https://github.com/benoitc/gunicorn/issues/3045
* Closes: https://github.com/benoitc/gunicorn/issues/3046

Merge order:
* rebased #3083 and #3085 are prepended, and are not needed after merging this one
* suggest merging #3108 *before* this one
* suggest merging #2836 *after* this one