### PR TITLE
fix: prevent UnboundLocalError in sd_notify when socket creation fails

### DIFF
--- a/gunicorn/systemd.py
+++ b/gunicorn/systemd.py
@@ -61,6 +61,7 @@ def sd_notify(state, logger, unset_environment=False):
     if addr is None:
         # not run in a service, just a noop
         return
+    sock = None
     try:
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM | socket.SOCK_CLOEXEC)
         if addr[0] == '@':
@@ -72,4 +73,5 @@ def sd_notify(state, logger, unset_environment=False):
     finally:
         if unset_environment:
             os.environ.pop('NOTIFY_SOCKET')
-        sock.close()
+        if sock is not None:
+            sock.close()


### PR DESCRIPTION
If `socket.socket()` raises an exception in `sd_notify()` (e.g., resource exhaustion, permission denied), the `sock` variable is never assigned. The `finally` block unconditionally calls `sock.close()`, which raises `UnboundLocalError` — masking the original exception and potentially crashing the arbiter during startup or shutdown.

This initializes `sock = None` before the try block and guards the close call.
