### PR TITLE
Add `buf_read_size` setting for WSGI configurable request body buffering

### DIFF
--- a/docs/content/reference/settings.md
+++ b/docs/content/reference/settings.md
@@ -1286,6 +1286,25 @@ If not set, the default temporary directory will be used.
     See [blocking-os-fchmod](#blocking_os_fchmod) for more detailed information
     and a solution for avoiding this problem.
 
+### `buf_read_size`
+
+**Command line:** `--buf-read-size INT`
+
+**Default:** `1024`
+
+Buffer size for reading request data from the socket.
+
+This controls the block size used while buffering request bodies for
+``wsgi.input``. Larger values can reduce Python loop overhead for large
+requests, while smaller values keep per-request buffering tighter.
+
+!!! note
+    Benchmarks show that, with WSGI workers, increased values up to
+    64 kB can improve bandwidth performance when transferring
+    large bodies, typically larger than 5 MB.
+
+The value must be greater than zero.
+
 ### `user`
 
 **Command line:** `-u USER`, `--user USER`

--- a/docs/content/reference/settings.md
+++ b/docs/content/reference/settings.md
@@ -1286,9 +1286,9 @@ If not set, the default temporary directory will be used.
     See [blocking-os-fchmod](#blocking_os_fchmod) for more detailed information
     and a solution for avoiding this problem.
 
-### `buf_read_size`
+### `wsgi_input_block_size`
 
-**Command line:** `--buf-read-size INT`
+**Command line:** `--wsgi-input-block-size INT`
 
 **Default:** `1024`
 
@@ -1298,12 +1298,12 @@ This controls the block size used while buffering request bodies for
 ``wsgi.input``. Larger values can reduce Python loop overhead for large
 requests, while smaller values keep per-request buffering tighter.
 
+The value must be greater than zero and at most 32 MB (33554432).
+
 !!! note
     Benchmarks show that, with WSGI workers, increased values up to
     64 kB can improve bandwidth performance when transferring
     large bodies, typically larger than 5 MB.
-
-The value must be greater than zero.
 
 ### `user`
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -389,6 +389,17 @@ def validate_pos_int(val):
     return val
 
 
+def validate_strict_pos_int(val):
+    if not isinstance(val, int):
+        val = int(val, 0)
+    else:
+        # Booleans are ints!
+        val = int(val)
+    if val <= 0:
+        raise ValueError("Value must be greater than zero: %s" % val)
+    return val
+
+
 def validate_http2_frame_size(val):
     """Validate HTTP/2 max frame size per RFC 7540."""
     if not isinstance(val, int):
@@ -1189,6 +1200,30 @@ class WorkerTmpDir(Setting):
 
            See :ref:`blocking-os-fchmod` for more detailed information
            and a solution for avoiding this problem.
+        """
+
+
+class BufReadSize(Setting):
+    name = "buf_read_size"
+    section = "Server Mechanics"
+    cli = ["--buf-read-size"]
+    meta = "INT"
+    validator = validate_strict_pos_int
+    type = int
+    default = 1024
+    desc = """\
+        Buffer size for reading request data from the socket.
+
+        This controls the block size used while buffering request bodies for
+        ``wsgi.input``. Larger values can reduce Python loop overhead for large
+        requests, while smaller values keep per-request buffering tighter.
+
+        .. note::
+              Benchmarks show that, with WSGI workers, increased values up to
+              64 kB can improve bandwidth performance when transferring
+              large bodies, typically larger than 5 MB.
+
+        The value must be greater than zero.
         """
 
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -400,6 +400,13 @@ def validate_strict_pos_int(val):
     return val
 
 
+def validate_wsgi_input_block_size(val):
+    val = validate_strict_pos_int(val)
+    if val > 32 * 1024 * 1024:
+        raise ValueError("Value must not exceed 32 MB (33554432): %s" % val)
+    return val
+
+
 def validate_http2_frame_size(val):
     """Validate HTTP/2 max frame size per RFC 7540."""
     if not isinstance(val, int):
@@ -1203,12 +1210,12 @@ class WorkerTmpDir(Setting):
         """
 
 
-class BufReadSize(Setting):
-    name = "buf_read_size"
+class WsgiInputBlockSize(Setting):
+    name = "wsgi_input_block_size"
     section = "Server Mechanics"
-    cli = ["--buf-read-size"]
+    cli = ["--wsgi-input-block-size"]
     meta = "INT"
-    validator = validate_strict_pos_int
+    validator = validate_wsgi_input_block_size
     type = int
     default = 1024
     desc = """\
@@ -1218,12 +1225,12 @@ class BufReadSize(Setting):
         ``wsgi.input``. Larger values can reduce Python loop overhead for large
         requests, while smaller values keep per-request buffering tighter.
 
+        The value must be greater than zero and at most 32 MB (33554432).
+
         .. note::
               Benchmarks show that, with WSGI workers, increased values up to
               64 kB can improve bandwidth performance when transferring
               large bodies, typically larger than 5 MB.
-
-        The value must be greater than zero.
         """
 
 

--- a/gunicorn/http/body.py
+++ b/gunicorn/http/body.py
@@ -184,8 +184,14 @@ class EOFReader:
 
 
 class Body:
-    def __init__(self, reader):
+    def __init__(self, reader, buf_read_size=1024):
+        if not isinstance(buf_read_size, int):
+            raise TypeError("buf_read_size must be an integral type")
+        if buf_read_size <= 0:
+            raise ValueError("buf_read_size must be greater than zero")
+
         self.reader = reader
+        self.buf_read_size = buf_read_size
         self.buf = io.BytesIO()
 
     def __iter__(self):
@@ -221,7 +227,7 @@ class Body:
             return ret
 
         while size > self.buf.tell():
-            data = self.reader.read(1024)
+            data = self.reader.read(self.buf_read_size)
             if not data:
                 break
             self.buf.write(data)
@@ -251,7 +257,7 @@ class Body:
 
             ret.append(data)
             size -= len(data)
-            data = self.reader.read(min(1024, size))
+            data = self.reader.read(min(self.buf_read_size, size))
             if not data:
                 break
 

--- a/gunicorn/http/body.py
+++ b/gunicorn/http/body.py
@@ -184,14 +184,12 @@ class EOFReader:
 
 
 class Body:
-    def __init__(self, reader, buf_read_size=1024):
-        if not isinstance(buf_read_size, int):
-            raise TypeError("buf_read_size must be an integral type")
-        if buf_read_size <= 0:
-            raise ValueError("buf_read_size must be greater than zero")
+    def __init__(self, reader, wsgi_input_block_size=1024):
+        if not isinstance(wsgi_input_block_size, int):
+            raise TypeError("wsgi_input_block_size must be an integral type")
 
         self.reader = reader
-        self.buf_read_size = buf_read_size
+        self.wsgi_input_block_size = wsgi_input_block_size
         self.buf = io.BytesIO()
 
     def __iter__(self):
@@ -227,7 +225,7 @@ class Body:
             return ret
 
         while size > self.buf.tell():
-            data = self.reader.read(self.buf_read_size)
+            data = self.reader.read(self.wsgi_input_block_size)
             if not data:
                 break
             self.buf.write(data)
@@ -257,7 +255,7 @@ class Body:
 
             ret.append(data)
             size -= len(data)
-            data = self.reader.read(min(self.buf_read_size, size))
+            data = self.reader.read(min(self.wsgi_input_block_size, size))
             if not data:
                 break
 

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -348,7 +348,7 @@ class Message:
                 # we cannot be certain the message framing we understood matches proxy intent
                 #  -> whatever happens next, remaining input must not be trusted
                 raise InvalidHeader("CONTENT-LENGTH", req=self)
-            self.body = Body(ChunkedReader(self, self.unreader))
+            self.body = Body(ChunkedReader(self, self.unreader), self.cfg.buf_read_size)
         elif content_length is not None:
             try:
                 if str(content_length).isnumeric():
@@ -361,9 +361,9 @@ class Message:
             if content_length < 0:
                 raise InvalidHeader("CONTENT-LENGTH", req=self)
 
-            self.body = Body(LengthReader(self.unreader, content_length))
+            self.body = Body(LengthReader(self.unreader, content_length), self.cfg.buf_read_size)
         else:
-            self.body = Body(EOFReader(self.unreader))
+            self.body = Body(EOFReader(self.unreader), self.cfg.buf_read_size)
 
     def should_close(self):
         if self.must_close:
@@ -828,4 +828,4 @@ class Request(Message):
     def set_body_reader(self):
         super().set_body_reader()
         if isinstance(self.body.reader, EOFReader):
-            self.body = Body(LengthReader(self.unreader, 0))
+            self.body = Body(LengthReader(self.unreader, 0), self.cfg.buf_read_size)

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -367,7 +367,7 @@ class Message:
                 # we cannot be certain the message framing we understood matches proxy intent
                 #  -> whatever happens next, remaining input must not be trusted
                 raise InvalidHeader("CONTENT-LENGTH", req=self)
-            self.body = Body(ChunkedReader(self, self.unreader), self.cfg.buf_read_size)
+            self.body = Body(ChunkedReader(self, self.unreader), self.cfg.wsgi_input_block_size)
         elif content_length is not None:
             try:
                 if str(content_length).isnumeric():
@@ -380,9 +380,11 @@ class Message:
             if content_length < 0:
                 raise InvalidHeader("CONTENT-LENGTH", req=self)
 
-            self.body = Body(LengthReader(self.unreader, content_length), self.cfg.buf_read_size)
+            self.body = Body(
+                LengthReader(self.unreader, content_length), self.cfg.wsgi_input_block_size
+            )
         else:
-            self.body = Body(EOFReader(self.unreader), self.cfg.buf_read_size)
+            self.body = Body(EOFReader(self.unreader), self.cfg.wsgi_input_block_size)
 
     def should_close(self):
         if self.must_close:
@@ -860,4 +862,4 @@ class Request(Message):
     def set_body_reader(self):
         super().set_body_reader()
         if isinstance(self.body.reader, EOFReader):
-            self.body = Body(LengthReader(self.unreader, 0), self.cfg.buf_read_size)
+            self.body = Body(LengthReader(self.unreader, 0), self.cfg.wsgi_input_block_size)

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -367,7 +367,7 @@ class Message:
                 # we cannot be certain the message framing we understood matches proxy intent
                 #  -> whatever happens next, remaining input must not be trusted
                 raise InvalidHeader("CONTENT-LENGTH", req=self)
-            self.body = Body(ChunkedReader(self, self.unreader))
+            self.body = Body(ChunkedReader(self, self.unreader), self.cfg.buf_read_size)
         elif content_length is not None:
             try:
                 if str(content_length).isnumeric():
@@ -380,9 +380,9 @@ class Message:
             if content_length < 0:
                 raise InvalidHeader("CONTENT-LENGTH", req=self)
 
-            self.body = Body(LengthReader(self.unreader, content_length))
+            self.body = Body(LengthReader(self.unreader, content_length), self.cfg.buf_read_size)
         else:
-            self.body = Body(EOFReader(self.unreader))
+            self.body = Body(EOFReader(self.unreader), self.cfg.buf_read_size)
 
     def should_close(self):
         if self.must_close:
@@ -860,4 +860,4 @@ class Request(Message):
     def set_body_reader(self):
         super().set_body_reader()
         if isinstance(self.body.reader, EOFReader):
-            self.body = Body(LengthReader(self.unreader, 0))
+            self.body = Body(LengthReader(self.unreader, 0), self.cfg.buf_read_size)

--- a/gunicorn/uwsgi/message.py
+++ b/gunicorn/uwsgi/message.py
@@ -222,7 +222,7 @@ class UWSGIRequest:
             except ValueError:
                 content_length = 0
 
-        self.body = Body(LengthReader(self.unreader, content_length))
+        self.body = Body(LengthReader(self.unreader, content_length), self.cfg.buf_read_size)
 
     def should_close(self):
         """Determine if the connection should be closed after this request."""

--- a/gunicorn/uwsgi/message.py
+++ b/gunicorn/uwsgi/message.py
@@ -222,7 +222,9 @@ class UWSGIRequest:
             except ValueError:
                 content_length = 0
 
-        self.body = Body(LengthReader(self.unreader, content_length), self.cfg.buf_read_size)
+        self.body = Body(
+            LengthReader(self.unreader, content_length), self.cfg.wsgi_input_block_size
+        )
 
     def should_close(self):
         """Determine if the connection should be closed after this request."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -157,6 +157,18 @@ def test_pos_int_validation():
     pytest.raises(TypeError, c.set, "workers", c)
 
 
+def test_strict_pos_int_validation():
+    c = config.Config()
+    assert c.buf_read_size == 1024
+    c.set("buf_read_size", 4096)
+    assert c.buf_read_size == 4096
+    c.set("buf_read_size", "8192")
+    assert c.buf_read_size == 8192
+    pytest.raises(ValueError, c.set, "buf_read_size", 0)
+    pytest.raises(ValueError, c.set, "buf_read_size", -1)
+    pytest.raises(TypeError, c.set, "buf_read_size", c)
+
+
 def test_str_validation():
     c = config.Config()
     assert c.proc_name == "gunicorn"
@@ -252,6 +264,9 @@ def test_cmd_line():
     with AltArgs(["prog_name", "-w", "3"]):
         app = NoConfigApp()
         assert app.cfg.workers == 3
+    with AltArgs(["prog_name", "--buf-read-size", "4096"]):
+        app = NoConfigApp()
+        assert app.cfg.buf_read_size == 4096
     with AltArgs(["prog_name", "--preload"]):
         app = NoConfigApp()
         assert app.cfg.preload_app

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -159,14 +159,15 @@ def test_pos_int_validation():
 
 def test_strict_pos_int_validation():
     c = config.Config()
-    assert c.buf_read_size == 1024
-    c.set("buf_read_size", 4096)
-    assert c.buf_read_size == 4096
-    c.set("buf_read_size", "8192")
-    assert c.buf_read_size == 8192
-    pytest.raises(ValueError, c.set, "buf_read_size", 0)
-    pytest.raises(ValueError, c.set, "buf_read_size", -1)
-    pytest.raises(TypeError, c.set, "buf_read_size", c)
+    assert c.wsgi_input_block_size == 1024
+    c.set("wsgi_input_block_size", 4096)
+    assert c.wsgi_input_block_size == 4096
+    c.set("wsgi_input_block_size", "8192")
+    assert c.wsgi_input_block_size == 8192
+    pytest.raises(ValueError, c.set, "wsgi_input_block_size", 0)
+    pytest.raises(ValueError, c.set, "wsgi_input_block_size", -1)
+    pytest.raises(ValueError, c.set, "wsgi_input_block_size", 32 * 1024 * 1024 + 1)
+    pytest.raises(TypeError, c.set, "wsgi_input_block_size", c)
 
 
 def test_str_validation():
@@ -264,9 +265,9 @@ def test_cmd_line():
     with AltArgs(["prog_name", "-w", "3"]):
         app = NoConfigApp()
         assert app.cfg.workers == 3
-    with AltArgs(["prog_name", "--buf-read-size", "4096"]):
+    with AltArgs(["prog_name", "--wsgi-input-block-size", "4096"]):
         app = NoConfigApp()
-        assert app.cfg.buf_read_size == 4096
+        assert app.cfg.wsgi_input_block_size == 4096
     with AltArgs(["prog_name", "--preload"]):
         app = NoConfigApp()
         assert app.cfg.preload_app

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -81,6 +81,33 @@ def test_readline_buffer_loaded_with_size():
     assert body.readline(2) == b"f"
 
 
+def test_body_read_uses_configured_buf_read_size():
+    reader = mock.MagicMock()
+    reader.read.side_effect = [b"abcd", b"ef", b""]
+
+    body = Body(reader, buf_read_size=4)
+
+    assert body.read(6) == b"abcdef"
+    assert reader.read.call_args_list == [mock.call(4), mock.call(4)]
+
+
+def test_body_readline_uses_configured_buf_read_size():
+    reader = mock.MagicMock()
+    reader.read.side_effect = [b"abcd", b"ef\n", b""]
+
+    body = Body(reader, buf_read_size=4)
+
+    assert body.readline() == b"abcdef\n"
+    assert reader.read.call_args_list == [mock.call(4), mock.call(4)]
+
+
+def test_body_invalid_buf_read_size():
+    with pytest.raises(TypeError):
+        Body(io.BytesIO(b""), buf_read_size="1024")
+    with pytest.raises(ValueError):
+        Body(io.BytesIO(b""), buf_read_size=0)
+
+
 def test_http_header_encoding():
     """ tests whether http response headers are USASCII encoded """
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -81,31 +81,29 @@ def test_readline_buffer_loaded_with_size():
     assert body.readline(2) == b"f"
 
 
-def test_body_read_uses_configured_buf_read_size():
+def test_body_read_uses_configured_wsgi_input_block_size():
     reader = mock.MagicMock()
     reader.read.side_effect = [b"abcd", b"ef", b""]
 
-    body = Body(reader, buf_read_size=4)
+    body = Body(reader, wsgi_input_block_size=4)
 
     assert body.read(6) == b"abcdef"
     assert reader.read.call_args_list == [mock.call(4), mock.call(4)]
 
 
-def test_body_readline_uses_configured_buf_read_size():
+def test_body_readline_uses_configured_wsgi_input_block_size():
     reader = mock.MagicMock()
     reader.read.side_effect = [b"abcd", b"ef\n", b""]
 
-    body = Body(reader, buf_read_size=4)
+    body = Body(reader, wsgi_input_block_size=4)
 
     assert body.readline() == b"abcdef\n"
     assert reader.read.call_args_list == [mock.call(4), mock.call(4)]
 
 
-def test_body_invalid_buf_read_size():
+def test_body_invalid_wsgi_input_block_size():
     with pytest.raises(TypeError):
-        Body(io.BytesIO(b""), buf_read_size="1024")
-    with pytest.raises(ValueError):
-        Body(io.BytesIO(b""), buf_read_size=0)
+        Body(io.BytesIO(b""), wsgi_input_block_size="1024")
 
 
 def test_http_header_encoding():

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -81,27 +81,55 @@ def test_readline_buffer_loaded_with_size():
     assert body.readline(2) == b"f"
 
 
-def test_body_read_uses_configured_wsgi_input_block_size():
+@pytest.mark.parametrize("read_kwargs,chunks,expected", [
+    # bounded read: requested size spans two blocks
+    ({"size": 6}, [b"abcd", b"ef"], b"abcdef"),
+    # unbounded read: body is exactly three blocks
+    ({}, [b"abcd", b"efgh", b"ijkl", b""], b"abcdefghijkl"),
+])
+def test_body_read_uses_block_size(read_kwargs, chunks, expected):
+    """read() calls the reader with exactly wsgi_input_block_size each time."""
     reader = mock.MagicMock()
-    reader.read.side_effect = [b"abcd", b"ef", b""]
-
+    reader.read.side_effect = chunks
     body = Body(reader, wsgi_input_block_size=4)
+    assert body.read(**read_kwargs) == expected
+    assert all(c == mock.call(4) for c in reader.read.call_args_list)
 
-    assert body.read(6) == b"abcdef"
-    assert reader.read.call_args_list == [mock.call(4), mock.call(4)]
+
+def test_body_read_prefetches_full_block_and_buffers_remainder():
+    """read(n) with n < block_size fetches a whole block; leftover stays
+    buffered so the next read() needs no additional reader call."""
+    reader = mock.MagicMock()
+    reader.read.side_effect = [b"abcdefgh", b""]
+    body = Body(reader, wsgi_input_block_size=8)
+
+    assert body.read(3) == b"abc"
+    assert reader.read.call_args_list == [mock.call(8)]
+    assert body.read(5) == b"defgh"
+    assert len(reader.read.call_args_list) == 1  # no second reader call
 
 
-def test_body_readline_uses_configured_wsgi_input_block_size():
+def test_body_readline_uses_block_size():
+    """readline() calls the reader with exactly wsgi_input_block_size each time."""
     reader = mock.MagicMock()
     reader.read.side_effect = [b"abcd", b"ef\n", b""]
-
     body = Body(reader, wsgi_input_block_size=4)
-
     assert body.readline() == b"abcdef\n"
     assert reader.read.call_args_list == [mock.call(4), mock.call(4)]
 
 
+def test_body_readline_size_clamps_reader_to_requested_size():
+    """readline(n) with n < block_size reads at most n bytes per call,
+    not a full block (exercises the min(wsgi_input_block_size, size) path)."""
+    reader = mock.MagicMock()
+    reader.read.side_effect = [b"abcde", b""]
+    body = Body(reader, wsgi_input_block_size=8)
+    assert body.readline(5) == b"abcde"
+    assert reader.read.call_args_list == [mock.call(5)]
+
+
 def test_body_invalid_wsgi_input_block_size():
+    """Non-integer wsgi_input_block_size raises TypeError at construction."""
     with pytest.raises(TypeError):
         Body(io.BytesIO(b""), wsgi_input_block_size="1024")
 

--- a/tests/test_uwsgi.py
+++ b/tests/test_uwsgi.py
@@ -53,6 +53,7 @@ class MockConfig:
     def __init__(self, is_ssl=False, uwsgi_allow_ips=None):
         self.is_ssl = is_ssl
         self.uwsgi_allow_ips = uwsgi_allow_ips or ['127.0.0.1', '::1']
+        self.buf_read_size = 1024
 
 
 class TestUWSGIPacketConstruction:

--- a/tests/test_uwsgi.py
+++ b/tests/test_uwsgi.py
@@ -53,7 +53,7 @@ class MockConfig:
     def __init__(self, is_ssl=False, uwsgi_allow_ips=None):
         self.is_ssl = is_ssl
         self.uwsgi_allow_ips = uwsgi_allow_ips or ['127.0.0.1', '::1']
-        self.buf_read_size = 1024
+        self.wsgi_input_block_size = 1024
 
 
 class TestUWSGIPacketConstruction:

--- a/tests/test_uwsgi.py
+++ b/tests/test_uwsgi.py
@@ -434,3 +434,19 @@ class TestUWSGIBody:
 
         # Negative content length should default to 0
         assert req.body.read() == b''
+
+    def test_wsgi_input_block_size_propagates(self):
+        """wsgi_input_block_size flows through to body.wsgi_input_block_size on uWSGI requests."""
+        body = b'hello uwsgi'
+        packet = make_uwsgi_packet_with_body({
+            'REQUEST_METHOD': 'POST',
+            'PATH_INFO': '/',
+            'CONTENT_LENGTH': str(len(body)),
+        }, body)
+        cfg = MockConfig()
+        cfg.wsgi_input_block_size = 4096
+
+        req = UWSGIRequest(cfg, IterUnreader([packet]), ('127.0.0.1', 12345))
+
+        assert req.body.wsgi_input_block_size == 4096
+        assert req.body.read() == body


### PR DESCRIPTION
This PR introduces `wsgi-input-block-size` setting to control buffer size for reading request data from the socket.

Cf this issue https://github.com/benoitc/gunicorn/issues/2596 and this stalled PR https://github.com/benoitc/gunicorn/pull/3068

## Experiment

Benchmarks running Flask 3.1 and Gunicorn 25.3 on Python 3.12, on different environments / setup:

<details>
<summary>Code running</summary>

### flask_app.py

```python
from flask import Flask, Response, request


app = Flask(__name__)


@app.post("/upload")
def upload():
    start = time.perf_counter()
    body = request.get_data(cache=False)
    received = len(body)

    process_seconds = time.perf_counter() - start
    payload = json.dumps(
        {
            "framework": "flask",
            "received_bytes": received,
            "process_seconds": process_seconds,
        }
    ).encode("ascii")
    response = Response(payload, mimetype="application/json")
    response.headers["Content-Length"] = str(len(payload))
    response.headers["X-Framework"] = "flask"
    response.headers["X-Received-Length"] = str(received)
    response.headers["X-Process-Duration"] = f"{process_seconds:.9f}"
    return response
```

### command
`gunicorn --bind 0.0.0.0:18100 --workers 1 --worker-class sync --wsgi-input-block-size xxx flask_app:app`

</details>

<details>
<summary>Results</summary>
Relative throughput change versus `1kB` wsgi-input-block-size, shown as a positive percentage when bandwidth increases.

| ↓ Payload ↓ | `2kB` | `4kB` | `8kB` | `16kB` | `32kB` | `64kB` | `128kB` | `256kB` | `512kB` | `1MB` |
| ---  | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `1kB` | `+24%` | `+13%` | `+7%` | `+7%` | `+5%` | `+5%` | `+22%` | `+16%` | `+11%` | `+14%` |
| `10kB` | `+28%` | `+28%` | `+34%` | `+36%` | `+35%` | `+34%` | `+38%` | `+50%` | `+44%` | `+41%` |
| `50kB` | `+50%` | `+95%` | `+60%` | `+149%` | `+83%` | `+124%` | `+89%` | `+99%` | `+131%` | `+96%` |
| `100kB` | `+34%` | `+40%` | `+64%` | `+59%` | `+16%` | `+6%` | `+80%` | `+41%` | `+57%` | `+101%` |
| `200kB` | `+29%` | `+55%` | `+75%` | `+82%` | `+50%` | `+60%` | `+67%` | `+72%` | `+105%` | `+59%` |
| `500kB` | `-1%` | `+5%` | `+2%` | `-2%` | `+4%` | `+4%` | `-2%` | `-5%` | `+10%` | `-4%` |
| `1MB` | `-2%` | `-1%` | `-6%` | `+1%` | `-0%` | `-3%` | `+3%` | `+12%` | `-1%` | `-19%` |
| `2MB` | `+15%` | `+12%` | `+17%` | `+30%` | `+4%` | `+14%` | `+21%` | `+22%` | `-3%` | `-2%` |
| `5MB` | `+13%` | `+23%` | `+23%` | `+17%` | `+30%` | `+20%` | `+17%` | `+12%` | `+10%` | `-15%` |
| `10MB` | `+13%` | `+25%` | `+27%` | `+25%` | `+26%` | `+22%` | `+19%` | `+20%` | `+11%` | `-14%` |
| `50MB` | `+17%` | `+37%` | `+42%` | `+40%` | `+45%` | `+47%` | `+42%` | `+22%` | `+43%` | `+12%` |
| `100MB` | `+24%` | `+38%` | `+47%` | `+59%` | `+53%` | `+55%` | `+45%` | `+40%` | `+48%` | `+22%` |
| `250MB` | `+24%` | `+43%` | `+59%` | `+58%` | `+61%` | `+55%` | `+52%` | `+50%` | `+29%` | `+21%` |
| `500MB` | `+34%` | `+58%` | `+57%` | `+70%` | `+67%` | `+61%` | `+55%` | `+59%` | `+46%` | `+25%` |
| `1000MB` | `+37%` | `+54%` | `+61%` | `+70%` | `+68%` | `+67%` | `+55%` | `+60%` | `+64%` | `+30%` |
</details>

## Findings

Note: these apply to WSGI sync workers. This parameter has no effect on ASGI configurations.

- 🚀 Large Payloads (≥ 5MB): we see significant performance gains and high stability across all environments/setup. Variance remains low, making this a clear win for large data transfers.
- ⚠️ Small Payloads (≤ 200kB): results are highly volatile. Due to significant variance between runs and environments, I cannot definitively categorize this as an improvement. I recommend benchmarking this within your specific infrastructure before tweaking `wsgi-input-block-size`.
- 🤔 Interestingly, payloads near the 1MB mark show either zero improvement or slight regressions, regardless of the `wsgi-input-block-size` configuration. This behavior is consistent across different environments. Any insights into why we might be hitting a bottleneck specifically at the 1MB threshold @benoitc ?
