### PR TITLE
partial revert of #2918 due to concurrency issues: Deadlock

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -83,6 +83,7 @@ Jakub Paweł Głazik <zytek@nuxi.pl>
 Jan-Philip Gehrcke <jgehrcke@googlemail.com>
 Jannis Leidel <jannis@leidel.info>
 Jason Madden <jason@nextthought.com>
+Javier Tejero Jurado <javier.tejero@travelperk.com>
 jean-philippe serafin <serafinjp@gmail.com>
 Jeremy Volkman <jeremy@jvolkman.com>
 Jeryn Mathew <jerynmathew@gmail.com>

--- a/examples/standalone_app_gthread.py
+++ b/examples/standalone_app_gthread.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# An example of a standalone application using the internal API of Gunicorn.
+#
+#   $ python standalone_app_gthread.py
+#
+# Stress test to ensure there are no deadlocks (using apache bench tool)
+#   $ ab -n1000 -c100 http://0.0.0.0:8080/
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+import gunicorn.app.base
+
+
+def handler_app(environ, start_response):
+    response_body = b'Works fine'
+    status = '200 OK'
+
+    response_headers = [
+        ('Content-Type', 'text/plain'),
+    ]
+
+    start_response(status, response_headers)
+
+    return [response_body]
+
+
+class StandaloneApplicationGthread(gunicorn.app.base.BaseApplication):
+
+    def __init__(self, app, options=None):
+        self.options = options or {}
+        self.application = app
+        super().__init__()
+
+    def load_config(self):
+        config = {key: value for key, value in self.options.items()
+                  if key in self.cfg.settings and value is not None}
+        for key, value in config.items():
+            self.cfg.set(key.lower(), value)
+
+    def load(self):
+        return self.application
+
+
+if __name__ == '__main__':
+    options = {
+        'bind': '%s:%s' % ('127.0.0.1', '8080'),
+        'workers': 1,
+        'threads': 3,
+        'worker_connections': 4,
+    }
+    StandaloneApplicationGthread(handler_app, options).run()

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -122,12 +122,9 @@ class ThreadWorker(base.Worker):
             sock, client = listener.accept()
             # initialize the connection object
             conn = TConn(self.cfg, sock, client, server)
-
             self.nr_conns += 1
-            # wait until socket is readable
-            with self._lock:
-                self.poller.register(conn.sock, selectors.EVENT_READ,
-                                     partial(self.on_client_socket_readable, conn))
+            # enqueue the job
+            self.enqueue_req(conn)
         except EnvironmentError as e:
             if e.errno not in (errno.EAGAIN, errno.ECONNABORTED,
                                errno.EWOULDBLOCK):


### PR DESCRIPTION
when opening many sockets the worker gets frozen consuming 100% cpu

to reproduce:

```
cd examples
python standalone_app_gthread.py
```

and then using Apache Bench tool:
```
ab -n1000 -c100 http://0.0.0.0:8080/
```

proposed solution: Partial revert of #2918

Fixes #3146
