### PR TITLE
fix(deps): exclude eventlet 0.36.0 to avoid WebSocket bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ Changelog = "https://docs.gunicorn.org/en/stable/news.html"
 
 [project.optional-dependencies]
 gevent = ["gevent>=1.4.0"]
-eventlet = ["eventlet>=0.24.1"]
+eventlet = ["eventlet>=0.24.1,!=0.36.0"]
 tornado = ["tornado>=0.2"]
 gthread = []
 setproctitle = ["setproctitle"]


### PR DESCRIPTION
Eventlet 0.36.0's WebSocket implementation has a bug that prevents it from running under a Gunicorn worker (as is done by Flask-SocketIO and possibly other things): https://github.com/eventlet/eventlet/issues/946

Probably this will be fixed in the next Eventlet release but Gunicorn should exclude 0.36.0 to avoid nasty surprises downstream!