### PR TITLE
config: permit `--reload-extra-files`  without `--reload`

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -83,6 +83,10 @@ system polling. Generally, inotify should be preferred if available
 because it consumes less system resources.
 
 .. note::
+   If the application fails to load while this option is used,
+   the (potentially sensitive!) traceback will be shared in
+   the response to subsequent HTTP requests.
+.. note::
    In order to use the inotify reloader, you must have the ``inotify``
    package installed.
 
@@ -114,10 +118,13 @@ Valid engines are:
 
 **Default:** ``[]``
 
-Extends :ref:`reload` option to also watch and reload on additional files
+Alternative or extension to :ref:`reload` option to (also) watch
+and reload on additional files
 (e.g., templates, configurations, specifications, etc.).
 
 .. versionadded:: 19.8
+.. versionchanged:: 23.FIXME
+    Option no longer silently ignored if used without :ref:`reload`.
 
 .. _spew:
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -922,6 +922,10 @@ class Reload(Setting):
         because it consumes less system resources.
 
         .. note::
+           If the application fails to load while this option is used,
+           the (potentially sensitive!) traceback will be shared in
+           the response to subsequent HTTP requests.
+        .. note::
            In order to use the inotify reloader, you must have the ``inotify``
            package installed.
         '''
@@ -956,10 +960,13 @@ class ReloadExtraFiles(Setting):
     validator = validate_list_of_existing_files
     default = []
     desc = """\
-        Extends :ref:`reload` option to also watch and reload on additional files
+        Alternative or extension to :ref:`reload` option to (also) watch
+        and reload on additional files
         (e.g., templates, configurations, specifications, etc.).
 
         .. versionadded:: 19.8
+        .. versionchanged:: 23.FIXME
+            Option no longer silently ignored if used without :ref:`reload`.
         """
 
 

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -119,7 +119,7 @@ class Worker:
         self.init_signals()
 
         # start the reloader
-        if self.cfg.reload:
+        if self.cfg.reload or self.cfg.reload_extra_files:
             def changed(fname):
                 self.log.info("Worker reloading: %s modified", fname)
                 self.alive = False
@@ -130,7 +130,7 @@ class Worker:
 
             reloader_cls = reloader_engines[self.cfg.reload_engine]
             self.reloader = reloader_cls(extra_files=self.cfg.reload_extra_files,
-                                         callback=changed)
+                                         callback=changed, auto_detect=self.cfg.reload)
 
         self.load_wsgi()
         if self.reloader:


### PR DESCRIPTION
Extracted for smaller patch size, this time only uncoupling `--reload-extra-files` from `--reload`

The latter implies `make_fail_app`, which is not always wanted when specifically only requesting the former.

* see #3360 for latter, bigger version of this patch