### PR TITLE
Notify workers of quick shutdown after graceful shutdown times out.

### DIFF
--- a/docs/source/signals.rst
+++ b/docs/source/signals.rst
@@ -10,9 +10,11 @@ signals used internally by Gunicorn to communicate with the workers.
 Master process
 ==============
 
-- ``QUIT``, ``INT``: Quick shutdown
+- ``QUIT``, ``INT``: Quick shutdown. Waits for workers to finish their current
+  requests up to the :ref:`quick-shutdown-timeout`.
 - ``TERM``: Graceful shutdown. Waits for workers to finish their
-  current requests up to the :ref:`graceful-timeout`.
+  current requests up to the
+  :ref:`graceful-timeout` + :ref:`quick-shutdown-timeout`.
 - ``HUP``: Reload the configuration, start the new worker processes with a new
   configuration and gracefully shutdown older workers. If the application is
   not preloaded (using the :ref:`preload-app` option), Gunicorn will also load

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -386,17 +386,22 @@ class Arbiter:
         sock.close_sockets(self.LISTENERS, unlink)
 
         self.LISTENERS = []
-        sig = signal.SIGTERM
-        if not graceful:
-            sig = signal.SIGQUIT
-        limit = time.time() + self.cfg.graceful_timeout
-        # instruct the workers to exit
-        self.kill_workers(sig)
-        # wait until the graceful timeout
-        while self.WORKERS and time.time() < limit:
-            time.sleep(0.1)
+
+        if graceful:
+            deadline = time.time() + self.cfg.graceful_timeout
+            self.kill_workers(signal.SIGTERM)
+            self.sleep_until(deadline)
+
+        if not graceful or self.cfg.quick_shutdown_timeout > 0:
+            deadline = time.time() + self.cfg.quick_shutdown_timeout
+            self.kill_workers(signal.SIGINT)
+            self.sleep_until(deadline)
 
         self.kill_workers(signal.SIGKILL)
+
+    def sleep_until(self, deadline):
+        while self.WORKERS and time.time() < deadline:
+            time.sleep(0.1)
 
     def reexec(self):
         """\

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -365,6 +365,13 @@ def validate_pos_int(val):
     return val
 
 
+def validate_pos_float(val):
+    val = float(val)
+    if val < 0:
+        raise ValueError("Value must be positive: %s" % val)
+    return val
+
+
 def validate_ssl_version(val):
     if val != SSLVersion.default:
         sys.stderr.write("Warning: option `ssl_version` is deprecated and it is ignored. Use ssl_context instead.\n")
@@ -811,7 +818,25 @@ class GracefulTimeout(Setting):
 
         After receiving a restart signal, workers have this much time to finish
         serving requests. Workers still alive after the timeout (starting from
-        the receipt of the restart signal) are force killed.
+        the receipt of the restart signal) are sent a quick shutdown signal (if
+        quick_shutdown_timeout is greater than zero) then are force killed.
+        """
+
+
+class QuickShutdownTimeout(Setting):
+    name = "quick_shutdown_timeout"
+    section = "Worker Processes"
+    cli = ["--quick-shutdown-timeout"]
+    meta = "INT"
+    validator = validate_pos_float
+    type = float
+    default = 0
+    desc = """\
+        Timeout for quick worker shutdown.
+
+        After receiving a quick shutdown signal, workers have this much time to
+        finish serving requests. Workers still alive after the timeout (starting
+        from the receipt of the quick shutdown signal) are force killed.
         """
 
 

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -191,12 +191,18 @@ class Worker:
     def handle_exit(self, sig, frame):
         self.alive = False
 
+    def quick_exit(self):
+        timeout = self.cfg.quick_shutdown_timeout
+        if timeout <= 0:
+            timeout = 0.1
+        time.sleep(timeout)
+        sys.exit(0)
+
     def handle_quit(self, sig, frame):
         self.alive = False
         # worker_int callback
         self.cfg.worker_int(self)
-        time.sleep(0.1)
-        sys.exit(0)
+        self.quick_exit()
 
     def handle_abort(self, sig, frame):
         self.alive = False

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -102,8 +102,7 @@ class ThreadWorker(base.Worker):
         # worker_int callback
         self.cfg.worker_int(self)
         self.tpool.shutdown(False)
-        time.sleep(0.1)
-        sys.exit(0)
+        self.quick_exit()
 
     def _wrap_future(self, fs, conn):
         fs.conn = conn


### PR DESCRIPTION
As per https://github.com/benoitc/gunicorn/issues/3385 this allows to distinguish between graceful and abnormal termination and gives a chance to workers to do something about it (e.g. to log a stack trace).

For backward compatibility, we keep the old 2 signals model if quick_shutdown_timeout is set to 0.