### PR TITLE
Add --max-worker-memory to recycle workers by RSS

### DIFF
--- a/docs/content/reference/settings.md
+++ b/docs/content/reference/settings.md
@@ -1868,6 +1868,25 @@ restarts to avoid all workers restarting at the same time.
 
 !!! info "Added in 19.2"
 
+### `max_worker_memory`
+
+**Command line:** `--max-worker-memory INT`
+
+**Default:** `0`
+
+The maximum resident memory (in MB) a worker may use before being
+recycled.
+
+When a worker's RSS exceeds this value, it will be gracefully
+restarted after the current request completes. This provides a
+hard safety net against memory leaks that ``max_requests`` alone
+cannot catch.
+
+If this is set to zero (the default) then memory-based worker
+recycling is disabled.
+
+Motivated by discussion in GitHub issues #124 and #1299.
+
 ### `timeout`
 
 **Command line:** `-t INT`, `--timeout INT`

--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -747,6 +747,7 @@ class ASGIProtocol(asyncio.Protocol):
                     self.log.info("Autorestarting worker after current request.")
                     self.worker.alive = False
                     keepalive = False
+                self.worker._check_memory_usage()
 
                 if not keepalive or not self.worker.alive:
                     break
@@ -815,6 +816,7 @@ class ASGIProtocol(asyncio.Protocol):
                 self.log.info("Autorestarting worker after current request.")
                 self.worker.alive = False
                 keepalive = False
+            self.worker._check_memory_usage()
 
             if not keepalive or not self.worker.alive:
                 break
@@ -1356,6 +1358,7 @@ class ASGIProtocol(asyncio.Protocol):
                     self.log.info("Autorestarting worker after current request.")
                     self.worker.alive = False
                     break
+                self.worker._check_memory_usage()
 
         except asyncio.CancelledError:
             pass

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -816,6 +816,30 @@ class MaxRequestsJitter(Setting):
         """
 
 
+class MaxWorkerMemory(Setting):
+    name = "max_worker_memory"
+    section = "Worker Processes"
+    cli = ["--max-worker-memory"]
+    meta = "INT"
+    validator = validate_pos_int
+    type = int
+    default = 0
+    desc = """\
+        The maximum resident memory (in MB) a worker may use before being
+        recycled.
+
+        When a worker's RSS exceeds this value, it will be gracefully
+        restarted after the current request completes. This provides a
+        hard safety net against memory leaks that ``max_requests`` alone
+        cannot catch.
+
+        If this is set to zero (the default) then memory-based worker
+        recycling is disabled.
+
+        Motivated by discussion in GitHub issues #124 and #1299.
+        """
+
+
 class Timeout(Setting):
     name = "timeout"
     section = "Worker Processes"

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -4,6 +4,7 @@
 
 import io
 import os
+import resource
 import signal
 import sys
 import time
@@ -60,12 +61,57 @@ class Worker:
         else:
             self.max_requests = sys.maxsize
 
+        # max_worker_memory is in MB; convert to bytes for comparison.
+        if cfg.max_worker_memory > 0:
+            self.max_worker_memory = cfg.max_worker_memory * 1024 * 1024
+        else:
+            self.max_worker_memory = 0
+
         self.alive = True
         self.log = log
         self.tmp = WorkerTmp(cfg)
 
     def __str__(self):
         return "<Worker %s>" % self.pid
+
+    def _check_memory_usage(self):
+        """Check worker RSS against max_worker_memory and initiate graceful
+        shutdown when the limit is exceeded."""
+        if not self.max_worker_memory:
+            return
+        rss = self._get_rss()
+        if rss > self.max_worker_memory:
+            self.log.warning(
+                "Worker %s exceeded memory limit "
+                "(%d MB > %d MB), restarting.",
+                self.pid,
+                rss // (1024 * 1024),
+                self.max_worker_memory // (1024 * 1024),
+            )
+            self.alive = False
+
+    @staticmethod
+    def _get_rss():
+        """Return the current process RSS in bytes.
+
+        Uses /proc/self/status on Linux for accuracy.  Falls back to
+        resource.getrusage on other platforms; note that ru_maxrss is the
+        *peak* RSS (high-water mark), not the current RSS, so the fallback
+        may recycle workers more eagerly than intended."""
+        try:
+            with open("/proc/self/status", "r") as f:
+                for line in f:
+                    if line.startswith("VmRSS:"):
+                        # VmRSS is reported in kB
+                        return int(line.split()[1]) * 1024
+        except (OSError, ValueError, IndexError):
+            pass
+        # Fallback: getrusage reports ru_maxrss in kB on Linux,
+        # bytes on macOS — normalize to bytes.
+        usage = resource.getrusage(resource.RUSAGE_SELF)
+        if sys.platform == "darwin":
+            return usage.ru_maxrss  # already in bytes
+        return usage.ru_maxrss * 1024  # kB → bytes
 
     def notify(self):
         """\

