### PR TITLE
style: argparse inheritance, hide some options from --help

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -1193,11 +1193,7 @@ group id.
 
 Directory to store temporary request data as they are read.
 
-This may disappear in the near future.
-
-This path should be writable by the process permissions set for Gunicorn
-workers. If not specified, Gunicorn will choose a system generated
-temporary directory.
+Unused, and may be removed from a future Gunicorn version.
 
 .. _secure-scheme-headers:
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -1207,7 +1207,7 @@ class Initgroups(BoolSetting):
         """
 
 
-class TmpUploadDir(Setting):
+class TmpUploadDir(Setting, Deprecated):
     name = "tmp_upload_dir"
     section = "Server Mechanics"
     meta = "DIR"
@@ -1216,11 +1216,7 @@ class TmpUploadDir(Setting):
     desc = """\
         Directory to store temporary request data as they are read.
 
-        This may disappear in the near future.
-
-        This path should be writable by the process permissions set for Gunicorn
-        workers. If not specified, Gunicorn will choose a system generated
-        temporary directory.
+        Unused, and may be removed from a future Gunicorn version.
         """
 
 


### PR DESCRIPTION
> We have way too much options (#3266)

Idea: We could hide deprecated ones from `--help`, and possibly move both *unstable* and *deprecated* ones to their own, bottom-most section in the documentation.

Attached patch hacks (style improvements welcome) the config.py-class-to-argparse code so we can subclass while keeping metaclass intact. Then it adds a `Deprecated` class that hides certain settings from `--help`. I tried to avoid additional functional changes.

If this PR moves forward with minor changes, then the following changes are the next steps:
1. change some options *default* value to None and have not specifying them mean "feature not used"
   * `--user/--group` unset should mean *do not do that* - see #3360
2. permit and document some options with existing default to be overridden to some `None`-like value
   * `--config=""` should mean *do not read config* (as in: `--config=/dev/null`) - see #3360
3. options that do not take effect based on environment / other options should be warned about
   * behavior of `--bind fd://3` when `LISTEN_FDS=1` set can be erratic & surprising
4. boolean options should use [argparse.BooleanOptionalAction](https://docs.python.org/3/library/argparse.html#argparse.BooleanOptionalAction) (Python [3.9+](https://github.com/benoitc/gunicorn/pull/3343))
   * paves the way to switch settings default-off to default-on without forcing admins to update their config

* Suggested merge order: *after* any feature/bugfix PRs. merge conflicts more easily solved within this PR.
* fixes: #3349