### PR TITLE
CI: revert macos-14 runners, migrate to tox v4-exclusive settings, add Python 3.13

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,7 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest] # All OSes pass except Windows because tests need Unix-only fcntl, grp, pwd, etc.
+        os:
+         - ubuntu-latest
+         # not defaulting to macos-latest: Python <= 3.9 was missing from macos-14 @ arm64
+         - macos-13
+         # Not testing Windows, because tests need Unix-only fcntl, grp, pwd, etc.
         python-version:
          # CPython <= 3.7 is EoL since 2023-06-27
          - "3.7"
@@ -26,6 +30,11 @@ jobs:
          # PyPy <= 3.8 is EoL since 2023-06-16
          - "pypy-3.9"
          - "pypy-3.10"
+        include:
+         # Note: potentially "universal2" release
+         # https://github.com/actions/runner-images/issues/9741
+         - os: macos-latest
+           python-version: "3.12"
     steps:
       - uses: actions/checkout@v4
       - name: Using Python ${{ matrix.python-version }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        unsupported: [false]
         os:
          - ubuntu-latest
          # not defaulting to macos-latest: Python <= 3.9 was missing from macos-14 @ arm64
@@ -35,6 +36,14 @@ jobs:
          # https://github.com/actions/runner-images/issues/9741
          - os: macos-latest
            python-version: "3.12"
+           unsupported: false
+         # will run these without showing red CI results should they fail
+         - os: macos-latest
+           python-version: "3.13"
+           unsupported: true
+         - os: ubuntu-latest
+           python-version: "3.13"
+           unsupported: true
     steps:
       - uses: actions/checkout@v4
       - name: Using Python ${{ matrix.python-version }}
@@ -44,10 +53,14 @@ jobs:
           cache: pip
           cache-dependency-path: requirements_test.txt
           check-latest: true
+          allow-prereleases: ${{ matrix.unsupported }}
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install tox
       - run: tox -e run-module
+        continue-on-error: ${{ matrix.unsupported }}
       - run: tox -e run-entrypoint
+        continue-on-error: ${{ matrix.unsupported }}
       - run: tox -e py
+        continue-on-error: ${{ matrix.unsupported }}

--- a/tox.ini
+++ b/tox.ini
@@ -6,24 +6,27 @@ envlist =
   pycodestyle,
   run-entrypoint,
   run-module,
-skipsdist = false
-; Can't set skipsdist and use_develop in tox v4 to true due to https://github.com/tox-dev/tox/issues/2730
 
 [testenv]
-use_develop = true
+package = editable
 commands = pytest --cov=gunicorn {posargs}
 deps =
   -rrequirements_test.txt
 
 [testenv:run-entrypoint]
+package = wheel
+deps =
 # entry point: console script (provided by setuptools from pyproject.toml)
 commands = python -c 'import subprocess; cmd_out = subprocess.check_output(["gunicorn", "--version"])[:79].decode("utf-8", errors="replace"); print(cmd_out); assert cmd_out.startswith("gunicorn ")'
 
 [testenv:run-module]
+package = wheel
+deps =
 # runpy (provided by module.__main__)
 commands = python -c 'import sys,subprocess; cmd_out = subprocess.check_output([sys.executable, "-m", "gunicorn", "--version"])[:79].decode("utf-8", errors="replace"); print(cmd_out); assert cmd_out.startswith("gunicorn ")'
 
 [testenv:lint]
+no_package = true
 commands =
   pylint -j0 \
     --max-line-length=120 \
@@ -44,6 +47,7 @@ deps =
   pylint==2.17.4
 
 [testenv:docs-lint]
+no_package = true
 allowlist_externals =
   rst-lint
   bash
@@ -56,6 +60,7 @@ commands =
   bash -c "(set -o pipefail; rst-lint --encoding utf-8 docs/source/*.rst | grep -v 'Unknown interpreted text role\|Unknown directive type'); test $? == 1"
 
 [testenv:pycodestyle]
+no_package = true
 commands =
   pycodestyle gunicorn
 deps =


### PR DESCRIPTION
1. A few other PRs have degraded CI results because Github does not provide Python 3.7 on the default macos-latest runners.
   * Suggestion: just drop back to macos-13, an try the macos-latest image just for a single known-good version.
   * Considered alternative: keep defaults and special case the other way around: not great while the macos-14 images also have unrelated issues.

2. The tox.ini contained supersedes settings and a reference to unpleasant behaviour in a scenario we may entirely avoid by using the `package` / `no_package` flags instead of `skipsdist` and `usedevelop`.
   * Suggestion: Just assert we are using tox v4 and let tox prepare something more like what we actually need for each tests

3. The upcoming Python 3.13 version comes with some interesting changes (see https://github.com/benoitc/gunicorn/issues/3205) which warrant some expansion in the area of automatic tests
   * Suggestion: Start by adding it to the test matrix, but suppress its (red) return status for now
   * Will by itself not do much as long as tests are always tried with *all* dependencies, and there is no 3.13 greenlet yet: https://github.com/python-greenlet/greenlet/issues/392

