### PR TITLE
Drop Python 3.7 support (fixes Github CI)

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,8 +21,7 @@ jobs:
          - macos-13
          # Not testing Windows, because tests need Unix-only fcntl, grp, pwd, etc.
         python-version:
-         # CPython <= 3.7 is EoL since 2023-06-27
-         - "3.7"
+         # CPython <= 3.8 is EoL since 2024-10-07
          - "3.8"
          - "3.9"
          - "3.10"

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ The documentation is hosted at https://docs.gunicorn.org.
 Installation
 ------------
 
-Gunicorn requires **Python 3.x >= 3.7**.
+Gunicorn requires **Python 3.x >= 3.8**.
 
 Install from PyPI::
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,6 @@ Please target reports against :white_check_mark: or current master. Please under
 
 ## Python Versions
 
-Gunicorn runs on Python 3.7+, we *highly recommend* the latest release of a 
+Gunicorn runs on Python 3.8+, we *highly recommend* the latest release of a
 [supported series](https://devguide.python.org/versions/) and will not prioritize issues exclusively 
 affecting in EoL environments.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -6,7 +6,7 @@ Requirements
 
 To generate documentation you need to install:
 
- - Python >= 3.7
+ - Python >= 3.8
  - Sphinx (https://www.sphinx-doc.org/)
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ Features
 * Simple Python configuration
 * Multiple worker configurations
 * Various server hooks for extensibility
-* Compatible with Python 3.x >= 3.7
+* Compatible with Python 3.x >= 3.8
 
 
 Contents

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -4,7 +4,7 @@ Installation
 
 .. highlight:: bash
 
-:Requirements: **Python 3.x >= 3.7**
+:Requirements: **Python 3.x >= 3.8**
 
 To install the latest released version of Gunicorn::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Operating System :: POSIX",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -35,9 +34,8 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: WSGI :: Server",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
-    'importlib_metadata; python_version<"3.8"',
     "packaging",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
it was EoL since 2023-06-27 and since today prevents the CI from running