### PR TITLE
unregister socket from poller just before setting alive to False

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -322,6 +322,9 @@ class ThreadWorker(base.Worker):
             if self.nr >= self.max_requests:
                 if self.alive:
                     self.log.info("Autorestarting worker after current request.")
+                    # do not accept new connections
+                    for sock_ in self.sockets:
+                        self.poller.unregister(sock_)
                     self.alive = False
                 resp.force_close()
 


### PR DESCRIPTION
It prevents new connections beeing sent to worker which is about to be restarted, more details: https://github.com/benoitc/gunicorn/issues/3380