### PR TITLE
3227: shutdown socket when worker is not alive

### DIFF
--- a/gunicorn/http/parser.py
+++ b/gunicorn/http/parser.py
@@ -5,14 +5,16 @@
 
 from gunicorn.http.message import Request
 from gunicorn.http.unreader import SocketUnreader, IterUnreader
+from gunicorn.util import Status
 
 
 class Parser(object):
 
     mesg_class = None
 
-    def __init__(self, cfg, source, source_addr):
+    def __init__(self, cfg, source, source_addr, status=None):
         self.cfg = cfg
+        self.status = status if status else Status()
         if hasattr(source, "recv"):
             self.unreader = SocketUnreader(source)
         else:
@@ -39,7 +41,7 @@ class Parser(object):
 
         # Parse the next request
         self.req_count += 1
-        self.mesg = self.mesg_class(self.cfg, self.unreader, self.source_addr, self.req_count)
+        self.mesg = self.mesg_class(self.cfg, self.unreader, self.source_addr, self.req_count, status=self.status)
         if not self.mesg:
             raise StopIteration()
         return self.mesg

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -652,3 +652,20 @@ def bytes_to_str(b):
 
 def unquote_to_wsgi_str(string):
     return urllib.parse.unquote_to_bytes(string).decode('latin-1')
+
+
+class Status:
+    """
+    This class's object holds information about the worker's status.
+    The status is represented by an object instead of a simple type to enable
+    sharing between different parts of the application.
+    """
+
+    def __init__(self, is_alive=True):
+        self._is_alive = is_alive
+
+    def is_alive(self):
+        return self._is_alive
+
+    def set_alive(self, is_alive):
+        self._is_alive = is_alive

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -24,6 +24,7 @@ from gunicorn.http.errors import (
 from gunicorn.http.wsgi import Response, default_environ
 from gunicorn.reloader import reloader_engines
 from gunicorn.workers.workertmp import WorkerTmp
+from gunicorn.util import Status
 
 
 class Worker(object):
@@ -59,12 +60,21 @@ class Worker(object):
         else:
             self.max_requests = sys.maxsize
 
+        self.status = Status()
         self.alive = True
         self.log = log
         self.tmp = WorkerTmp(cfg)
 
     def __str__(self):
         return "<Worker %s>" % self.pid
+
+    @property
+    def alive(self):
+        return self.status.is_alive()
+
+    @alive.setter
+    def alive(self, value):
+        self.status.set_alive(value)
 
     def notify(self):
         """\

--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -33,7 +33,7 @@ class AsyncWorker(base.Worker):
     def handle(self, listener, client, addr):
         req = None
         try:
-            parser = http.RequestParser(self.cfg, client, addr)
+            parser = http.RequestParser(self.cfg, client, addr, status=self.status)
             try:
                 listener_name = listener.getsockname()
                 if not self.cfg.keepalive:


### PR DESCRIPTION
More info: https://github.com/benoitc/gunicorn/issues/3227

<s>Simply close the waiting reads (pending due to keepalive) and allow the worker to restart without having to wait for the graceful period.