### PR TITLE
Invoke TConn().init() in gunicorn worker thread.

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -46,6 +46,8 @@ class TConn:
         self.sock.setblocking(False)
 
     def init(self):
+        if self.initialized:
+            return
         self.initialized = True
         self.sock.setblocking(True)
 
@@ -111,7 +113,6 @@ class ThreadWorker(base.Worker):
         fs.add_done_callback(self.finish_request)
 
     def enqueue_req(self, conn):
-        conn.init()
         # submit the connection to a worker
         fs = self.tpool.submit(self.handle, conn)
         self._wrap_future(fs, conn)
@@ -273,6 +274,7 @@ class ThreadWorker(base.Worker):
         keepalive = False
         req = None
         try:
+            conn.init()
             req = next(conn.parser)
             if not req:
                 return (False, conn)


### PR DESCRIPTION
MainThread in gunicorn gthread worker calls TConn().init() function, but when ssl is used that function may raise an ENOTCONN exception. There is very low probability for that, but still it is needed to catch potential socket errors during that call, otherwise whole gunicorn worker with all threads will be crashed.