### PR TITLE
fix: passing maxsplit in re.split() as positional argument is deprecated

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -248,7 +248,7 @@ class Config:
         for e in raw_global_conf:
             s = util.bytes_to_str(e)
             try:
-                k, v = re.split(r'(?<!\\)=', s, 1)
+                k, v = re.split(r'(?<!\\)=', s, maxsplit=1)
             except ValueError:
                 raise RuntimeError("environment setting %r invalid" % s)
             k = k.replace('\\=', '=')


### PR DESCRIPTION
This has been deprecated in python 3.13 [source](https://docs.python.org/3/library/re.html#re.split)