### PR TITLE
alias CLD to CHLD in signal handlers

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -81,6 +81,7 @@ Igor Petrov <igor.s.petrov@gmail.com>
 INADA Naoki <methane@users.noreply.github.com>
 Jakub Paweł Głazik <zytek@nuxi.pl>
 Jan-Philip Gehrcke <jgehrcke@googlemail.com>
+Jason Jones <jcjones@gmail.com>
 Jannis Leidel <jannis@leidel.info>
 Jason Madden <jason@nextthought.com>
 jean-philippe serafin <serafinjp@gmail.com>

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -242,6 +242,8 @@ class Arbiter(object):
         self.reap_workers()
         self.wakeup()
 
+    handle_cld = handle_chld  # chld aliased as cld in some systems
+
     def handle_hup(self):
         """\
         HUP handling.


### PR DESCRIPTION
![image](https://github.com/benoitc/gunicorn/assets/6596226/a32d7fcd-a8f3-4bb8-b147-c953c6095664)

some systems have 17 mapped to both CHLD and CLD, this prevents a CHLD signal from not being handled in this case

I observed on our systems this issue prevented the arbiter from recognizing a worker getting killed and did not restart it.