### PR TITLE
gracefully handle chunked encoding missing size

### DIFF
--- a/gunicorn/http/body.py
+++ b/gunicorn/http/body.py
@@ -91,6 +91,8 @@ class ChunkedReader(object):
             chunk_size = chunk_size.rstrip(b" \t")
         if any(n not in b"0123456789abcdefABCDEF" for n in chunk_size):
             raise InvalidChunkSize(chunk_size)
+        if len(chunk_size) == 0:
+            raise InvalidChunkSize(chunk_size)
         chunk_size = int(chunk_size, 16)
 
         if chunk_size == 0:

--- a/tests/requests/invalid/chunked_12.http
+++ b/tests/requests/invalid/chunked_12.http
@@ -1,0 +1,7 @@
+POST /chunked_no_chunk_size_but_ext HTTP/1.1\r\n
+Transfer-Encoding: chunked\r\n
+\r\n
+ ;foo=bar\r\n
+hello\r\n
+0\r\n
+\r\n

--- a/tests/requests/invalid/chunked_12.py
+++ b/tests/requests/invalid/chunked_12.py
@@ -1,0 +1,2 @@
+from gunicorn.http.errors import InvalidChunkSize
+request = InvalidChunkSize

--- a/tests/requests/invalid/chunked_13.http
+++ b/tests/requests/invalid/chunked_13.http
@@ -1,0 +1,7 @@
+POST /chunked_no_chunk_size HTTP/1.1\r\n
+Transfer-Encoding: chunked\r\n
+\r\n
+\r\n
+hello\r\n
+0\r\n
+\r\n

--- a/tests/requests/invalid/chunked_13.py
+++ b/tests/requests/invalid/chunked_13.py
@@ -1,0 +1,2 @@
+from gunicorn.http.errors import InvalidChunkSize
+request = InvalidChunkSize


### PR DESCRIPTION
Integer conversion from zero-length strings is invalid: `ValueError: invalid literal for int() with base 10: ''`

Treat it the same as invalid characters where size should be.
