### PR TITLE
fix: ensure pidfile fd is closed on rename failure

### DIFF
--- a/gunicorn/pidfile.py
+++ b/gunicorn/pidfile.py
@@ -33,12 +33,14 @@ class Pidfile:
         if fdir and not os.path.isdir(fdir):
             raise RuntimeError("%s doesn't exist. Can't create pidfile." % fdir)
         fd, fname = tempfile.mkstemp(dir=fdir)
-        os.write(fd, ("%s\n" % self.pid).encode('utf-8'))
-        if self.fname:
-            os.rename(fname, self.fname)
-        else:
-            self.fname = fname
-        os.close(fd)
+        try:
+            os.write(fd, ("%s\n" % self.pid).encode('utf-8'))
+            if self.fname:
+                os.rename(fname, self.fname)
+            else:
+                self.fname = fname
+        finally:
+            os.close(fd)
 
         # set permissions to -rw-r--r--
         os.chmod(self.fname, 420)


### PR DESCRIPTION
In `Pidfile.create()`, if `os.rename()` fails (cross-device, permissions, etc.), the file descriptor from `tempfile.mkstemp()` is never closed — `os.close(fd)` is placed after the rename without any try/finally protection.

On repeated failures during reload cycles, this accumulates leaked file descriptors. Wrapping the write+rename in try/finally ensures the fd is always closed.
