### PR TITLE
workers: drain unread request body before close to prevent TCP RST

### DIFF
--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -32,6 +32,7 @@ class AsyncWorker(base.Worker):
 
     def handle(self, listener, client, addr):
         req = None
+        parser = None
         try:
             # Complete the handshake to ensure ALPN negotiation is done
             # (needed if do_handshake_on_connect is False)
@@ -98,6 +99,14 @@ class AsyncWorker(base.Worker):
         except BaseException as e:
             self.handle_error(req, client, addr, e)
         finally:
+            # Drain unread request body to prevent RST on close.
+            # See: https://github.com/benoitc/gunicorn/issues/3334
+            if parser:
+                try:
+                    client.settimeout(1)
+                    parser.finish_body()
+                except Exception:
+                    pass
             util.close(client)
 
     def handle_http2(self, listener, client, addr):

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -443,6 +443,7 @@ class ThreadWorker(base.Worker):
     def handle(self, conn):
         """Handle a request on a connection. Runs in a worker thread."""
         req = None
+        drain = False
         try:
             # For new connections (not yet initialized), wait for data with timeout
             # to prevent slow clients from blocking thread pool slots indefinitely.
@@ -468,6 +469,7 @@ class ThreadWorker(base.Worker):
             if conn.is_http2:
                 return self.handle_http2(conn)
 
+            drain = True
             req = next(conn.parser)
             if not req:
                 return False
@@ -478,6 +480,7 @@ class ThreadWorker(base.Worker):
                 # Discard any unread request body before keepalive
                 # to prevent socket appearing readable due to leftover bytes
                 conn.parser.finish_body()
+                drain = False
                 return True
         except http.errors.NoMoreData as e:
             self.log.debug("Ignored premature client disconnection. %s", e)
@@ -502,6 +505,15 @@ class ThreadWorker(base.Worker):
                     self.log.debug("Ignoring connection epipe")
         except Exception as e:
             self.handle_error(req, conn.sock, conn.client, e)
+        finally:
+            # Drain unread request body to prevent RST on close.
+            # See: https://github.com/benoitc/gunicorn/issues/3334
+            if drain and hasattr(conn.parser, 'finish_body'):
+                try:
+                    conn.sock.settimeout(1)
+                    conn.parser.finish_body()
+                except Exception:
+                    pass
 
         return False
 

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -134,6 +134,7 @@ class SyncWorker(base.Worker):
 
     def handle(self, listener, client, addr):
         req = None
+        parser = None
         try:
             if self.cfg.is_ssl:
                 client = sock.ssl_wrap_socket(client, self.cfg)
@@ -164,6 +165,14 @@ class SyncWorker(base.Worker):
         except BaseException as e:
             self.handle_error(req, client, addr, e)
         finally:
+            # Drain unread request body to prevent RST on close.
+            # See: https://github.com/benoitc/gunicorn/issues/3334
+            if parser:
+                try:
+                    client.settimeout(1)
+                    parser.finish_body()
+                except Exception:
+                    pass
             util.close(client)
 
     def handle_request(self, listener, req, client, addr):

