### PR TITLE
Fix request body handling in gthread worker

### DIFF
--- a/gunicorn/http/parser.py
+++ b/gunicorn/http/parser.py
@@ -25,17 +25,17 @@ class Parser:
     def __iter__(self):
         return self
 
-    def __next__(self):
+    def finish(self):
         # Stop if HTTP dictates a stop.
         if self.mesg and self.mesg.should_close():
             raise StopIteration()
-
         # Discard any unread body of the previous message
         if self.mesg:
             data = self.mesg.body.read(8192)
             while data:
                 data = self.mesg.body.read(8192)
 
+    def __next__(self):
         # Parse the next request
         self.req_count += 1
         self.mesg = self.mesg_class(self.cfg, self.unreader, self.source_addr, self.req_count)

--- a/gunicorn/http/parser.py
+++ b/gunicorn/http/parser.py
@@ -25,10 +25,7 @@ class Parser:
     def __iter__(self):
         return self
 
-    def finish(self):
-        # Stop if HTTP dictates a stop.
-        if self.mesg and self.mesg.should_close():
-            raise StopIteration()
+    def finish_body(self):
         # Discard any unread body of the previous message
         if self.mesg:
             data = self.mesg.body.read(8192)
@@ -36,6 +33,11 @@ class Parser:
                 data = self.mesg.body.read(8192)
 
     def __next__(self):
+        # Stop if HTTP dictates a stop.
+        if self.mesg and self.mesg.should_close():
+            raise StopIteration()
+        self.finish_body()
+
         # Parse the next request
         self.req_count += 1
         self.mesg = self.mesg_class(self.cfg, self.unreader, self.source_addr, self.req_count)

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -280,6 +280,7 @@ class ThreadWorker(base.Worker):
             # handle the request
             keepalive = self.handle_request(req, conn)
             if keepalive:
+                conn.parser.finish()
                 return (keepalive, conn)
         except http.errors.NoMoreData as e:
             self.log.debug("Ignored premature client disconnection. %s", e)

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -280,7 +280,7 @@ class ThreadWorker(base.Worker):
             # handle the request
             keepalive = self.handle_request(req, conn)
             if keepalive:
-                conn.parser.finish()
+                conn.parser.finish_body()
                 return (keepalive, conn)
         except http.errors.NoMoreData as e:
             self.log.debug("Ignored premature client disconnection. %s", e)


### PR DESCRIPTION
Fixes #3301.

The problem is that if the request body is not read and the gthread worker finishes handling a request with a large request body, it will see that the socket is still readable and call on_client_socket_readable. However, the readable bytes are just the rest of the request body. The part of the code annotated "Discard any unread body of the previous message" will discard that request body, but gthread will then proceed to subsequently try and read a full HTTP request, which may have not been sent. This change will discard the request body after handling a request, and before on_client_socket_readable can be called so this doesn't happen.

I'm not sure how to make a test for this because it requires multiple connections and doesn't seem to fit in with the rest of gunicorn's test suite.