### PR TITLE
Restore Python 3.10 and 3.11 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,11 +21,14 @@ jobs:
          - macos-13
          # Not testing Windows, because tests need Unix-only fcntl, grp, pwd, etc.
         python-version:
-         # Supporting only N (3.13) and N-1 (3.12)
+         # Supporting Python 3.10 through 3.13
+         - "3.10"
+         - "3.11"
          - "3.12"
          - "3.13"
+         - "pypy-3.10"
         include:
-         # Test on macos-latest (arm64) with both versions
+         # Test on macos-latest (arm64) with recent versions
          - os: macos-latest
            python-version: "3.12"
            unsupported: false

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ The documentation is hosted at https://docs.gunicorn.org.
 Installation
 ------------
 
-Gunicorn requires **Python 3.x >= 3.7**.
+Gunicorn requires **Python 3.x >= 3.10**.
 
 Install from PyPI::
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,6 @@ Please target reports against :white_check_mark: or current master. Please under
 
 ## Python Versions
 
-Gunicorn runs on Python 3.12+, supporting only the latest (N) and previous (N-1) Python versions.
+Gunicorn runs on Python 3.10+, supporting Python versions that are still maintained by the PSF.
 We *highly recommend* the latest release of a [supported series](https://devguide.python.org/versions/)
 and will not prioritize issues affecting EoL environments.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ Features
 * Simple Python configuration
 * Multiple worker configurations
 * Various server hooks for extensibility
-* Compatible with Python 3.x >= 3.7
+* Compatible with Python 3.x >= 3.10
 
 
 Contents

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -4,7 +4,7 @@ Installation
 
 .. highlight:: bash
 
-:Requirements: **Python 3.x >= 3.12**
+:Requirements: **Python 3.x >= 3.10**
 
 To install the latest released version of Gunicorn::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ classifiers = [
     "Operating System :: POSIX",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
@@ -31,7 +33,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: WSGI :: Server",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 dependencies = [
     "packaging",
 ]


### PR DESCRIPTION
## Summary
- Extends Python version support back to 3.10 and 3.11
- Maintains compatibility with Python 3.12 and 3.13
- Re-adds PyPy 3.10 support to CI matrix

## Motivation
The recent change to require Python 3.12+ (PR #3422) was too restrictive. Python 3.10 and 3.11 are still actively maintained by the PSF:
- **Python 3.10**: Security support until October 2026
- **Python 3.11**: Active support with latest features
- **Python 3.12**: Active support  
- **Python 3.13**: Latest stable release

Many production environments are still using Python 3.10 and 3.11, and dropping support prematurely limits gunicorn's usability.

## Changes
- Updated `pyproject.toml` to set minimum Python version to 3.10
- Added Python 3.10, 3.11, and PyPy 3.10 back to the CI test matrix
- Updated all documentation files to reflect Python 3.10+ requirement
- Updated SECURITY.md to clarify support for PSF-maintained versions

## Test plan
- [x] CI tests should pass for Python 3.10, 3.11, 3.12, and 3.13
- [x] PyPy 3.10 tests should pass
- [x] Documentation builds correctly