--- a/tests/test_drain_body.py
+++ b/tests/test_drain_body.py
@@ -1,0 +1,132 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+"""Tests for TCP RST prevention via request body draining (issue #3334)."""
+
+import os
+from unittest import mock
+
+from gunicorn.config import Config
+from gunicorn.workers import sync as sync_mod
+from gunicorn.workers import gthread
+from gunicorn.workers import base_async
+
+
+def _make_cfg(**overrides):
+    cfg = Config()
+    cfg.set('workers', 1)
+    cfg.set('threads', 1)
+    cfg.set('worker_connections', 100)
+    for key, value in overrides.items():
+        cfg.set(key, value)
+    return cfg
+
+
+def _make_worker(cls, cfg=None, **kwargs):
+    cfg = cfg or _make_cfg()
+    return cls(
+        age=1,
+        ppid=os.getpid(),
+        sockets=[],
+        app=mock.Mock(),
+        timeout=30,
+        cfg=cfg,
+        log=mock.Mock(),
+        **kwargs,
+    )
+
+
+class TestSyncDrainBody:
+    """Sync worker drains unread body before closing the socket."""
+
+    def test_finish_body_called_on_normal_close(self):
+        worker = _make_worker(sync_mod.SyncWorker)
+        client = mock.Mock()
+        parser = mock.Mock()
+
+        with mock.patch('gunicorn.workers.sync.http.get_parser', return_value=parser):
+            parser.__next__ = mock.Mock(side_effect=StopIteration)
+            worker.handle(mock.Mock(), client, ('127.0.0.1', 0))
+
+        client.settimeout.assert_called_with(1)
+        parser.finish_body.assert_called_once()
+
+    def test_finish_body_exception_suppressed(self):
+        worker = _make_worker(sync_mod.SyncWorker)
+        client = mock.Mock()
+        parser = mock.Mock()
+        parser.finish_body.side_effect = OSError("read failed")
+
+        with mock.patch('gunicorn.workers.sync.http.get_parser', return_value=parser):
+            parser.__next__ = mock.Mock(side_effect=StopIteration)
+            # Should not raise
+            worker.handle(mock.Mock(), client, ('127.0.0.1', 0))
+
+        parser.finish_body.assert_called_once()
+
+
+class TestGthreadDrainBody:
+    """Gthread worker drains unread body before closing the socket."""
+
+    def _make_conn(self):
+        conn = mock.Mock()
+        conn.initialized = True
+        conn.data_ready = False
+        conn.is_http2 = False
+        conn.client = ('127.0.0.1', 0)
+        conn.sock = mock.Mock()
+        conn.parser = mock.Mock()
+        conn.parser.__next__ = mock.Mock(side_effect=StopIteration)
+        return conn
+
+    def test_finish_body_called_on_normal_close(self):
+        worker = _make_worker(gthread.ThreadWorker)
+        conn = self._make_conn()
+
+        worker.handle(conn)
+
+        conn.sock.settimeout.assert_called_with(1)
+        conn.parser.finish_body.assert_called_once()
+
+    def test_finish_body_exception_suppressed(self):
+        worker = _make_worker(gthread.ThreadWorker)
+        conn = self._make_conn()
+        conn.parser.finish_body.side_effect = OSError("read failed")
+
+        # Should not raise
+        result = worker.handle(conn)
+
+        assert result is False
+        conn.parser.finish_body.assert_called_once()
+
+
+class TestAsyncDrainBody:
+    """Async worker drains unread body before closing the socket."""
+
+    def test_finish_body_called_on_normal_close(self):
+        cfg = _make_cfg(keepalive=0)
+        worker = _make_worker(base_async.AsyncWorker, cfg=cfg)
+        client = mock.Mock()
+        parser = mock.Mock()
+
+        with mock.patch('gunicorn.workers.base_async.http.get_parser', return_value=parser):
+            parser.__next__ = mock.Mock(side_effect=StopIteration)
+            worker.handle(mock.Mock(), client, ('127.0.0.1', 0))
+
+        client.settimeout.assert_called_with(1)
+        parser.finish_body.assert_called_once()
+
+    def test_finish_body_exception_suppressed(self):
+        cfg = _make_cfg(keepalive=0)
+        worker = _make_worker(base_async.AsyncWorker, cfg=cfg)
+        client = mock.Mock()
+        parser = mock.Mock()
+        parser.finish_body.side_effect = OSError("read failed")
+
+        with mock.patch('gunicorn.workers.base_async.http.get_parser', return_value=parser):
+            parser.__next__ = mock.Mock(side_effect=StopIteration)
+            # Should not raise
+            worker.handle(mock.Mock(), client, ('127.0.0.1', 0))
+
+        parser.finish_body.assert_called_once()


### PR DESCRIPTION
When keep-alive is disabled and a WSGI app does not consume the full request body, closing the socket with unread data in the receive buffer triggers the kernel to send a TCP RST instead of a graceful FIN. This prematurely aborts the connection, often causing clients to encounter a ConnectionResetError before they can finish reading the response.

This change unifies the close path with the keep-alive path by calling parser.finish_body() to drain the remaining request data in the finally block of sync, base_async, and gthread workers.

To prevent worker exhaustion from slow-reading or malicious clients, a 1-second timeout is enforced during this drain. This ensures the worker moves to the next task while still providing a window for a graceful TCP shutdown.

Fixes #3334