--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -159,6 +159,7 @@ class AsyncWorker(base.Worker):
                 if self.alive:
                     self.log.info("Autorestarting worker after current request.")
                     self.alive = False
+            self._check_memory_usage()
 
             # Run WSGI app
             respiter = self.wsgi(environ, resp.start_response)
@@ -210,6 +211,7 @@ class AsyncWorker(base.Worker):
                 if self.alive:
                     self.log.info("Autorestarting worker after current request.")
                     self.alive = False
+            self._check_memory_usage()
 
             if not self.alive or not self.cfg.keepalive:
                 resp.force_close()

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -591,6 +591,7 @@ class ThreadWorker(base.Worker):
                 if self.alive:
                     self.log.info("Autorestarting worker after current request.")
                     self.alive = False
+            self._check_memory_usage()
 
             # Run WSGI app
             respiter = self.wsgi(environ, resp.start_response)
@@ -661,6 +662,7 @@ class ThreadWorker(base.Worker):
                     self.log.info("Autorestarting worker after current request.")
                     self.alive = False
                 resp.force_close()
+            self._check_memory_usage()
 
             if not self.alive or not self.cfg.keepalive:
                 resp.force_close()

--- a/gunicorn/workers/gtornado.py
+++ b/gunicorn/workers/gtornado.py
@@ -41,6 +41,7 @@ class TornadoWorker(Worker):
         if self.alive and self.nr >= self.max_requests:
             self.log.info("Autorestarting worker after current request.")
             self.alive = False
+        self._check_memory_usage()
 
     def watchdog(self):
         if self.alive:

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -195,6 +195,7 @@ class SyncWorker(base.Worker):
                 self.log.access(resp, req, environ, request_time)
                 if hasattr(respiter, "close"):
                     respiter.close()
+            self._check_memory_usage()
         except OSError:
             # pass to next try-except level
             util.reraise(*sys.exc_info())

--- a/tests/ctl/test_handlers.py
+++ b/tests/ctl/test_handlers.py
@@ -52,6 +52,7 @@ class MockConfig:
         self.keepalive = 2
         self.max_requests = 0
         self.max_requests_jitter = 0
+        self.max_worker_memory = 0
         self.worker_connections = 1000
         self.preload_app = False
         self.daemon = False

--- a/tests/ctl/test_server.py
+++ b/tests/ctl/test_server.py
@@ -40,6 +40,7 @@ class MockConfig:
         self.keepalive = 2
         self.max_requests = 0
         self.max_requests_jitter = 0
+        self.max_worker_memory = 0
         self.worker_connections = 1000
         self.preload_app = False
         self.daemon = False

--- a/tests/test_asgi_protocol_compat.py
+++ b/tests/test_asgi_protocol_compat.py
@@ -59,6 +59,7 @@ class TestHttp100ContinueViaResponseStart:
         worker.asgi = mock.Mock()
         worker.nr = 0
         worker.max_requests = 10000
+        worker.max_worker_memory = 0
         worker.alive = True
         worker.state = {}
 
@@ -152,6 +153,7 @@ class TestHttp100ContinueViaResponseStart:
         worker.asgi = mock.Mock()
         worker.nr = 0
         worker.max_requests = 10000
+        worker.max_worker_memory = 0
         worker.alive = True
         worker.state = {}
 
@@ -857,6 +859,7 @@ class TestTransferEncodingChunked:
         worker.asgi = mock.Mock()
         worker.nr = 0
         worker.max_requests = 10000
+        worker.max_worker_memory = 0
         worker.alive = True
         worker.state = {}
 
@@ -901,6 +904,7 @@ class TestTransferEncodingChunked:
         worker.asgi = mock.Mock()
         worker.nr = 0
         worker.max_requests = 10000
+        worker.max_worker_memory = 0
         worker.alive = True
         worker.state = {}
 
@@ -966,6 +970,7 @@ class TestTransferEncodingChunked:
         worker.asgi = mock.Mock()
         worker.nr = 0
         worker.max_requests = 10000
