### PR TITLE
Fix false error logs for non-worker child processes in reap_workers

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -613,9 +613,24 @@ class Arbiter:
                     # and should not be reported as worker errors.
                     worker = self.WORKERS.pop(wpid, None)
                     if not worker:
-                        self.log.debug(
-                            "Reaped unknown child process (pid:%s, "
-                            "status:%s). Not a gunicorn worker.", wpid, status)
+                        if os.WIFEXITED(status):
+                            self.log.debug(
+                                "Reaped non-worker child (pid:%s) "
+                                "exited with code %s.", wpid,
+                                os.WEXITSTATUS(status))
+                        elif os.WIFSIGNALED(status):
+                            sig = os.WTERMSIG(status)
+                            try:
+                                sig_name = signal.Signals(sig).name
+                            except ValueError:
+                                sig_name = "signal {}".format(sig)
+                            self.log.debug(
+                                "Reaped non-worker child (pid:%s) "
+                                "received %s.", wpid, sig_name)
+                        else:
+                            self.log.debug(
+                                "Reaped non-worker child (pid:%s, "
+                                "status:%s).", wpid, status)
                         continue
 
                     # A worker was terminated. If the termination reason was

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -606,6 +606,18 @@ class Arbiter:
                 if self.reexec_pid == wpid:
                     self.reexec_pid = 0
                 else:
+                    # Check if this is a known worker process first.
+                    # When running as PID 1 (e.g. in containers), the
+                    # arbiter inherits orphaned child processes and reaps
+                    # them via waitpid(-1). These are not gunicorn workers
+                    # and should not be reported as worker errors.
+                    worker = self.WORKERS.pop(wpid, None)
+                    if not worker:
+                        self.log.debug(
+                            "Reaped unknown child process (pid:%s, "
+                            "status:%s). Not a gunicorn worker.", wpid, status)
+                        continue
+
                     # A worker was terminated. If the termination reason was
                     # that it could not boot, we'll shut it down to avoid
                     # infinite start/stop cycles.
@@ -643,9 +655,6 @@ class Arbiter:
                         reason = "App failed to load."
                         raise HaltServer(reason, self.APP_LOAD_ERROR)
 
-                    worker = self.WORKERS.pop(wpid, None)
-                    if not worker:
-                        continue
                     worker.tmp.close()
                     self.cfg.child_exit(self, worker)
         except OSError as e:

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -432,6 +432,75 @@ class TestReapWorkers:
         log_messages = ' '.join(str(call) for call in mock_log.call_args_list)
         assert 'out of memory' in log_messages.lower()
 
