### PR TITLE
CI: verify docs are up to date

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,13 +7,18 @@ env:
   FORCE_COLOR: 1
 jobs:
   lint:
-    name: tox-${{ matrix.toxenv }}
+    name: ${{ matrix.python-version }} / tox-${{ matrix.toxenv || '(other)' }}
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         toxenv: [lint, docs-lint, pycodestyle]
         python-version: [ "3.10" ]
+        include:
+          # for actions that want git env, not tox env
+          - toxenv: null
+            python-version: "3.10"
     steps:
       - uses: actions/checkout@v4
       - name: Using Python ${{ matrix.python-version }}
@@ -21,8 +26,26 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-      - name: Install Dependencies
+      - name: Install Dependencies (tox)
+        if: ${{ matrix.toxenv }}
         run: |
           python -m pip install --upgrade pip
           python -m pip install tox
       - run: tox -e ${{ matrix.toxenv }}
+        if: ${{ matrix.toxenv }}
+      - name: Install Dependencies (non-toxic)
+        if: ${{ ! matrix.toxenv }}
+        run: |
+          python -m pip install sphinx
+      - name: "Update docs"
+        if: ${{ ! matrix.toxenv }}
+        run: |
+          # this will update docs/source/settings.rst - but will not create html output
+          (cd docs && sphinx-build -b "dummy" -d _build/doctrees source "_build/dummy")
+          if unclean=$(git status --untracked-files=no --porcelain) && [ -z "$unclean" ]; then
+            echo "no uncommitted changes in working tree (as it should be)"
+          else
+            echo "did you forget to run `make -C docs html`?"
+            echo "$unclean"
+            exit 2
+          fi

--- a/docs/source/2023-news.rst
+++ b/docs/source/2023-news.rst
@@ -11,6 +11,11 @@ Changelog - 2023
 
 This is fixing the bad file description error.
 
+21.1.0 - 2023-07-18
+===================
+
+- fix thread worker: fix socket removal from the queue
+
 21.0.1 - 2023-07-17
 ===================
 

--- a/docs/source/news.rst
+++ b/docs/source/news.rst
@@ -2,6 +2,24 @@
 Changelog
 =========
 
+23.0.0 - unreleased
+===================
+
+* minor docs fixes (:pr:`3217`, :pr:`3089`, :pr:`3167`)
+* worker_class parameter accepts a class (:pr:`3079`)
+* fix deadlock if request terminated during chunked parsing (:pr:`2688`)
+* permit receiving Transfer-Encodings: compress, deflate, gzip (:pr:`3261`)
+* permit Transfer-Encoding headers specifying multiple encodings. note: no parameters, still (:pr:`3261`)
+* sdist generation now explicitly excludes sphinx build folder (:pr:`3257`)
+* decode bytes-typed status (as can be passed by gevent) as utf-8 instead of raising `TypeError` (:pr:`2336`)
+* raise correct Exception when encounting invalid chunked requests (:pr:`3258`)
+
+** Breaking changes **
+* refuse requests where the uri field is empty (:pr:`3255`)
+* refuse requests with invalid CR/LR/NUL in heade field values (:pr:`3253`)
+* remove temporary `--tolerate-dangerous-framing` switch from 22.0 (:pr:`3260`)
+* If any of the breaking changes affect you, be aware that now refused requests can post a security problem, especially so in setups involving request pipe-lining and/or proxies.
+
 22.0.0 - 2024-04-17
 ===================
 
@@ -33,49 +51,12 @@ Changelog
 
 - fix CVE-2024-1135
 
-21.2.0 - 2023-07-19
-===================
-
-- fix thread worker: revert change considering connection as idle . 
-
-*** NOTE ***
-
-This is fixing the bad file description error.
-
-21.1.0 - 2023-07-18
-===================
-
-- fix thread worker: fix socket removal from the queue
-
-21.0.1 - 2023-07-17
-===================
-
-- fix documentation build
-
-21.0.0 - 2023-07-17
-===================
-
-- support python 3.11
-- fix gevent and eventlet workers
-- fix threads support (gththread): improve performance and unblock requests
-- SSL: now use SSLContext object
-- HTTP parser: miscellaneous fixes
-- remove unnecessary setuid calls
-- fix testing
-- improve logging
-- miscellaneous fixes to core engine
-
-*** RELEASE NOTE ***
-
-We made this release major to start our new release cycle. More info will be provided on our discussion forum.
-
 History
 =======
 
 .. toctree::
    :titlesonly:
 
