### PR TITLE
logging: swap error/debug severity on socket creation failure

### DIFF
--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -188,10 +188,10 @@ def create_sockets(conf, log, fds=None):
                     log.error("Connection in use: %s", str(addr))
                 if e.args[0] == errno.EADDRNOTAVAIL:
                     log.error("Invalid address: %s", str(addr))
+                msg = "connection to {addr} failed: {error}"
+                log.error(msg.format(addr=str(addr), error=str(e)))
                 if i < 5:
-                    msg = "connection to {addr} failed: {error}"
-                    log.debug(msg.format(addr=str(addr), error=str(e)))
-                    log.error("Retrying in 1 second.")
+                    log.debug("Retrying in 1 second.")
                     time.sleep(1)
             else:
                 break


### PR DESCRIPTION
* The error-severity message should [say what went wrong](https://knowyourmeme.com/memes/oopsie-woopsie
).
  * It must not be not be omitted on the 5th error.
* The debug-severity message may add the non-news that absolutely fantastically nothing will happen in the next second.
  * This one must be omitted as we are not planning to go to sleep() again.

This patch does not depend on https://github.com/benoitc/gunicorn/pull/3127 - I just noticed it in that context.