+    @mock.patch('os.waitpid')
+    def test_reap_non_worker_child_no_error_log(self, mock_waitpid):
+        """Verify that non-worker child processes are reaped silently.
+
+        When gunicorn runs as PID 1 (e.g. in containers), it inherits
+        orphaned child processes. These should be reaped to prevent
+        zombies but must not be reported as worker errors.
+        """
+        # pid 30740 exits with code 23 (status = 23 << 8 = 5888)
+        # but is NOT in WORKERS dict
+        mock_waitpid.side_effect = [(30740, 23 << 8), (0, 0)]
+
+        arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
+        arbiter.cfg.settings['child_exit'] = mock.Mock()
+        arbiter.WORKERS = {}  # no workers registered
+
+        with mock.patch.object(arbiter.log, 'error') as mock_error, \
+             mock.patch.object(arbiter.log, 'debug') as mock_debug:
+            arbiter.reap_workers()
+
+        # Should NOT log any error
+        mock_error.assert_not_called()
+        # Should log at debug level
+        assert any('30740' in str(call) for call in mock_debug.call_args_list)
+        # child_exit should NOT be called for non-worker processes
+        arbiter.cfg.child_exit.assert_not_called()
+
+    @mock.patch('os.waitpid')
+    def test_reap_non_worker_child_with_signal_no_error_log(self, mock_waitpid):
+        """Verify that non-worker child killed by signal is not reported."""
+        # pid 12345 killed by SIGKILL, but not a worker
+        mock_waitpid.side_effect = [(12345, signal.SIGKILL), (0, 0)]
+
+        arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
+        arbiter.cfg.settings['child_exit'] = mock.Mock()
+        arbiter.WORKERS = {}
+
+        with mock.patch.object(arbiter.log, 'error') as mock_error:
+            arbiter.reap_workers()
+
+        # Should NOT log OOM hint or any error for non-worker
+        mock_error.assert_not_called()
+
+    @mock.patch('os.waitpid')
+    def test_reap_mixed_worker_and_non_worker(self, mock_waitpid):
+        """Verify correct handling when both worker and non-worker exit."""
+        # First: non-worker pid 99999 with error exit
+        # Second: real worker pid 42 with normal exit
+        mock_waitpid.side_effect = [
+            (99999, 1 << 8),  # non-worker, exit code 1
+            (42, 0),          # real worker, normal exit
+            (0, 0),           # end
+        ]
+
+        arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
+        arbiter.cfg.settings['child_exit'] = mock.Mock()
+        mock_worker = mock.Mock()
+        arbiter.WORKERS = {42: mock_worker}
+
+        with mock.patch.object(arbiter.log, 'error') as mock_error:
+            arbiter.reap_workers()
+
+        # Should NOT log error for pid 99999
+        assert not any('99999' in str(call) for call in mock_error.call_args_list)
+        # Worker 42 should be properly cleaned up
+        mock_worker.tmp.close.assert_called_once()
+        arbiter.cfg.child_exit.assert_called_once_with(arbiter, mock_worker)
+        assert 42 not in arbiter.WORKERS
+
 
 # ============================================================================
 # SIGHUP Reload Tests

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -434,7 +434,8 @@ class TestReapWorkers:
 
     @mock.patch('os.waitpid')
     def test_reap_non_worker_child_no_error_log(self, mock_waitpid):
-        """Verify that non-worker child processes are reaped silently.
+        """Verify that non-worker child processes are reaped with
+        exit status details at DEBUG level, not as worker errors.
 
         When gunicorn runs as PID 1 (e.g. in containers), it inherits
         orphaned child processes. These should be reaped to prevent
@@ -454,14 +455,17 @@ class TestReapWorkers:
 
         # Should NOT log any error
         mock_error.assert_not_called()
-        # Should log at debug level
-        assert any('30740' in str(call) for call in mock_debug.call_args_list)
+        # Should log exit code at debug level
+        debug_messages = ' '.join(str(call) for call in mock_debug.call_args_list)
+        assert '30740' in debug_messages
+        assert 'exited with code' in debug_messages
         # child_exit should NOT be called for non-worker processes
         arbiter.cfg.child_exit.assert_not_called()
 
     @mock.patch('os.waitpid')
     def test_reap_non_worker_child_with_signal_no_error_log(self, mock_waitpid):
-        """Verify that non-worker child killed by signal is not reported."""
+        """Verify that non-worker child killed by signal logs details
+        at DEBUG level but not as a worker error."""
         # pid 12345 killed by SIGKILL, but not a worker
         mock_waitpid.side_effect = [(12345, signal.SIGKILL), (0, 0)]
 
@@ -469,11 +473,16 @@ class TestReapWorkers:
         arbiter.cfg.settings['child_exit'] = mock.Mock()
         arbiter.WORKERS = {}
 
-        with mock.patch.object(arbiter.log, 'error') as mock_error:
+        with mock.patch.object(arbiter.log, 'error') as mock_error, \
+             mock.patch.object(arbiter.log, 'debug') as mock_debug:
             arbiter.reap_workers()
 
         # Should NOT log OOM hint or any error for non-worker
         mock_error.assert_not_called()
+        # Should log signal details at debug level
+        debug_messages = ' '.join(str(call) for call in mock_debug.call_args_list)
+        assert '12345' in debug_messages
+        assert 'SIGKILL' in debug_messages
 
     @mock.patch('os.waitpid')
     def test_reap_mixed_worker_and_non_worker(self, mock_waitpid):


