### PR TITLE
Publish full exception when the application fails to load

### DIFF
--- a/docs/content/reference/settings.md
+++ b/docs/content/reference/settings.md
@@ -73,6 +73,11 @@ because it consumes less system resources.
     In order to use the inotify reloader, you must have the ``inotify``
     package installed.
 
+!!! warning
+    Enabling this will change what happens on failure to load the
+    the application: While the reloader is active, any and all clients
+    that can make requests can see the full exception and traceback!
+
 ### `reload_engine`
 
 **Command line:** `--reload-engine STRING`

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -952,6 +952,10 @@ class Reload(Setting):
         .. note::
            In order to use the inotify reloader, you must have the ``inotify``
            package installed.
+        .. warning::
+           Enabling this will change what happens on failure to load the
+           the application: While the reloader is active, any and all clients
+           that can make requests can see the full exception and traceback!
         '''
 
 

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -128,6 +128,7 @@ class Worker:
                 time.sleep(0.1)
                 sys.exit(0)
 
+            self.log.warning("Reloader is on. Use in development only!")
             reloader_cls = reloader_engines[self.cfg.reload_engine]
             self.reloader = reloader_cls(extra_files=self.cfg.reload_extra_files,
                                          callback=changed)
@@ -155,7 +156,7 @@ class Worker:
                 self.reloader.add_extra_file(e.filename)
 
             with io.StringIO() as tb_string:
-                traceback.print_tb(e.__traceback__, file=tb_string)
+                traceback.print_exception(e, file=tb_string)
                 self.wsgi = util.make_fail_app(tb_string.getvalue())
 
     def init_signals(self):


### PR DESCRIPTION
Every wondered what this is supposed to mean?
```
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 936, in exec_module
  File "<frozen importlib._bootstrap_external>", line 1074, in get_code
  File "<frozen importlib._bootstrap_external>", line 1004, in source_to_code
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
```
This is the thing that actually spells out what went wrong:
```
  File "/gunicorn/app.py", line 24
    asd=
        ^
SyntaxError: invalid syntax
```
So that is what we should send. Since that is potentially even more sensitive, turn up the documented and logged warnings about this feature.

The rest of the patch is just dropping `sys.exc_info()` (see #1228 - workaround for problems from a long bygone era) and getting rid of the ResourceWarning.