### PR TITLE
chore: Add clarity to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ At this time, **only the latest release** receives any security attention whatso
 
 | Version | Status          |
 | ------- | ------------------ |
-| latest release  | :white_check_mark: |
-| 21.2.0  | :x: |
+| master  | :white_check_mark: |
+| 21.2.0  | :white_check_mark: |
 | 20.0.0  | :x: |
 | < 20.0  | :x: |
 


### PR DESCRIPTION
The security policy currently contains a contradiction where it says that the latest release is the only version supported, but also notes that v21.2.0 is not supported. However, according to the repo, [v21.2.0](https://github.com/benoitc/gunicorn/releases/tag/21.2.0) is the latest release.

<img width="860" alt="image" src="https://github.com/benoitc/gunicorn/assets/1795659/6d3db782-cf8e-4ce3-a6c4-abf6b3bf9e42">

This updates the policy to make it clear that v21.2.0 is currently eligible for security reports as the latest version and also explicitly mentions master as well.

