### PR TITLE
fix: problematic parsing leniency in parsing chunk extensions

### DIFF
--- a/gunicorn/http/body.py
+++ b/gunicorn/http/body.py
@@ -6,7 +6,7 @@ import io
 import sys
 
 from gunicorn.http.errors import (NoMoreData, ChunkMissingTerminator,
-                                  InvalidChunkSize)
+                                  InvalidChunkSize, InvalidChunkExtension)
 
 
 class ChunkedReader:
@@ -91,6 +91,10 @@ class ChunkedReader:
         chunk_size, *chunk_ext = line.split(b";", 1)
         if chunk_ext:
             chunk_size = chunk_size.rstrip(b" \t")
+            # Security: Don't newlines in chunk extension
+            # This can cause request smuggling issues with some proxies
+            if b"\n" in chunk_ext[0]:
+                raise InvalidChunkExtension(chunk_ext[0])
         if any(n not in b"0123456789abcdefABCDEF" for n in chunk_size):
             raise InvalidChunkSize(chunk_size)
         if len(chunk_size) == 0:

--- a/gunicorn/http/errors.py
+++ b/gunicorn/http/errors.py
@@ -97,6 +97,14 @@ class InvalidChunkSize(IOError):
         return "Invalid chunk size: %r" % self.data
 
 
+class InvalidChunkExtension(IOError):
+    def __init__(self, data):
+        self.data = data
+
+    def __str__(self):
+        return "Invalid chunk extension: %r" % self.data
+
+
 class ChunkMissingTerminator(IOError):
     def __init__(self, term):
         self.term = term

--- a/tests/requests/invalid/chunked_14.http
+++ b/tests/requests/invalid/chunked_14.http
@@ -1,0 +1,7 @@
+POST /chunked_newline_in_chunk_ext HTTP/1.1\r\n
+Transfer-Encoding: chunked\r\n
+\r\n
+5;foo\nbar\r\n
+hello\r\n
+0\r\n
+\r\n

--- a/tests/requests/invalid/chunked_14.py
+++ b/tests/requests/invalid/chunked_14.py
@@ -1,0 +1,2 @@
+from gunicorn.http.errors import InvalidChunkExtension
+request = InvalidChunkExtension


### PR DESCRIPTION
Stop allowing newline characters in chunk extensions. This can cause request smuggling issues with some reverse proxies. 

Reference: https://grenfeldt.dev/2021/10/08/gunicorn-20.1.0-public-disclosure-of-request-smuggling/