### PR TITLE
fix: keep forwarded_allow_ips as strings for backward compatibility

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -58,17 +58,21 @@ VERSION_RE = re.compile(r"HTTP/(\d)\.(\d)")
 RFC9110_5_5_INVALID_AND_DANGEROUS = re.compile(r"[\0\r\n]")
 
 
-def _ip_in_allow_list(ip_str, allow_list):
-    """Check if IP address is in the allow list (which may contain networks)."""
+def _ip_in_allow_list(ip_str, allow_list, networks):
+    """Check if IP address is in the allow list.
+
+    Args:
+        ip_str: The IP address string to check
+        allow_list: The original allow list (strings, may contain "*")
+        networks: Pre-computed ipaddress.ip_network objects from config
+    """
     if '*' in allow_list:
         return True
     try:
         ip = ipaddress.ip_address(ip_str)
     except ValueError:
         return False
-    for network in allow_list:
-        if network == '*':
-            return True
+    for network in networks:
         if ip in network:
             return True
     return False
@@ -127,7 +131,8 @@ class Message:
             #  .. or we are just behind a proxy who does not remove conflicting trailers
             pass
         elif (not isinstance(self.peer_addr, tuple)
-              or _ip_in_allow_list(self.peer_addr[0], cfg.forwarded_allow_ips)):
+              or _ip_in_allow_list(self.peer_addr[0], cfg.forwarded_allow_ips,
+                                   cfg.forwarded_allow_networks())):
             secure_scheme_headers = cfg.secure_scheme_headers
             forwarder_headers = cfg.forwarder_headers
 
@@ -407,7 +412,8 @@ class Request(Message):
     def proxy_protocol_access_check(self):
         """Check if proxy protocol is allowed from this peer."""
         if (isinstance(self.peer_addr, tuple) and
-                not _ip_in_allow_list(self.peer_addr[0], self.cfg.proxy_allow_ips)):
+                not _ip_in_allow_list(self.peer_addr[0], self.cfg.proxy_allow_ips,
+                                      self.cfg.proxy_allow_networks())):
             raise ForbiddenProxyRequest(self.peer_addr[0])
 
     def _parse_proxy_protocol_v1(self, unreader, buf):

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -50,8 +50,10 @@ class MockConfig:
     def __init__(self):
         self.is_ssl = False
         self.proxy_protocol = "off"
-        self.proxy_allow_ips = [ipaddress.ip_network("127.0.0.1")]
-        self.forwarded_allow_ips = [ipaddress.ip_network("127.0.0.1")]
+        self.proxy_allow_ips = ["127.0.0.1"]
+        self.forwarded_allow_ips = ["127.0.0.1"]
+        self._proxy_allow_networks = None
+        self._forwarded_allow_networks = None
         self.secure_scheme_headers = {}
         self.forwarder_headers = []
         self.limit_request_line = 8190
@@ -63,6 +65,24 @@ class MockConfig:
         self.casefold_http_method = False
         self.strip_header_spaces = False
         self.header_map = "refuse"
+
+    def forwarded_allow_networks(self):
+        if self._forwarded_allow_networks is None:
+            self._forwarded_allow_networks = [
+                ipaddress.ip_network(addr)
+                for addr in self.forwarded_allow_ips
+                if addr != "*"
+            ]
+        return self._forwarded_allow_networks
+
+    def proxy_allow_networks(self):
+        if self._proxy_allow_networks is None:
+            self._proxy_allow_networks = [
+                ipaddress.ip_network(addr)
+                for addr in self.proxy_allow_ips
+                if addr != "*"
+            ]
+        return self._proxy_allow_networks
 
 
 # AsyncUnreader Tests


### PR DESCRIPTION
## Summary

- Fix startup crash when using uvicorn workers with gunicorn 24.1.0
- Keep `forwarded_allow_ips` and `proxy_allow_ips` as string lists for backward compatibility
- Add cached `forwarded_allow_networks()` and `proxy_allow_networks()` methods for efficient IP checking
- Use strict mode for network validation to detect mistakes like `192.168.1.1/24` where host bits are set

Fixes #3458
Supersedes #3457