### PR TITLE
fix: change log level of sigterm signal received from error to warning

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -550,7 +550,7 @@ class Arbiter:
                         # Additional hint for SIGKILL
                         if status == signal.SIGKILL:
                             msg += " Perhaps out of memory?"
-                        self.log.error(msg)
+                        self.log.warning(msg)
 
                     worker = self.WORKERS.pop(wpid, None)
                     if not worker:


### PR DESCRIPTION
Hi,

This PR addresses the issue reported here: https://github.com/benoitc/gunicorn/issues/3050.

I have reverted the log level back to warning, as it was previously. This prevents the log from being sent to stderr and cluttering the monitoring, as it’s not truly an error.

Thansk!