-   2024-news
    2023-news
    2021-news
    2020-news

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -210,7 +210,7 @@ H            protocol
 s            status
 B            response length
 b            response length or ``'-'`` (CLF format)
-f            referer
+f            referrer (note: header is ``referer``)
 a            user agent
 T            request time in seconds
 M            request time in milliseconds
@@ -314,7 +314,7 @@ file format.
 
 The log config dictionary to use, using the standard Python
 logging module's dictionary configuration format. This option
-takes precedence over the :ref:`logconfig` and :ref:`logConfigJson` options,
+takes precedence over the :ref:`logconfig` and :ref:`logconfig-json` options,
 which uses the older file configuration format and JSON
 respectively.
 
@@ -569,7 +569,7 @@ Whether client certificate is required (see stdlib ssl module's)
 ===========  ===========================
 --cert-reqs      Description
 ===========  ===========================
-`0`          no client veirifcation
+`0`          no client verification
 `1`          ssl.CERT_OPTIONAL
 `2`          ssl.CERT_REQUIRED
 ===========  ===========================
@@ -1503,32 +1503,6 @@ instead be solved by specifically renaming or rewriting only the intended header
 on a proxy in front of Gunicorn.
 
 .. versionadded:: 22.0.0
-
-.. _tolerate-dangerous-framing:
-
-``tolerate_dangerous_framing``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-**Command line:** ``--tolerate-dangerous-framing``
-
-**Default:** ``False``
-
-Process requests with both Transfer-Encoding and Content-Length
-
-This is known to induce vulnerabilities, but not strictly forbidden by RFC9112.
-
-In any case, the connection is closed after the malformed request,
-as it is unclear if and at which boundary additional requests start.
-
-Use with care and only if necessary.
-Temporary; will be changed or removed in a future version.
-
-.. versionadded:: 22.0.0
-.. versionchanged: 22.1.0
-   The newly added rejection of invalid and dangerous characters CR, LF and NUL in
-   header field values is also controlled with this setting. rfc9110 permits both
-   rejecting and SP-replacing. With this option set, Gunicorn passes the field value
-   unchanged. With this option unset, Gunicorn rejects the request.
 
 Server Socket
 -------------

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1395,7 +1395,7 @@ class AccessLogFormat(Setting):
         s            status
         B            response length
         b            response length or ``'-'`` (CLF format)
-        f            referer
+        f            referrer (note: header is ``referer``)
         a            user agent
         T            request time in seconds
         M            request time in milliseconds
@@ -2154,7 +2154,7 @@ class CertReqs(Setting):
     ===========  ===========================
     --cert-reqs      Description
     ===========  ===========================
-    `0`          no client veirifcation
+    `0`          no client verification
     `1`          ssl.CERT_OPTIONAL
     `2`          ssl.CERT_REQUIRED
     ===========  ===========================

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1506,7 +1506,7 @@ class LogConfigDict(Setting):
     desc = """\
     The log config dictionary to use, using the standard Python
     logging module's dictionary configuration format. This option
-    takes precedence over the :ref:`logconfig` and :ref:`logConfigJson` options,
+    takes precedence over the :ref:`logconfig` and :ref:`logconfig-json` options,
     which uses the older file configuration format and JSON
     respectively.
 


### PR DESCRIPTION
New CI task: complain if `docs/source/settings.rst` has changed after invoking `sphinx-build`, indicating someone (me) has forgotten to run `make -C docs html`

* Its not a tox env because I found it easier to ask git whether the file has changed.
* It will also fail if sphinx-build fails. This is good. We should know when that happens (note however, that this does not yet fail on a mistyped reference. that is, so far, just a warning.)

Proof that this works can be found in the earlier CI run of this very PR:
 * https://github.com/benoitc/gunicorn/actions/runs/9185099713/job/25258482749
 * it fails - which is to be expected, because only a later commit fixes includes the updated rst file.

Assumption:
* no need to duplicate between `news.rst` / `2023-news.rst` - just move the content to referenced-in-toc subfiles when the main news file gets large.