### PR TITLE
detect obviously unintended address mask

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -413,7 +413,7 @@ def validate_string_to_addr_list(val):
             result.append(addr)
             continue
         # Support both single IPs and CIDR networks
-        result.append(ipaddress.ip_network(addr, strict=False))
+        result.append(ipaddress.ip_network(addr))
 
     return result
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -200,6 +200,9 @@ def test_str_to_addr_list_validation():
     pytest.raises(ValueError, c.set, "forwarded_allow_ips", "127.0.0")
     # detect typos
     pytest.raises(ValueError, c.set, "forwarded_allow_ips", "::f:")
+    # dangerous typos such as accidently permitting half the internet
+    #  clearly recognizable - masked bits are not zero
+    pytest.raises(ValueError, c.set, "forwarded_allow_ips", "100.64.0.0/1")
 
 
 def test_str_to_list():


### PR DESCRIPTION
When there is a digit missing from the ip address mask, then Python stdlib offers an option to pretend it did not notice.
We do **not** want to use that option. Because when the caller went through the extra effort to spell out the address including non-zero bits covered by the mask, then what they meant was clearly not permitting half the internet!

Revert that bit from e52ac46e297d9d483ad8cf16e43487545185a997 and add to regression test.