### PR TITLE
refuse empty request-target in HTTP request

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -426,6 +426,17 @@ class Request(Message):
         # URI
         self.uri = bits[1]
 
+        # Python stdlib explicitly tells us it will not perform validation.
+        # https://docs.python.org/3/library/urllib.parse.html#url-parsing-security
+        # There are *four* `request-target` forms in rfc9112, none of them can be empty:
+        # 1. origin-form, which starts with a slash
+        # 2. absolute-form, which starts with a non-empty scheme
+        # 3. authority-form, (for CONNECT) which contains a colon after the host
+        # 4. asterisk-form, which is an asterisk (`\x2A`)
+        # => manually reject one always invalid URI: empty
+        if len(self.uri) == 0:
+            raise InvalidRequestLine(bytes_to_str(line_bytes))
+
         try:
             parts = split_request_uri(self.uri)
         except ValueError:


### PR DESCRIPTION
The shortest origin-form is a single slash, *not* empty. So refuse request lines that have two consecutive spaces where the URI should be. There should be *something* there.

Python [stdlib explicitly tells us](https://docs.python.org/3/library/urllib.parse.html#url-parsing-security ) it will not perform validation - and neither does this patch! This patch merely closes the one trivial hole that is of special interest, as it might confuse setups involving proxies and pipe-lining.

* Fixes: #3235