### PR TITLE
Refactor: plain socket objects instead of wrapper classes

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -158,7 +158,7 @@ class Arbiter:
             if not (self.cfg.reuse_port and hasattr(socket, 'SO_REUSEPORT')):
                 self.LISTENERS = sock.create_sockets(self.cfg, self.log, fds)
 
-        listeners_str = ",".join([str(lnr) for lnr in self.LISTENERS])
+        listeners_str = ",".join([sock.get_uri(lnr, self.cfg.is_ssl) for lnr in self.LISTENERS])
         self.log.debug("Arbiter booted")
         self.log.info("Listening at: %s (%s)", listeners_str, self.pid)
         self.log.info("Using worker: %s", self.cfg.worker_class_str)
@@ -459,7 +459,7 @@ class Arbiter:
                 lnr.close()
             # init new listeners
             self.LISTENERS = sock.create_sockets(self.cfg, self.log)
-            listeners_str = ",".join([str(lnr) for lnr in self.LISTENERS])
+            listeners_str = ",".join([sock.get_uri(lnr, self.cfg.is_ssl) for lnr in self.LISTENERS])
             self.log.info("Listening at: %s", listeners_str)
 
         # do some actions on reload
@@ -601,8 +601,8 @@ class Arbiter:
                                   "mtype": "gauge"})
 
         if self.cfg.enable_backlog_metric:
-            backlog = sum(sock.get_backlog() or 0
-                          for sock in self.LISTENERS)
+            backlog = sum(sock.get_backlog(lnr) or 0
+                          for lnr in self.LISTENERS)
 
             if backlog >= 0:
                 self.log.debug("socket backlog: {0}".format(backlog),

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -2225,7 +2225,7 @@ class KeyFile(Setting):
     section = "SSL"
     cli = ["--keyfile"]
     meta = "FILE"
-    validator = validate_file_exists
+    validator = validate_string
     default = None
     desc = """\
     SSL key file
@@ -2237,7 +2237,7 @@ class CertFile(Setting):
     section = "SSL"
     cli = ["--certfile"]
     meta = "FILE"
-    validator = validate_file_exists
+    validator = validate_string
     default = None
     desc = """\
     SSL certificate file

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -2225,7 +2225,7 @@ class KeyFile(Setting):
     section = "SSL"
     cli = ["--keyfile"]
     meta = "FILE"
-    validator = validate_string
+    validator = validate_file_exists
     default = None
     desc = """\
     SSL key file
@@ -2237,7 +2237,7 @@ class CertFile(Setting):
     section = "SSL"
     cli = ["--certfile"]
     meta = "FILE"
-    validator = validate_string
+    validator = validate_file_exists
     default = None
     desc = """\
     SSL certificate file

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -120,6 +120,7 @@ def create_sockets(conf, log, fds=None):
         for fd in fdaddr:
             # no file descriptor duplication
             sock = socket.socket(fileno=fd)
+            sock.listen(conf.backlog)
             set_socket_options(conf, sock)
             listeners.append(sock)
         return listeners

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -21,7 +21,9 @@ if PLATFORM != "linux":
 else:
     import struct
     # tcp_info struct from include/uapi/linux/tcp.h
-    _TCPI_FMT = 'B' * 8 + 'I' * 24
+    _TCPI_FMT = '=' + 'B' * 8 + 'I' * 24
+    # getsockopt silently truncates to requested length
+    _TCPI_LEN = struct.calcsize(_TCPI_FMT)  # 104
     _TCPI_INDEX_UNACKED = 12
 
     def get_backlog(sock):
@@ -29,7 +31,7 @@ else:
             return -1
         try:
             tcp_info_struct = sock.getsockopt(socket.IPPROTO_TCP,
-                                              socket.TCP_INFO, 104)
+                                              socket.TCP_INFO, _TCPI_LEN)
             return struct.unpack(_TCPI_FMT, tcp_info_struct)[_TCPI_INDEX_UNACKED]
         except (AttributeError, OSError):
             pass

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -23,6 +23,7 @@ else:
     # tcp_info struct from include/uapi/linux/tcp.h
     _TCPI_FMT = 'B' * 8 + 'I' * 24
     _TCPI_INDEX_UNACKED = 12
+
     def get_backlog(sock):
         if sock.family not in (socket.AF_INET, socket.AF_INET6):
             return -1

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -15,7 +15,7 @@ from gunicorn import util
 PLATFORM = sys.platform
 
 
-if PLATFORM == "linux":
+if PLATFORM != "linux":
     def get_backlog(sock):
         return -1
 else:

--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -27,8 +27,8 @@ else:
         if sock.family not in (socket.AF_INET, socket.AF_INET6):
             return -1
         try:
-            tcp_info_struct = self.sock.getsockopt(socket.IPPROTO_TCP,
-                                                   socket.TCP_INFO, 104)
+            tcp_info_struct = sock.getsockopt(socket.IPPROTO_TCP,
+                                              socket.TCP_INFO, 104)
             return struct.unpack(_TCPI_FMT, tcp_info_struct)[_TCPI_INDEX_UNACKED]
         except (AttributeError, OSError):
             pass
@@ -124,7 +124,6 @@ def create_sockets(conf, log, fds=None):
     # no sockets is bound, first initialization of gunicorn in this env.
     old_umask = os.umask(conf.umask)
     try:
