### PR TITLE
stop pretending to support gzip *request* transfer-encoding

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -190,11 +190,6 @@ class Message:
                         # safe option: nuke it, its never needed
                         if chunked:
                             raise InvalidHeader("TRANSFER-ENCODING", req=self)
-                    elif val.lower() in ('compress', 'deflate', 'gzip'):
-                        # chunked should be the last one
-                        if chunked:
-                            raise InvalidHeader("TRANSFER-ENCODING", req=self)
-                        self.force_close()
                     else:
                         raise UnsupportedTransferCoding(value)
 

--- a/tests/requests/invalid/chunked_06.http
+++ b/tests/requests/invalid/chunked_06.http
@@ -1,6 +1,6 @@
 POST /chunked_not_last HTTP/1.1\r\n
 Transfer-Encoding: chunked\r\n
-Transfer-Encoding: gzip\r\n
+Transfer-Encoding: identity\r\n
 \r\n
 5\r\n
 hello\r\n

--- a/tests/requests/valid/025.http
+++ b/tests/requests/valid/025.http
@@ -1,5 +1,5 @@
 POST /chunked HTTP/1.1\r\n
-Transfer-Encoding: gzip\r\n
+Transfer-Encoding: identity\r\n
 Transfer-Encoding: chunked\r\n
 \r\n
 5\r\n

--- a/tests/requests/valid/025.py
+++ b/tests/requests/valid/025.py
@@ -3,7 +3,7 @@ request = {
     "uri": uri("/chunked"),
     "version": (1, 1),
     "headers": [
-        ('TRANSFER-ENCODING', 'gzip'),
+        ('TRANSFER-ENCODING', 'identity'),
         ('TRANSFER-ENCODING', 'chunked')
     ],
     "body": b"hello world"

--- a/tests/requests/valid/025_line.http
+++ b/tests/requests/valid/025_line.http
@@ -1,5 +1,5 @@
 POST /chunked HTTP/1.1\r\n
-Transfer-Encoding: gzip,chunked\r\n
+Transfer-Encoding: identity,chunked\r\n
 \r\n
 5\r\n
 hello\r\n

--- a/tests/requests/valid/025_line.py
+++ b/tests/requests/valid/025_line.py
@@ -3,7 +3,7 @@ request = {
     "uri": uri("/chunked"),
     "version": (1, 1),
     "headers": [
-        ('TRANSFER-ENCODING', 'gzip,chunked')
+        ('TRANSFER-ENCODING', 'identity,chunked')
 
     ],
     "body": b"hello world"


### PR DESCRIPTION
Gunicorn **does not** decode compressed body, so forwarding the header to the application without offering a robust method of failing safe or working against different server versions **can only lead to a mess**. A small mess, because nobody is using this. Yet an important one, because almost *everyone using this is trying to exploit a flaw in a proxy setup*.

This PR undoes (or restarts the conversation about) the part of https://github.com/benoitc/gunicorn/pull/3260 that I do not understand.

If Gunicorn does not *fully* handle a hop-by-hop header, and leaves the WSGI application in no place to figure out what is left to do, it should not not *partially* handle it.

https://peps.python.org/pep-3333/#other-http-features

> WSGI servers must handle any supported inbound “hop-by-hop” headers on their own, such as by decoding any inbound Transfer-Encoding, including chunked encoding if applicable.

https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.1

> intermediaries SHOULD remove or replace fields that are known to require removal before forwarding