### PR TITLE
Disable SO_REUSEPORT for unix sockets

### DIFF
--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -36,10 +36,13 @@ class BaseSocket:
     def __getattr__(self, name):
         return getattr(self.sock, name)
 
+    def supports_reuseport(self):
+        return hasattr(socket, 'SO_REUSEPORT')
+
     def set_options(self, sock, bound=False):
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         if (self.conf.reuse_port
-                and hasattr(socket, 'SO_REUSEPORT')):  # pragma: no cover
+                and self.supports_reuseport()):  # pragma: no cover
             try:
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
             except OSError as err:
@@ -118,6 +121,9 @@ class UnixSocket(BaseSocket):
 
     def __str__(self):
         return "unix:%s" % self.cfg_addr
+
+    def supports_reuseport(self):
+        return False
 
     def bind(self, sock):
         old_umask = os.umask(self.conf.umask)


### PR DESCRIPTION
Because of the fix for [CVE-2024-57903](https://nvd.nist.gov/vuln/detail/CVE-2024-57903), the linux kernel started returning an error if an attempt is made to set the `SO_REUSEPORT` socket option on non-inet/inet6 sockets.

In gunicorn, if `reuse_port` is set to `True` and one of the bind addresses is a unix socket, this causes the arbiter to hang on newer kernels.