-        bind_list = [bind for bind in conf.address if not isinstance(bind, int)]
         for addr in laddr:
             sock = create_socket(conf, log, addr)
             set_socket_options(conf, sock)

--- a/gunicorn/workers/gasgi.py
+++ b/gunicorn/workers/gasgi.py
@@ -14,6 +14,7 @@ import os
 import signal
 import sys
 
+from gunicorn.sock import get_uri
 from gunicorn.workers import base
 from gunicorn.asgi.protocol import ASGIProtocol
 
@@ -178,15 +179,15 @@ class ASGIWorker(base.Worker):
             try:
                 server = await self.loop.create_server(
                     lambda: ASGIProtocol(self),
-                    sock=sock.sock,
+                    sock=sock,
                     ssl=ssl_context,
                     reuse_address=True,
                     start_serving=True,
                 )
                 self.servers.append(server)
-                self.log.info("ASGI server listening on %s", sock)
+                self.log.info("ASGI server listening on %s", get_uri(sock, self.cfg.is_ssl))
             except Exception as e:
-                self.log.error("Failed to create server on %s: %s", sock, e)
+                self.log.error("Failed to create server on %s: %s", get_uri(sock, self.cfg.is_ssl), e)
 
         if not self.servers:
             self.log.error("No servers could be started")

--- a/gunicorn/workers/ggevent.py
+++ b/gunicorn/workers/ggevent.py
@@ -40,8 +40,8 @@ class GeventWorker(AsyncWorker):
         # patch sockets
         sockets = []
         for s in self.sockets:
-            sockets.append(socket.socket(s.FAMILY, socket.SOCK_STREAM,
-                                         fileno=s.sock.detach()))
+            sockets.append(socket.socket(s.family, socket.SOCK_STREAM,
+                                         fileno=s.detach()))
         self.sockets = sockets
 
     def notify(self):

--- a/tests/test_sock.py
+++ b/tests/test_sock.py
@@ -44,7 +44,7 @@ def test_inherit_socket(chown, socket):
     listener = listeners[0]
     assert listener == socket.return_value
     socket.assert_called_with(fileno=3)
-    listener.listen.assert_not_called()
+    listener.listen.assert_called_with(conf.backlog)
     chown.assert_not_called()
 
 

--- a/tests/test_sock.py
+++ b/tests/test_sock.py
@@ -2,30 +2,41 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
+import socket
 from unittest import mock
+
+import pytest
 
 from gunicorn import sock
 
+@pytest.fixture(scope='function')
+def addr(request, tmp_path):
+    if isinstance(request.param, str):
+        return str(tmp_path / request.param)
+    return request.param
 
-@mock.patch('os.stat')
-def test_create_sockets_unix_bytes(stat):
-    conf = mock.Mock(address=[b'127.0.0.1:8000'])
+
+@pytest.mark.parametrize(
+    'addr, family',
+    [
+        ('gunicorn.sock', socket.AF_UNIX),
+        (('0.0.0.0', 0), socket.AF_INET),
+        (('::', 0), socket.AF_INET6),
+    ],
+    indirect=['addr'],
+)
+@mock.patch('socket.socket')
+@mock.patch('gunicorn.util.chown')
+def test_create_socket(chown, socket, addr, family):
+    conf = mock.Mock(address=[addr], umask=0o22)
     log = mock.Mock()
-    with mock.patch.object(sock.UnixSocket, '__init__', lambda *args: None):
-        listeners = sock.create_sockets(conf, log)
-        assert len(listeners) == 1
-        print(type(listeners[0]))
-        assert isinstance(listeners[0], sock.UnixSocket)
-
-
-@mock.patch('os.stat')
-def test_create_sockets_unix_strings(stat):
-    conf = mock.Mock(address=['127.0.0.1:8000'])
-    log = mock.Mock()
-    with mock.patch.object(sock.UnixSocket, '__init__', lambda *args: None):
-        listeners = sock.create_sockets(conf, log)
-        assert len(listeners) == 1
-        assert isinstance(listeners[0], sock.UnixSocket)
+    listener = sock.create_socket(conf, log, addr)
+    assert listener == socket.return_value
+    socket.assert_called_with(family)
+    listener.bind.assert_called_with(addr)
+    listener.listen.assert_called_with(conf.backlog)
+    if family is socket.AF_UNIX:
+        chown.assert_called_with(addr, conf.uid, conf.gid)
 
 
 def test_socket_close():
@@ -40,7 +51,7 @@ def test_socket_close():
 
 @mock.patch('os.unlink')
 def test_unix_socket_close_unlink(unlink):
-    listener = mock.Mock()
+    listener = mock.Mock(family=socket.AF_UNIX)
     listener.getsockname.return_value = '/var/run/test.sock'
     sock.close_sockets([listener])
     listener.close.assert_called_with()
@@ -49,7 +60,7 @@ def test_unix_socket_close_unlink(unlink):
 
 @mock.patch('os.unlink')
 def test_unix_socket_close_without_unlink(unlink):
-    listener = mock.Mock()
+    listener = mock.Mock(family=socket.AF_UNIX)
     listener.getsockname.return_value = '/var/run/test.sock'
     sock.close_sockets([listener], False)
     listener.close.assert_called_with()


### PR DESCRIPTION
* #3127 still works for my limited use case
* still looks like a straightforward and useful refactor
* I would still volunteer to work on it, if there is any work to be done

So, here is a rebased version with the fixup I commented earlier.