### PR TITLE
Fix #3383 we should not exit when the process represented by pid is running

### DIFF
--- a/gunicorn/pidfile.py
+++ b/gunicorn/pidfile.py
@@ -2,7 +2,6 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
-import errno
 import os
 import tempfile
 
@@ -19,13 +18,6 @@ class Pidfile:
         self.pid = None
 
     def create(self, pid):
-        oldpid = self.validate()
-        if oldpid:
-            if oldpid == os.getpid():
-                return
-            msg = "Already running on PID %s (or pid file '%s' is stale)"
-            raise RuntimeError(msg % (oldpid, self.fname))
-
         self.pid = pid
 
         # Write pidfile
@@ -58,28 +50,3 @@ class Pidfile:
                 os.unlink(self.fname)
         except Exception:
             pass
-
-    def validate(self):
-        """ Validate pidfile and make it stale if needed"""
-        if not self.fname:
-            return
-        try:
-            with open(self.fname) as f:
-                try:
-                    wpid = int(f.read())
-                except ValueError:
-                    return
-
-                try:
-                    os.kill(wpid, 0)
-                    return wpid
-                except OSError as e:
-                    if e.args[0] == errno.EPERM:
-                        return wpid
-                    if e.args[0] == errno.ESRCH:
-                        return
-                    raise
-        except OSError as e:
-            if e.args[0] == errno.ENOENT:
-                return
-            raise


### PR DESCRIPTION
- Many software also have a pidfile, eg NGINX., but it does not exit just because the process number in the pidfile is running; it merely writes a new pid to the file
- Whether to run repeatedly or not can be guaranteed by the user themselves