### PR TITLE
Use library function to get exitcode from status

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -523,7 +523,7 @@ class Arbiter:
                     # A worker was terminated. If the termination reason was
                     # that it could not boot, we'll shut it down to avoid
                     # infinite start/stop cycles.
-                    exitcode = status >> 8
+                    exitcode = os.waitstatus_to_exitcode(status)
                     if exitcode != 0:
                         self.log.error('Worker (pid:%s) exited with code %s', wpid, exitcode)
                     if exitcode == self.WORKER_BOOT_ERROR:


### PR DESCRIPTION
Shifting by 8 bits will hide the correct exit code in some cases.

On linux sending `SIGKILL` will produce the log entry.

```
Worker (pid:22) was sent SIGKILL! Perhaps out of memory
```

The logline printing the exitcode is not triggered because shifting the status will zero it.

The patched version using `os.waitstatus_to_exitcode` produces.
```
Worker (pid:7) exited with code -9
Worker (pid:7) was sent SIGKILL! Perhaps out of memory?
```

Yes, this is a minute detail. I discovered it when investigating #3330.