### PR TITLE
Fix setproctitle initialization with systemd socket activation

### DIFF
--- a/gunicorn/util.py
+++ b/gunicorn/util.py
@@ -53,7 +53,12 @@ if sys.platform == "darwin":
         pass
 else:
     try:
-        from setproctitle import setproctitle
+        from setproctitle import setproctitle, getproctitle
+
+        # Force early initialization before any os.environ modifications
+        # (e.g. removing LISTEN_FDS in systemd socket activation)
+        # https://github.com/benoitc/gunicorn/issues/3430
+        getproctitle()
 
         def _setproctitle(title):
             setproctitle("gunicorn: %s" % title)


### PR DESCRIPTION
## Summary

- Force early setproctitle initialization by calling `getproctitle()` immediately after import
- Ensures setproctitle captures argv/environ memory layout before `systemd.listen_fds()` modifies the environment
- Without this fix, if `LISTEN_FDS` is the first environment variable, setproctitle fails silently

Fixes #3430