### PR TITLE
refuse HTTP method CONNECT

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -417,6 +417,12 @@ class Request(Message):
                 raise InvalidRequestMethod(self.method)
             if not 3 <= len(bits[0]) <= 20:
                 raise InvalidRequestMethod(self.method)
+            # this restriction mitigates the failure to validate authority-form below
+            # ! do not remove simply because cfg.permit_unconventional_http_method is removed
+            if self.method == "CONNECT":
+                # BUG: method is not necessarily invalid, merely unsupported
+                # TODO: improve once Worker.handle_error is refactored
+                raise InvalidRequestMethod(self.method)
         # standard restriction: RFC9110 token
         if not TOKEN_RE.fullmatch(self.method):
             raise InvalidRequestMethod(self.method)

--- a/tests/requests/invalid/method_01.http
+++ b/tests/requests/invalid/method_01.http
@@ -1,0 +1,4 @@
+CONNECT host:25 HTTP/1.1\r\n
+Content-Length: 3\r\n
+\r\n
+BOO

--- a/tests/requests/invalid/method_01.py
+++ b/tests/requests/invalid/method_01.py
@@ -1,0 +1,3 @@
+from gunicorn.http.errors import InvalidRequestMethod
+
+request = InvalidRequestMethod

--- a/tests/requests/invalid/method_02.http
+++ b/tests/requests/invalid/method_02.http
@@ -1,0 +1,4 @@
+CONNECT domain.example HTTP/1.1\r\n
+Content-Length: 3\r\n
+\r\n
+FOO

--- a/tests/requests/invalid/method_02.py
+++ b/tests/requests/invalid/method_02.py
@@ -1,0 +1,3 @@
+from gunicorn.http.errors import InvalidRequestMethod
+
+request = InvalidRequestMethod


### PR DESCRIPTION
Semantics of the CONNECT method are not implemented, and URL parser does not enforce the syntactical requirement for the request-target to include the port. Refuse all such requests to shut down attempts at exploiting this parser difference. Note that the refusal happens prior to the (dangerous) `cfg.casefold_http_method` compatibility switch, so this really only applies to upper case `CONNECT`.

* Discussion of reply status: Replying 405 [would necessitate sending an `Allow` header](https://datatracker.ietf.org/doc/html/rfc9110#name-405-method-not-allowed), which is not something Gunicorn should do, not knowing what is a valid method *for a specific URL*. Fortunately, [*any* non-2XX-reponse](https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.6-7) fulfills the purpose of not triggering any special handling in proxies, thus a 400 response is okay.

* See https://github.com/benoitc/gunicorn/issues/3363