### PR TITLE
Updated IRC Channel info & Slightly improved the Community Doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ benoitc.
 
 * Step 1: learn the component inside out
 * Step 2: make yourself useful by contributing code, bugfixes, support etc.
-* Step 3: volunteer on the irc channel (#gunicorn@freenode)
+* Step 3: volunteer on our [Libera Chat](https://libera.chat/) irc channel [#gunicorn](https://web.libera.chat/?channels=#gunicorn)
 
 Don't forget: being a maintainer is a time investment. Make sure you
 will have time to make yourself available.  You don't have to be a

--- a/docs/source/community.rst
+++ b/docs/source/community.rst
@@ -2,38 +2,36 @@
 Community
 =========
 
-Use these channels to communicate about the project.
+Use these channels to communicate about the project:
 
 Project Management & Discussions
 ================================
 
-Gunicorn uses `GitHub for the project management <https://github.com/benoitc/gunicorn/projects>`_. GitHub issues are used
-for 3 different purposes:
-
-  * `Bug tracker <https://github.com/benoitc/gunicorn/projects/2>`_ : to check latest bug 
-  * `Forum <https://github.com/benoitc/gunicorn/projects/4>`_ : Stackoverflow-style questions about Gunicorn usage
-  * `Mailing list <https://github.com/benoitc/gunicorn/projects/3>`_ : Discussion of Gunicorn development, new features
-    and project management.  
-
 Project maintenance guidelines are available on the `wiki <https://github.com/benoitc/gunicorn/wiki/Project-management>`_
-.
+
+GitHub issues are used for 3 different purposes:
+
+  * `Bug tracker <https://github.com/benoitc/gunicorn/issues>`_ : To check for latest bugs. Tip: See existing issues before opening a new one! 
+  * `Forum <https://github.com/benoitc/gunicorn/discussions>`_ : Stackoverflow-style questions about Gunicorn usage.
+  * `Other Issues <https://github.com/benoitc/gunicorn/issues>`_ : Discussion of Gunicorn development, new features
+    and project management.
 
 IRC
 ===
 
-The Gunicorn channel is on the `Freenode <http://freenode.net/>`_ IRC
-network. You can chat with other on `#gunicorn channel
-<http://webchat.freenode.net/?channels=gunicorn>`_.
+The Gunicorn channel is on the `Libera Chat <https://libera.chat/>`_ IRC
+network. You can chat with others on `#gunicorn channel
+<https://web.libera.chat/#gunicorn>`_
 
 Issue Tracking
 ==============
 
 Bug reports, enhancement requests and tasks generally go in the `Github
-issue tracker <http://github.com/benoitc/gunicorn/issues>`_.
+issue tracker <http://github.com/benoitc/gunicorn/issues>`_
 
 Security Issues
 ===============
 
 The security mailing list is a place to report security issues. Only
 developers are subscribed to it. To post a message to the list use the address
-to `security@gunicorn.org <mailto:security@gunicorn.org>`_ .
+to `security@gunicorn.org <mailto:security@gunicorn.org>`_

--- a/docs/source/community.rst
+++ b/docs/source/community.rst
@@ -21,7 +21,7 @@ IRC
 
 The Gunicorn channel is on the `Libera Chat <https://libera.chat/>`_ IRC
 network. You can chat with others on `#gunicorn channel
-<https://web.libera.chat/#gunicorn>`_
+<https://web.libera.chat/?channels=#gunicorn>`_
 
 Issue Tracking
 ==============


### PR DESCRIPTION
The Community page was a little bit outdated. Specially the IRC channel info was totally wrong, causing potential help-seekers issues in finding the correct channel/network. 

Also, slightly updated the Community page text. Its not perfect, but is a noticeable improvement imho. Fixed some broken links.