### PR TITLE
detect incomplete body before reading next request

### DIFF
--- a/gunicorn/http/errors.py
+++ b/gunicorn/http/errors.py
@@ -22,6 +22,11 @@ class NoMoreData(IOError):
         return "No more data after: %r" % self.buf
 
 
+class IncompleteBody(ParseException):
+    def __str__(self):
+        return "Incomplete Request Body"
+
+
 class ConfigurationProblem(ParseException):
     def __init__(self, info):
         self.info = info

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -15,6 +15,7 @@ from ssl import SSLError
 
 from gunicorn import util
 from gunicorn.http.errors import (
+    IncompleteBody,
     ForbiddenProxyRequest, InvalidHeader,
     InvalidHeaderName, InvalidHTTPVersion,
     InvalidProxyLine, InvalidRequestLine,
@@ -233,6 +234,8 @@ class Worker(object):
                 reason = "Request Header Fields Too Large"
                 mesg = "Error parsing headers: '%s'" % str(exc)
                 status_int = 431
+            elif isinstance(exc, IncompleteBody):
+                mesg = "'%s'" % str(exc)
             elif isinstance(exc, InvalidProxyLine):
                 mesg = "'%s'" % str(exc)
             elif isinstance(exc, ForbiddenProxyRequest):

--- a/tests/requests/valid/099.http
+++ b/tests/requests/valid/099.http
@@ -7,7 +7,7 @@ Accept-Encoding: gzip, deflate\r\n
 Cookie: csrftoken=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX; sessionid=YYYYYYYYYYYYYYYYYYYYYYYYYYYY\r\n
 Connection: keep-alive\r\n
 Content-Type: multipart/form-data; boundary=---------------------------320761477111544\r\n
-Content-Length: 17914\r\n
+Content-Length: 8599\r\n
 \r\n
 -----------------------------320761477111544\r\n
 Content-Disposition: form-data; name="csrfmiddlewaretoken"\r\n

--- a/tests/requests/valid/099.py
+++ b/tests/requests/valid/099.py
@@ -11,7 +11,7 @@ request = {
         ("COOKIE", "csrftoken=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX; sessionid=YYYYYYYYYYYYYYYYYYYYYYYYYYYY"),
         ("CONNECTION", "keep-alive"),
         ("CONTENT-TYPE", "multipart/form-data; boundary=---------------------------320761477111544"),
-        ("CONTENT-LENGTH", "17914"),
+        ("CONTENT-LENGTH", "8599"),
     ],
     "body": b"""-----------------------------320761477111544
 Content-Disposition: form-data; name="csrfmiddlewaretoken"


### PR DESCRIPTION
**DO NOT MERGE: ** The attached patch only checks that we have read the entire expected body after processing is done. It merely assist in testing and demonstrating that there is a problem, it does not prevent replying to truncated input yet.

I wonder if there is a way to approach #3234 with just one length check. We have one NoMoreData now, but it appears we want two variants - a) done reading, and b) unable to read more.
