### PR TITLE
asgi: get valid/invalid http tests to pass

### DIFF
--- a/gunicorn/asgi/message.py
+++ b/gunicorn/asgi/message.py
@@ -16,6 +16,7 @@ import struct
 from gunicorn.http.errors import (
     ExpectationFailed,
     InvalidHeader, InvalidHeaderName, NoMoreData,
+    InvalidChunkSize, ChunkMissingTerminator,
     InvalidRequestLine, InvalidRequestMethod, InvalidHTTPVersion,
     LimitRequestLine, LimitRequestHeaders,
     UnsupportedTransferCoding, ObsoleteFolding,
@@ -648,9 +649,9 @@ class AsyncRequest:
                 chunk_size = chunk_size.rstrip(b" \t")
 
             if any(n not in b"0123456789abcdefABCDEF" for n in chunk_size):
-                raise InvalidHeader("Invalid chunk size")
+                raise InvalidChunkSize(chunk_size)
             if len(chunk_size) == 0:
-                raise InvalidHeader("Invalid chunk size")
+                raise InvalidChunkSize(chunk_size)
 
             chunk_size = int(chunk_size, 16)
 
@@ -678,7 +679,7 @@ class AsyncRequest:
                         break
                     crlf += more
                 if crlf != b"\r\n":
-                    raise InvalidHeader("Missing chunk terminator")
+                    raise ChunkMissingTerminator(crlf)
 
     async def _read_chunk_size_line(self):
         """Read a chunk size line.

--- a/tests/requests/invalid/006.py
+++ b/tests/requests/invalid/006.py
@@ -2,5 +2,9 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
+from gunicorn.config import Config
 from gunicorn.http.errors import LimitRequestLine
+
+cfg = Config()
+cfg.set("limit_request_line", 4094)
 request = LimitRequestLine

--- a/tests/requests/valid/040.py
+++ b/tests/requests/valid/040.py
@@ -2,6 +2,11 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
+from gunicorn.config import Config
+
+cfg = Config()
+cfg.set("header_map", "drop")
+
 request = {
     "method": "GET",
     "uri": uri("/keep/same/as?invalid/040"),

--- a/tests/requests/valid/nonascii_01.http
+++ b/tests/requests/valid/nonascii_01.http
@@ -1,0 +1,5 @@
+PUT /ß/germans..?ö=ä HTTP/1.1\r\n
+Unicode: awesome\r\n
+Content-Length: 6\r\n
+\r\n
+ÄÖÜ

--- a/tests/requests/valid/nonascii_01.py
+++ b/tests/requests/valid/nonascii_01.py
@@ -1,0 +1,15 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+request = {
+    "method": "PUT",
+    # intentionally expressive - suffix to be stripped once treq.py:uri() is refactored
+    "uri": uri("/\N{LATIN SMALL LETTER SHARP S}/germans..?\N{LATIN SMALL LETTER O WITH DIAERESIS}=\N{LATIN SMALL LETTER A WITH DIAERESIS}".encode().decode("latin-1")),
+    "version": (1, 1),
+    "headers": [
+        ("UNICODE", "awesome"),
+        ("CONTENT-LENGTH", "6"),
+    ],
+    "body": "\N{LATIN CAPITAL LETTER A WITH DIAERESIS}\N{LATIN CAPITAL LETTER O WITH DIAERESIS}\N{LATIN CAPITAL LETTER U WITH DIAERESIS}".encode()
+}

--- a/tests/requests/valid/nonascii_02.http
+++ b/tests/requests/valid/nonascii_02.http
@@ -1,0 +1,5 @@
+PUT /ÿ/french..?é=è HTTP/1.1\r\n
+Unicode: awesome\r\n
+Content-Length: 6\r\n
+\r\n
+ÀÁÂ

--- a/tests/requests/valid/nonascii_02.py
+++ b/tests/requests/valid/nonascii_02.py
@@ -1,0 +1,15 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+request = {
+    "method": "PUT",
+    # intentionally expressive - suffix to be stripped once treq.py:uri() is refactored
+    "uri": uri("/\N{LATIN SMALL LETTER Y WITH DIAERESIS}/french..?\N{LATIN SMALL LETTER E WITH ACUTE}=\N{LATIN SMALL LETTER E WITH GRAVE}".encode().decode("latin-1")),
+    "version": (1, 1),
+    "headers": [
+        ("UNICODE", "awesome"),
+        ("CONTENT-LENGTH", "6"),
+    ],
+    "body": "\N{LATIN CAPITAL LETTER A WITH GRAVE}\N{LATIN CAPITAL LETTER A WITH ACUTE}\N{LATIN CAPITAL LETTER A WITH CIRCUMFLEX}".encode()
+}


### PR DESCRIPTION
There are 101 perfectly fine HTTP test cases in `tests/requests/**.http` many of which of no use for testing the ASGI workers right now. Let's fix that.

* change asgi HTTP error exceptions to match base sync worker
  * did not look intentional, link to diff in PR here: https://github.com/benoitc/gunicorn/pull/3444#discussion_r2724675416
* <del>use StopAsyncIteration in async def - my reasoning here is that sticking with this signalling is *exclusively* practical when the exception can bubble in async iterator</del>
* override config in cases tests/test_asgi.py::MockConfig has non-default
  * those test cases actually care about the configs set there, and though this could equally be fixed by switching the test to use the default settings instead, *explicit is better than implicit*

(updated `tests/treq.py` and new `tests/test_nginx.py` intentionally omitted here, they match most of my parallel PRs)