### PR TITLE
fix gthread infinite loop bug

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -205,7 +205,7 @@ class ThreadWorker(base.Worker):
             self.notify()
 
             # can we accept more connections?
-            if self.nr_conns < self.worker_connections:
+            if self.nr_conns < self.worker_connections or not self.futures:
                 # wait for an event
                 events = self.poller.select(1.0)
                 for key, _ in events:


### PR DESCRIPTION
resolves #3407 . The problem arises from `on_client_socket_readable`, which shares a queue with `self.accept`. When the number of active connections reaches the `worker_connections` limit and if all of those connections are expected to be terminated via `on_client_socket_readable`, the worker reaches a state where it no longer polls from `self.poller` (`self.nr_conns` >= self.worker_connections`) and hence is incapable of closing any connections. This happens more often when the application is under stress and `worker_connections` is set to a low value (such as 4).

This solution adds a selector specifically for sockets that are expected to close and uses this in case the application has finished handling all other connections and has no capacity to queue up any more. This should ensure that the number of active connections never exceeds `self.worker_connections` while avoiding this rare case of deadlock.