### PR TITLE
exclude generate html files from source tarballs (sdist)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .tox
 __pycache__
 build
+docs/_build
 coverage.xml
 dist
 examples/frameworks/django/testing/testdb.sql

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,4 +10,6 @@ recursive-include examples *
 recursive-include docs *
 recursive-include examples/frameworks *
 recursive-exclude * __pycache__
+recursive-exclude docs/build *
+recursive-exclude docs/_build *
 recursive-exclude * *.py[co]

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,5 +1,7 @@
 # Makefile for Sphinx documentation
 #
+# if you want to compare this file to current sphinx defaults, recreate it:
+# BUILDDIR=build sphinx-quickstart --sep --extensions=gunicorn_ext --templatedir=_templates --makefile --batchfile --no-use-make-mode --master=index
 
 # You can set these variables from the command line.
 PYTHON        = python

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -6,8 +6,8 @@ Requirements
 
 To generate documentation you need to install:
 
- - Python >= 3.4
- - Sphinx (http://sphinx-doc.org/)
+ - Python >= 3.7
+ - Sphinx (https://www.sphinx-doc.org/)
 
 
 Generate html


### PR DESCRIPTION
**source** distributions should probably not contains artifacts from compiling documentation

* drive-by change: sphinx-doc.org does not have working https on the bare 2nd-level domain - link the www homepage
* drive-by change: clarify that the docs/Makefile is *generated*, recreating which could lead to BUILDDIR=_build (extra underscore) - exclude that folder too, just in case
* Fixes: #3109