### PR TITLE
docs: fix Markdown formatting in /configure

### DIFF
--- a/docs/content/configure.md
+++ b/docs/content/configure.md
@@ -15,18 +15,17 @@ only the file specified on the command line is used.
 !!! note
     Print the fully resolved configuration:
 
-bash
-gunicorn --print-config APP_MODULE
-```
+    ```bash
+    gunicorn --print-config APP_MODULE
+    ```
 
-Validate configuration and exit:
+    Validate configuration and exit:
 
-```bash
-gunicorn --check-config APP_MODULE
-```
+    ```bash
+    gunicorn --check-config APP_MODULE
+    ```
 
-This is also a quick way to confirm that your application can start.
-```
+    This is also a quick way to confirm that your application can start.
 
 ## Command line
 


### PR DESCRIPTION
Fixes https://github.com/benoitc/gunicorn/issues/3498.

Before:

<img width="1242" height="684" alt="before" src="https://github.com/user-attachments/assets/5ae3c3cd-b51d-47b3-9c36-3dd85c148b0d" />

After:

<img width="1271" height="779" alt="after" src="https://github.com/user-attachments/assets/9372987d-8992-46ba-9ed7-afc3ccc83810" />

