### PR TITLE
packaging: include tox.ini in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include README.rst
 include THANKS
 include requirements_dev.txt
 include requirements_test.txt
+include tox.ini
 recursive-include tests *
 recursive-include examples *
 recursive-include docs *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include THANKS
 include requirements_dev.txt
 include requirements_test.txt
 include tox.ini
+include .pylintrc
 recursive-include tests *
 recursive-include examples *
 recursive-include docs *


### PR DESCRIPTION
* Fixes: #3267 (not immediately, the change merely requests inclusion in *future* source distributions)

Argument from authority: See what setuptools does & documents: https://github.com/pypa/setuptools/blob/1d2fd37368fc2381e21cd5466aeb222fc11db2db/MANIFEST.in

Confirmation:
```shell
$ python -m build
$ tar -tf dist/gunicorn-*.tar.gz | grep tox
gunicorn-23.0.0/tox.ini
```
note: if ever using setuptools-scm: .gitattributes / MANIFEST.in precedence could undo this change