### PR TITLE
revert: 4023228 ("let's exception not bubble")

### DIFF
--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -29,6 +29,8 @@ from gunicorn.workers.workertmp import WorkerTmp
 
 class Worker:
 
+    WORKAROUND_BASE_EXCEPTIONS = ()  # none
+
     SIGNALS = [getattr(signal, "SIG%s" % x) for x in (
         "ABRT HUP QUIT INT TERM USR1 USR2 WINCH CHLD".split()
     )]

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -264,7 +264,7 @@ class Worker:
             elif hasattr(req, "uri"):
                 self.log.exception("Error handling request %s", req.uri)
             else:
-                self.log.exception("Error handling request (no URI read)")
+                self.log.debug("Error handling request (no URI read)")
             status_int = 500
             reason = "Internal Server Error"
             mesg = ""

--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -96,7 +96,8 @@ class AsyncWorker(base.Worker):
                 else:
                     self.log.debug("Ignoring EPIPE")
         except self.WORKAROUND_BASE_EXCEPTIONS as e:
-            self.log.warning("Catched async exception (compat workaround). If this is not a bug in your app, please file a report.")
+            self.log.warning("Catched async exception (compat workaround). "
+                             "If this is not a bug in your app, please file a report.")
             self.handle_error(req, client, addr, e)
         except Exception as e:
             self.handle_error(req, client, addr, e)

--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -95,6 +95,9 @@ class AsyncWorker(base.Worker):
                     self.log.debug("Ignoring socket not connected")
                 else:
                     self.log.debug("Ignoring EPIPE")
+        except self.WORKAROUND_BASE_EXCEPTIONS as e:
+            self.log.warning("Catched async exception (compat workaround). If this is not a bug in your app, please file a report.")
+            self.handle_error(req, client, addr, e)
         except Exception as e:
             self.handle_error(req, client, addr, e)
         finally:

--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -95,7 +95,7 @@ class AsyncWorker(base.Worker):
                     self.log.debug("Ignoring socket not connected")
                 else:
                     self.log.debug("Ignoring EPIPE")
-        except BaseException as e:
+        except Exception as e:
             self.handle_error(req, client, addr, e)
         finally:
             util.close(client)

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -31,6 +31,8 @@ VERSION = "gevent/%s gunicorn/%s" % (gevent.__version__, gunicorn.__version__)
 
 class GeventWorker(AsyncWorker):
 
+    WORKAROUND_BASE_EXCEPTIONS = (gevent.Timeout, )
+
     server_class = None
     wsgi_handler = None
 

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -109,6 +109,8 @@ class SyncWorker(base.Worker):
                 return
 
     def run(self):
+        assert len(self.WORKAROUND_BASE_EXCEPTIONS) == 0
+
         # if no timeout is given the worker will never wait and will
         # use the CPU for nothing. This minimal timeout prevent it.
         timeout = self.timeout or 0.5

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -160,7 +160,7 @@ class SyncWorker(base.Worker):
                     self.log.debug("Ignoring socket not connected")
                 else:
                     self.log.debug("Ignoring EPIPE")
-        except BaseException as e:
+        except Exception as e:
             self.handle_error(req, client, addr, e)
         finally:
             util.close_graceful(client)


### PR DESCRIPTION
The report in https://github.com/benoitc/gunicorn/issues/2923 may have been not caused by a bug in Gunicorn or gevent in the first place. In any case, going from "this particular exception" to "each and every BaseException" was *way* excessive and is a likely explanation for https://github.com/benoitc/gunicorn/issues/3207

Context:
* https://github.com/benoitc/gunicorn/commit/40232284934c32939c0e4e78caad1987c3773e08#r144628336

Suggested changes:
* revert that patch
* reintroduce a more specific exception catching that mimics what the reverted patch tried to accomplish, while emitting a new warning.

Unfinished, but no longer needed after eventlet support was dropped:
* the SSLError from wrap_socket in the *eventlet* worker (afaict, can only be triggered by the client sending garbage or disconnecting while Gunicorn was overloaded) cannot be dealt with this way due to class inheritance stepping outside the huge try-except block. I have a [currently skipped test to reproduce this](https://github.com/pajod/gunicorn/blob/3370ad6be6ae7bf3be1a340d2fc4cfcbf9243975/tests/test_wrk.py#L346-L347) - the problem is over here: https://github.com/benoitc/gunicorn/blob/903792f152af6a27033d458020923cb2bcb11459/gunicorn/workers/geventlet.py#L153-L156
  * WIP: https://github.com/pajod/gunicorn/commit/f63030411982edf390149c8df5f10b8fdeaf8907
----
* Partially reverts: 40232284934c32939c0e4e78caad1987c3773e08
* Partially reverts: 0b10cbab1d6368fcab2d5a7b6fe359a6cecc81a7
* Fixes: https://github.com/benoitc/gunicorn/issues/3207
* Partially fixes: https://github.com/benoitc/gunicorn/issues/3410