### PR TITLE
chore(logging): enrich request handling log line with request method

### DIFF
--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -257,7 +257,9 @@ class Worker:
             msg = "Invalid request from ip={ip}: {error}"
             self.log.warning(msg.format(ip=addr[0], error=str(exc)))
         else:
-            if hasattr(req, "uri"):
+            if hasattr(req, "uri") and hasattr(req, "method"):
+                self.log.exception("Error handling request %s %s", req.method, req.uri)
+            elif hasattr(req, "uri"):
                 self.log.exception("Error handling request %s", req.uri)
             else:
                 self.log.exception("Error handling request (no URI read)")


### PR DESCRIPTION
# Context & Motivation

Currently, when a request fails, the error logs only display the URI. While this identifies the endpoint, it lacks the context of the action being performed (e.g., distinguishing between a GET fetch and a DELETE operation).

Current Behavior:
```
Error handling request /v1/my-route
```

Therefore this PR adds the HTTP request method to the log line.

New Behavior:
```
Error handling request GET /v1/my-route
```