### PR TITLE
fix(http): decrement LengthReader.length by actual bytes read, not requested size

### DIFF
--- a/gunicorn/http/body.py
+++ b/gunicorn/http/body.py
@@ -138,7 +138,7 @@ class LengthReader:
         buf = buf.getvalue()
         ret, rest = buf[:size], buf[size:]
         self.unreader.unread(rest)
-        self.length -= size
+        self.length -= len(ret)
         return ret
 
 


### PR DESCRIPTION
`LengthReader.read()` decrements `self.length` by the requested `size` rather than the actual number of bytes returned:

```python
ret, rest = buf[:size], buf[size:]
self.unreader.unread(rest)
self.length -= size    # should be len(ret)
return ret
```

When the underlying reader returns fewer bytes than requested (slow client, premature connection close), `ret` is shorter than `size`, but `self.length` is still reduced by the full amount. This causes `self.length` to undercount the remaining bytes in the request body.

On keepalive connections (gthread and async workers), this can cause `parser.finish_body()` to stop draining the body too early, leaving unconsumed bytes on the socket that bleed into the next HTTP request's parsing.
