### PR TITLE
Close open resources

### DIFF
--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -32,11 +32,14 @@ class Statsd(Logger):
         else:
             address_family = socket.AF_INET
 
+        self.sock = None
         try:
             self.sock = socket.socket(address_family, socket.SOCK_DGRAM)
             self.sock.connect(cfg.statsd_host)
         except Exception:
-            self.sock = None
+            if self.sock is not None:
+                self.sock.close()
+                self.sock = None
 
         self.dogstatsd_tags = cfg.dogstatsd_tags
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ main = "gunicorn.app.pasterapp:serve"
 norecursedirs = ["examples", "lib", "local", "src"]
 testpaths = ["tests/"]
 addopts = "--assert=plain --cov=gunicorn --cov-report=xml"
+filterwarnings = [
+    "error",
+]
 
 [tool.setuptools]
 zip-safe = false

--- a/tests/t.py
+++ b/tests/t.py
@@ -65,3 +65,6 @@ class FakeSocket(object):
 
     def seek(self, offset, whence=0):
         self.tmp.seek(offset, whence)
+
+    def close(self):
+        self.tmp.close()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -184,11 +184,14 @@ def test_socket_unreader_chunk():
     fake_sock = t.FakeSocket(io.BytesIO(b'Lorem ipsum dolor'))
     sock_unreader = SocketUnreader(fake_sock, max_chunk=5)
 
-    assert sock_unreader.chunk() == b'Lorem'
-    assert sock_unreader.chunk() == b' ipsu'
-    assert sock_unreader.chunk() == b'm dol'
-    assert sock_unreader.chunk() == b'or'
-    assert sock_unreader.chunk() == b''
+    try:
+        assert sock_unreader.chunk() == b'Lorem'
+        assert sock_unreader.chunk() == b' ipsu'
+        assert sock_unreader.chunk() == b'm dol'
+        assert sock_unreader.chunk() == b'or'
+        assert sock_unreader.chunk() == b''
+    finally:
+        fake_sock.close()
 
 
 def test_length_reader_read():


### PR DESCRIPTION
There are several places in the test suite and in the production code where resources are opened but not closed. This results in `ResourceWarning`s while the test suite is running (which Python normally ignores), and is revealed by setting pytest's `filterwarning=errors`.

This PR introduces the following changes:

* Close sockets that are opened _by production code_ but unclosed when an exception is encountered
* Close resources that are opened _by the test suite_
* Configure pytest to escalate warnings to errors

If this is merged, it will help ensure that gunicorn consistently closes resources (files and sockets).