### PR TITLE
fix: the worker_abort hook interrupted after executing part

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -503,8 +503,8 @@ class Arbiter:
 
             if not worker.aborted:
                 self.log.critical("WORKER TIMEOUT (pid:%s)", pid)
-                worker.aborted = True
                 self.kill_worker(pid, signal.SIGABRT)
+                worker.aborted = True
             else:
                 self.kill_worker(pid, signal.SIGKILL)
 

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -199,8 +199,9 @@ class Worker:
         sys.exit(0)
 
     def handle_abort(self, sig, frame):
-        self.alive = False
         self.cfg.worker_abort(self)
+        time.sleep(0.1)
+        self.alive = False
         sys.exit(1)
 
     def handle_error(self, req, client, addr, exc):


### PR DESCRIPTION
**Issue**: When a custom worker_abort hook contains time-consuming operations, it will be interrupted after executing part of it. 
Closes #3336

**Solve**:
I change worker.aborted flag after kill_worker and it works fine

