### PR TITLE
remove whitespace in transfer-encoding

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -135,6 +135,9 @@ VERSION_RE = re.compile(r"HTTP/(\d)\.(\d)")
 # control range (0x00-0x1F except HTAB, plus DEL 0x7F) must be rejected.
 RFC9110_5_5_INVALID_AND_DANGEROUS = re.compile(r"[\x00-\x08\x0a-\x1f\x7f]")
 
+# OWS = *( SP / HTAB )
+RFC9110_5_6_3_WHITESPACE = " \t"
+
 # RFC 9110 section 6.5.1: fields forbidden in trailers because they alter
 # routing, framing, or authentication. Using the uppercased names stored
 # by parse_headers.
@@ -308,6 +311,7 @@ class Message:
                 raise InvalidHeader(curr)
             name, value = curr.split(":", 1)
             if self.cfg.strip_header_spaces:
+                # non-standard and dangerous
                 name = name.rstrip(" \t")
             if not TOKEN_RE.fullmatch(name):
                 raise InvalidHeaderName(name)
@@ -322,10 +326,12 @@ class Message:
             if from_trailer and name in RFC9110_6_5_1_FORBIDDEN_TRAILER:
                 raise InvalidHeaderName(name)
 
-            value = [value.strip(" \t")]
+            # https://datatracker.ietf.org/doc/html/rfc9112#name-field-syntax
+            # optional whitespace before and after field-value
+            value = [value.strip(RFC9110_5_6_3_WHITESPACE)]
 
             # Consume value continuation lines..
-            while lines and lines[0].startswith((" ", "\t")):
+            while lines and lines[0].startswith(tuple(RFC9110_5_6_3_WHITESPACE)):
                 # .. which is obsolete here, and no longer done by default
                 if not self.cfg.permit_obsolete_folding:
                     raise ObsoleteFolding(name)
@@ -334,7 +340,7 @@ class Message:
                 if header_length > self.limit_request_field_size > 0:
                     raise LimitRequestHeaders("limit request headers "
                                               "fields size")
-                value.append(curr.strip("\t "))
+                value.append(curr.strip(RFC9110_5_6_3_WHITESPACE))
             value = " ".join(value)
 
             if RFC9110_5_5_INVALID_AND_DANGEROUS.search(value):
@@ -366,7 +372,7 @@ class Message:
             elif name == "TRANSFER-ENCODING":
                 # T-E can be a list
                 # https://datatracker.ietf.org/doc/html/rfc9112#name-transfer-encoding
-                vals = [v.strip() for v in value.split(',')]
+                vals = [v.strip(RFC9110_5_6_3_WHITESPACE) for v in value.split(',')]
                 for val in vals:
                     if val.lower() == "chunked":
                         # DANGER: transfer codings stack, and stacked chunking is never intended
@@ -419,7 +425,9 @@ class Message:
             return True
         for (h, v) in self.headers:
             if h == "CONNECTION":
-                v = v.lower().strip(" \t")
+                # https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.1
+                # Connection options are case-insensitive.
+                v = v.lower().strip(RFC9110_5_6_3_WHITESPACE)
                 if v == "close":
                     return True
                 elif v == "keep-alive":

--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -32,6 +32,7 @@ import urllib.parse
 
 REDIRECT_TO = getattr(os, 'devnull', '/dev/null')
 
+# https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.1
 # Server and Date aren't technically hop-by-hop
 # headers, but they are in the purview of the
 # origin server which the WSGI spec says we should
@@ -41,6 +42,7 @@ REDIRECT_TO = getattr(os, 'devnull', '/dev/null')
 # might be better, but nothing else does it and
 # dropping them is easier.
 hop_headers = set("""
+    proxy-connection
     connection keep-alive proxy-authenticate proxy-authorization
     te trailers transfer-encoding upgrade
     server date

--- a/tests/requests/invalid/chunked_whitespace.http
+++ b/tests/requests/invalid/chunked_whitespace.http
@@ -1,0 +1,8 @@
+POST /upload HTTP/1.1\r\n
+Host: example.com\r\n
+Transfer-Encoding: identity, \x0bchunked\r\n
+\r\n
+5\r\n
+hello\r\n
+0\r\n
+\r\n

--- a/tests/requests/invalid/chunked_whitespace.py
+++ b/tests/requests/invalid/chunked_whitespace.py
@@ -1,0 +1,6 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+from gunicorn.http.errors import InvalidHeader
+request = InvalidHeader

--- a/tests/requests/valid/obs_fold_whitespace.http
+++ b/tests/requests/valid/obs_fold_whitespace.http
@@ -1,0 +1,18 @@
+POST /1 HTTP/1.1\r\n
+Host: example.com\r\n
+Connection: keep-alive\r\n
+ \r\n
+Content-Length: 3\r\n
+\r\n
+123
+POST /2 HTTP/1.1\r\n
+Host: example.com\r\n
+Connection: close\r\n
+ \r\n
+Transfer-Encoding: chunked\r\n
+\r\n
+3\r\n
+123\r\n
+0\r\n
+Trailer-Checksum: 0\r\n
+\r\n

--- a/tests/requests/valid/obs_fold_whitespace.py
+++ b/tests/requests/valid/obs_fold_whitespace.py
@@ -1,0 +1,38 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+from gunicorn.http.errors import ObsoleteFolding
+from gunicorn.config import Config
+
+cfg = Config()
+cfg.set('permit_obsolete_folding', True)
+
+req1 = {
+    "method": "POST",
+    "uri": uri("/1"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com"),
+        ("CONNECTION", "keep-alive "),
+        ("CONTENT-LENGTH", "3"),
+    ],
+    "body": b"123",
+}
+
+req2 = {
+    "method": "POST",
+    "uri": uri("/2"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com"),
+        ("CONNECTION", "close "),
+        ("TRANSFER-ENCODING", "chunked"),
+    ],
+    "trailers": [
+        ("TRAILER-CHECKSUM", "0"),
+    ],
+    "body": b"123",
+}
+
+request = [req1, req2]


### PR DESCRIPTION
HTTP parser Whitespace cleanup

1. one no-op replacement
2. one variable reuse after casting to tuple, to clarify these are still just SP and HTAB
3. another no-op replacement
4. a meaningful change for https://github.com/benoitc/gunicorn/issues/3364
   * N.B. this still disallows `Content-Encoding: identity,` (trailing comma), probably a [robust](https://en.wikipedia.org/wiki/Robustness_principle) choice
   * no longer meaningful after 2073e13dc80969074954cabd61c01d5e1f427d7f - `\x0b` is rejected by the new `RFC9110_5_5_INVALID_AND_DANGEROUS`
   * N.B. responding 501 is not [what the original reporter recommended](https://github.com/benoitc/gunicorn/issues/3364#issuecomment-2741541765) - but differentiating invalid and unsupported is is complicated because of potential parameters, and I do no see how the difference matters.
5. a no-op replacement in checking the `CONNECTION` header.. which should probably just be dropped. How could `v != v.strip(" \t")` legitimately happen, unless something was wrong with obsolete folding?

Searching for `strip()` revealed additional references in `cfg.strip_header_spaces` (known dangerous) in `util.is_hoppish()` (unreachable after 72238fcf8d29db62fdbb9d2481ced801e27fe139 - left as-is but did add the extra header rfc9112 tells us to drop) and in the websockets example (not reviewed yet).

References:
* https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.3
* https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.1.2