### PR DESCRIPTION
## Summary

When gunicorn runs as PID 1 in a container (common in Docker/ECS/Kubernetes without `tini` or `dumb-init`), `reap_workers()` emits false ERROR logs for non-worker child processes reaped via `waitpid(-1)`.

This PR moves the `WORKERS` membership check **before** exit status logging, so that non-worker processes are reaped silently at DEBUG level while real worker exits continue to be reported as errors.

## Problem

`reap_workers()` calls `os.waitpid(-1)`, which reaps **any** terminated child process. When gunicorn is PID 1, orphaned child processes are reparented to it by the kernel. Upon termination, these non-worker processes are reaped and incorrectly logged as:

```
[ERROR] Worker (pid:30740) exited with code 23
```

This triggers false alerts in error tracking systems (e.g. Sentry).

### Current code flow

```
waitpid(-1) -> get exit code -> log ERROR -> check if worker -> skip if not worker
```

The error log fires **before** the worker membership check, so every non-worker child with a non-zero exit code produces a spurious error.

## Evidence from production

**Environment:** AWS ECS Fargate, gunicorn 21.2.0, Python 3.11, Django backend

**Observed:**
- Sentry captured `Worker (pid:30740) exited with code 23` from `gunicorn.error` logger
- CloudWatch log analysis showed only 3 active workers in the container: pid 40, 41, 42 (matching `--workers 3`)
- **Zero** application logs from pid 30740 — it was never a gunicorn worker
- **Zero** `Booting worker` logs for pid 30740
- `max_requests` was not configured, ruling out worker recycling
- All 3 real workers continued processing requests normally before and after the event
- The error was a single occurrence over 7 days — a non-worker child process reaped by PID 1

## Fix

Move the `WORKERS.pop(wpid)` check to the top of the else branch:

```python
worker = self.WORKERS.pop(wpid, None)
if not worker:
    self.log.debug(
        "Reaped unknown child process (pid:%s, status:%s). "
        "Not a gunicorn worker.", wpid, status)
    continue

# Only report exit status for actual workers
exitcode = ...
```

**What stays the same:**
- `waitpid(-1)` is preserved — PID 1 must reap all children to prevent zombies
- Worker error reporting, `HaltServer` on boot/load errors, signal logging — all unchanged
- `child_exit` hook only fires for real workers (same as before)

**What changes:**
- Non-worker child processes are logged at DEBUG instead of ERROR
- No false alerts in monitoring systems

## Tests added

- `test_reap_non_worker_child_no_error_log` — non-worker exit with error code produces no ERROR log
- `test_reap_non_worker_child_with_signal_no_error_log` — non-worker killed by SIGKILL produces no OOM error
- `test_reap_mixed_worker_and_non_worker` — mixed scenario: non-worker is silent, real worker is reported

All existing tests pass (1671 passed, 214 skipped).

## Design note: why DEBUG instead of suppressing entirely

A question that may come up: is it safe to silently reap unknown child processes?

First, `waitpid` does not kill anything — it reaps an **already terminated** process from the kernel's process table. The three options are:

| Approach | Result |
|----------|--------|
| Don't reap | Zombie accumulates in process table (worse) |
| Reap + ERROR log | Zombie prevented, but false alert (current behavior) |
| Reap + DEBUG log | Zombie prevented, no false alert, still traceable (this PR) |

DEBUG was chosen over complete suppression so that operators can still trace unexpected child processes when needed (e.g. `--log-level debug`). This preserves observability without generating noise at the default log level.

The reaping itself is not optional — as PID 1, gunicorn **must** call `waitpid` for all children, whether it spawned them or not. This is standard POSIX behavior: the kernel reparents orphaned processes to init (PID 1), and init is responsible for reaping them.

## Related issues

- #3220 — Workers that are not supposed to exist exit with code 255
- #1585 — Proposed checking all worker pids instead of every child (closed, not merged)

This PR takes a simpler approach than #1585: rather than changing `waitpid(-1)` to per-pid `waitpid`, it keeps the reaping behavior intact and only fixes the log level for non-worker processes.