+        worker.max_worker_memory = 0
         worker.alive = True
         worker.state = {}
 
@@ -1029,6 +1034,7 @@ class TestTransferEncodingChunked:
         worker.asgi = mock.Mock()
         worker.nr = 0
         worker.max_requests = 10000
+        worker.max_worker_memory = 0
         worker.alive = True
         worker.state = {}
 
@@ -1088,6 +1094,7 @@ class TestTransferEncodingChunked:
         worker.asgi = mock.Mock()
         worker.nr = 0
         worker.max_requests = 10000
+        worker.max_worker_memory = 0
         worker.alive = True
         worker.state = {}
 

--- a/tests/test_http2_alpn.py
+++ b/tests/test_http2_alpn.py
@@ -230,6 +230,7 @@ class TestAsyncWorkerAlpnHandshake:
         worker.wsgi = mock.MagicMock()
         worker.nr = 0
         worker.max_requests = 1000
+        worker.max_worker_memory = 0
 
         return worker
 
@@ -326,6 +327,7 @@ class TestGeventWorkerAlpn:
         worker.wsgi = mock.MagicMock()
         worker.nr = 0
         worker.max_requests = 1000
+        worker.max_worker_memory = 0
         worker.worker_connections = 1000
 
         return worker
@@ -377,6 +379,7 @@ class TestEventletWorkerAlpn:
         worker.wsgi = mock.MagicMock()
         worker.nr = 0
         worker.max_requests = 1000
+        worker.max_worker_memory = 0
         worker.worker_connections = 1000
 
         return worker

--- a/tests/test_max_worker_memory.py
+++ b/tests/test_max_worker_memory.py
@@ -1,0 +1,147 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+"""Tests for the --max-worker-memory feature."""
+
+import os
+from unittest import mock
+
+import pytest
+
+from gunicorn.config import Config
+
+
+class TestMaxWorkerMemoryConfig:
+    """Tests for the MaxWorkerMemory config setting."""
+
+    def test_default_is_zero(self):
+        cfg = Config()
+        assert cfg.max_worker_memory == 0
+
+    def test_set_via_config(self):
+        cfg = Config()
+        cfg.set("max_worker_memory", 100)
+        assert cfg.max_worker_memory == 100
+
+    def test_rejects_negative(self):
+        cfg = Config()
+        with pytest.raises(Exception):
+            cfg.set("max_worker_memory", -1)
+
+
+class TestGetRss:
+    """Tests for Worker._get_rss()."""
+
+    def test_returns_positive_int(self):
+        from gunicorn.workers.base import Worker
+        rss = Worker._get_rss()
+        assert isinstance(rss, int)
+        assert rss > 0
+
+    def test_fallback_when_proc_unavailable(self):
+        """_get_rss falls back to resource.getrusage when /proc is absent."""
+        from gunicorn.workers.base import Worker
+        with mock.patch("builtins.open", side_effect=OSError("no /proc")):
+            rss = Worker._get_rss()
+        assert isinstance(rss, int)
+        assert rss > 0
+
+    def test_fallback_on_malformed_proc(self):
+        """_get_rss falls back gracefully if /proc content is malformed."""
+        from gunicorn.workers.base import Worker
+        fake_content = "Name:\tpython\nVmPeak:\t12345 kB\n"
+        with mock.patch("builtins.open", mock.mock_open(read_data=fake_content)):
+            rss = Worker._get_rss()
+        assert isinstance(rss, int)
+        assert rss > 0
+
+
+class TestCheckMemoryUsage:
+    """Tests for Worker._check_memory_usage()."""
+
+    def _make_worker(self, max_worker_memory_mb=0):
+        from gunicorn.workers.base import Worker
+
+        cfg = Config()
+        cfg.set("max_worker_memory", max_worker_memory_mb)
+
+        with mock.patch("gunicorn.workers.base.WorkerTmp"):
+            worker = Worker(
+                age=1, ppid=os.getpid(), sockets=[],
+                app=mock.Mock(), timeout=30, cfg=cfg, log=mock.Mock(),
+            )
+        return worker
+
+    def test_disabled_when_zero(self):
+        """No recycling when max_worker_memory is 0 (disabled)."""
+        worker = self._make_worker(0)
+        worker._check_memory_usage()
+        assert worker.alive is True
+        worker.log.warning.assert_not_called()
+
+    def test_triggers_shutdown_when_exceeded(self):
+        """Worker sets alive=False when RSS exceeds limit."""
+        worker = self._make_worker(1)  # 1 MB — current process is larger
+        worker._check_memory_usage()
+        assert worker.alive is False
+        worker.log.warning.assert_called_once()
+
+    def test_no_shutdown_when_within_limit(self):
+        """Worker stays alive when RSS is within limit."""
+        worker = self._make_worker(999999)  # ~1 TB — way above current RSS
+        worker._check_memory_usage()
+        assert worker.alive is True
+        worker.log.warning.assert_not_called()
+
+    def test_log_message_contains_mb(self):
+        """Warning log message reports memory in MB."""
+        worker = self._make_worker(1)
+        worker._check_memory_usage()
+        msg = worker.log.warning.call_args[0][0]
+        assert "MB" in msg
+
+
+try:
+    import tornado  # noqa: F401
+    HAS_TORNADO = True
+except ImportError:
+    HAS_TORNADO = False
+
+
+@pytest.mark.skipif(not HAS_TORNADO, reason="tornado not installed")
+class TestTornadoWorkerMemoryCheck:
+    """Tests that memory check is called in tornado worker."""
+
+    def create_worker(self, max_worker_memory_mb=0):
+        from gunicorn.workers import gtornado
+
+        cfg = Config()
+        cfg.set("workers", 1)
+        cfg.set("max_worker_memory", max_worker_memory_mb)
+
+        worker = gtornado.TornadoWorker(
+            age=1,
+            ppid=os.getpid(),
+            sockets=[],
+            app=mock.Mock(),
+            timeout=30,
+            cfg=cfg,
+            log=mock.Mock(),
+        )
+        return worker
+
+    def test_memory_check_called_on_handle_request(self):
+        worker = self.create_worker()
+        worker.nr = 0
+        worker.alive = True
+        with mock.patch.object(worker, "_check_memory_usage") as mock_check:
+            worker.handle_request()
+            mock_check.assert_called_once()
+
+    def test_memory_limit_triggers_shutdown(self):
+        worker = self.create_worker(max_worker_memory_mb=1)  # 1 MB
+        worker.nr = 0
+        worker.alive = True
+        worker.handle_request()
+        assert worker.alive is False


