### PR TITLE
perf(gthread): reduce unnecessary polling

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -20,6 +20,7 @@ Andreas Stührk <andy-python@hammerhartes.de>
 Andrew Burdo <zeezooz@gmail.com>
 Andrew Svetlov <andrew.svetlov@gmail.com>
 Anil V <avaitla16@gmail.com>
+Ankush Menat <ankushmenat@gmail.com>
 Antoine Girard <antoine.girard.dev@gmail.com>
 Anton Vlasenko <antares.spica@gmail.com>
 Artur Kruchinin <arturkruchinin@gmail.com>

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -1793,3 +1793,6 @@ set this to a higher value.
    ``sync`` worker does not support persistent connections and will
    ignore this option.
 
+.. note::
+   When the worker becomes idle, some connections may remain open for
+   up to twice the specified keepalive value.

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -206,8 +206,13 @@ class ThreadWorker(base.Worker):
 
             # can we accept more connections?
             if self.nr_conns < self.worker_connections:
+                # Block for new events until worker times out or keepalive timeout.
+                select_timeout = self.timeout or 1.0
+                if self._keep:
+                    select_timeout = min(select_timeout, self.cfg.keepalive)
+
                 # wait for an event
-                events = self.poller.select(self.timeout)
+                events = self.poller.select(select_timeout)
                 for key, _ in events:
                     callback = key.data
                     callback(key.fileobj)

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -207,7 +207,7 @@ class ThreadWorker(base.Worker):
             # can we accept more connections?
             if self.nr_conns < self.worker_connections:
                 # wait for an event
-                events = self.poller.select(1.0)
+                events = self.poller.select(self.timeout)
                 for key, _ in events:
                     callback = key.data
                     callback(key.fileobj)


### PR DESCRIPTION
gthread calls `epoll_wait` (and 2 other syscalls) every second because it
specifies timeout to be 1 second.

```
λ sudo strace -p `pgrep -f "gunicorn: worker" | head -n1`
strace: Process 30815 attached
epoll_wait(7, [], 1, 666)               = 0
getppid()                               = 30800
utimensat(6, NULL, [{tv_sec=3157, tv_nsec=198136276} /* 1970-01-01T06:22:37.198136276+0530 */, {tv_sec=3157, tv_nsec=198136276} /* 1970-01-01T06:22:37.198136276+0530 */], 0) = 0
epoll_wait(7, [], 1, 1000)              = 0
getppid()                               = 30800
utimensat(6, NULL, [{tv_sec=3158, tv_nsec=204192934} /* 1970-01-01T06:22:38.204192934+0530 */, {tv_sec=3158, tv_nsec=204192934} /* 1970-01-01T06:22:38.204192934+0530 */], 0) = 0
epoll_wait(7, [], 1, 1000)              = 0
getppid()                               = 30800
utimensat(6, NULL, [{tv_sec=3159, tv_nsec=210145196} /* 1970-01-01T06:22:39.210145196+0530 */, {tv_sec=3159, tv_nsec=210145196} /* 1970-01-01T06:22:39.210145196+0530 */], 0) = 0
epoll_wait(7, [], 1, 1000)              = 0
getppid()                               = 30800
utimensat(6, NULL, [{tv_sec=3160, tv_nsec=215517372} /* 1970-01-01T06:22:40.215517372+0530 */, {tv_sec=3160, tv_nsec=215517372} /* 1970-01-01T06:22:40.215517372+0530 */], 0) = 0
epoll_wait(7, ^Cstrace: Process 30815 detached
 <detached ...>
 ```

Timing out every second wakes up the process and loads it on CPU even
if there is nothing to service.

This can be detrimental when you have `total workers >> total cores` and
a multi-tenant setup where most tenants might be sitting idle. (but not
"idle enough" because of 1s polling timeout)

This can possibly keep a completed future in the queue until the next 
request arrives, but I don't see any obvious problem with it except a few 
bytes of extra memory usage? I could be wrong here, please check this.

fixes https://github.com/benoitc/gunicorn/issues/3317 (more details on issue)