### PR TITLE
Remove RuntimeDirectory from systemd service

### DIFF
--- a/docs/source/deploy.rst
+++ b/docs/source/deploy.rst
@@ -254,7 +254,6 @@ to the newly created unix socket:
     Group=someuser
     # this user can be transiently created by systemd
     # DynamicUser=true
-    RuntimeDirectory=gunicorn
     WorkingDirectory=/home/someuser/applicationroot
     ExecStart=/usr/bin/gunicorn applicationname.wsgi
     ExecReload=/bin/kill -s HUP $MAINPID


### PR DESCRIPTION
In ab81ae3b4d15 this was added with the following remark:

> Without this /run/gunicorn isn't created

However, in ba0d784960be the final reference to `/run/gunicorn/` (for `/run/gunicorn/pid`) was removed. I've checked like so:

find -type f | x grep run/\gunicorn\/