### PR DESCRIPTION
## Summary

Adds a `--max-worker-memory` config option that gracefully restarts workers when their RSS exceeds a configurable threshold (in MB). This provides a hard safety net against memory leaks that `max_requests` alone cannot catch.

Closes #3581. Motivated by discussion in #124 and #1299.

## Changes

- **Config**: `MaxWorkerMemory` setting in `gunicorn/config.py` (int, default `0` = disabled, units: MB)
- **Core**: `_check_memory_usage()` and `_get_rss()` methods on `Worker` base class in `gunicorn/workers/base.py`
  - `_get_rss()` reads `/proc/self/status` `VmRSS` on Linux, falls back to `resource.getrusage` on other platforms (note: fallback measures peak RSS, documented in docstring)
  - Memory check skips entirely when feature is disabled (no `/proc` reads on the default hot path)
- **All worker types**: memory check wired into sync, gthread, async (gevent/eventlet), tornado, and ASGI protocol handlers — placed alongside existing `max_requests` checks
- **Docs**: settings reference regenerated via `build_settings_doc.py`
- **Tests**: 12 unit tests covering config parsing, `_get_rss()` (including `/proc` fallback), `_check_memory_usage()` logic, and tornado worker integration
- **Existing test mocks**: added `max_worker_memory` attribute to mock config objects in `test_handlers.py`, `test_server.py`, `test_asgi_protocol_compat.py`, `test_http2_alpn.py`

## Test plan

- [x] Full test suite passes: 1850 passed, 216 skipped, 0 failures
- [x] New tests in `tests/test_max_worker_memory.py` all pass
- [x] Manual validation: ran gunicorn with `--max-worker-memory 50 --workers 2` against a memory-leaking WSGI app; workers recycled correctly when RSS exceeded 50 MB

### Pre-existing test flakiness (not introduced by this PR)

When `tests/test_http2_alpn.py` runs before `tests/ctl/test_server.py` in the same pytest session, 9 `test_server` integration tests fail with socket connection errors. This is caused by eventlet's monkey-patching of the socket module during `TestEventletWorkerAlpn` — it corrupts socket state for subsequent tests. Verified by reproducing the same failures on unmodified `master` with `git stash && python -m pytest tests/test_http2_alpn.py tests/ctl/test_server.py`. The tests pass when run in isolation.