### PR TITLE
test: codify RFC 9112 request-target and TE/CL vectors (phase 1)

### DIFF
--- a/tests/requests/invalid/rfc9112_smuggle_cl_te_chunked_01.http
+++ b/tests/requests/invalid/rfc9112_smuggle_cl_te_chunked_01.http
@@ -1,0 +1,7 @@
+POST /p HTTP/1.1\r\n
+Host: example.com\r\n
+Content-Length: 3\r\n
+Transfer-Encoding: chunked\r\n
+\r\n
+0\r\n
+\r\n

--- a/tests/requests/invalid/rfc9112_smuggle_cl_te_chunked_01.py
+++ b/tests/requests/invalid/rfc9112_smuggle_cl_te_chunked_01.py
@@ -1,0 +1,9 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 6.1: a message with both Content-Length and
+# Transfer-Encoding: chunked is the classic CL.TE desync vector and MUST
+# be rejected by the origin server. PortSwigger HTTP Desync corpus, CL.TE.
+from gunicorn.http.errors import InvalidHeader
+request = InvalidHeader

--- a/tests/requests/valid/rfc9112_smuggle_gzip_chunked_01.http
+++ b/tests/requests/valid/rfc9112_smuggle_gzip_chunked_01.http
@@ -1,0 +1,8 @@
+POST /upload HTTP/1.1\r\n
+Host: example.com\r\n
+Transfer-Encoding: gzip, chunked\r\n
+\r\n
+5\r\n
+hello\r\n
+0\r\n
+\r\n

--- a/tests/requests/valid/rfc9112_smuggle_gzip_chunked_01.py
+++ b/tests/requests/valid/rfc9112_smuggle_gzip_chunked_01.py
@@ -1,0 +1,16 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 6.1: Transfer-Encoding codings stack left-to-right;
+# chunked must be the final coding. gzip before chunked is valid.
+request = {
+    "method": "POST",
+    "uri": uri("/upload"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com"),
+        ("TRANSFER-ENCODING", "gzip, chunked"),
+    ],
+    "body": b"hello",
+}

--- a/tests/requests/valid/rfc9112_smuggle_te_identity_chunked_01.http
+++ b/tests/requests/valid/rfc9112_smuggle_te_identity_chunked_01.http
@@ -1,0 +1,8 @@
+POST /upload HTTP/1.1\r\n
+Host: example.com\r\n
+Transfer-Encoding: identity, chunked\r\n
+\r\n
+5\r\n
+hello\r\n
+0\r\n
+\r\n

--- a/tests/requests/valid/rfc9112_smuggle_te_identity_chunked_01.py
+++ b/tests/requests/valid/rfc9112_smuggle_te_identity_chunked_01.py
@@ -1,0 +1,16 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 6.1: identity is a no-op coding and may precede chunked.
+# Worth codifying because proxies have historically disagreed on this form.
+request = {
+    "method": "POST",
+    "uri": uri("/upload"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com"),
+        ("TRANSFER-ENCODING", "identity, chunked"),
+    ],
+    "body": b"hello",
+}

--- a/tests/requests/valid/rfc9112_target_absolute_01.http
+++ b/tests/requests/valid/rfc9112_target_absolute_01.http
@@ -1,0 +1,3 @@
+GET http://example.com/foo?q=1 HTTP/1.1\r\n
+Host: example.com\r\n
+\r\n

--- a/tests/requests/valid/rfc9112_target_absolute_01.py
+++ b/tests/requests/valid/rfc9112_target_absolute_01.py
@@ -1,0 +1,14 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 3.2.2: absolute-form request-target.
+request = {
+    "method": "GET",
+    "uri": uri("http://example.com/foo?q=1"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com"),
+    ],
+    "body": b"",
+}

--- a/tests/requests/valid/rfc9112_target_asterisk_options_01.http
+++ b/tests/requests/valid/rfc9112_target_asterisk_options_01.http
@@ -1,0 +1,3 @@
+OPTIONS * HTTP/1.1\r\n
+Host: example.com\r\n
+\r\n

--- a/tests/requests/valid/rfc9112_target_asterisk_options_01.py
+++ b/tests/requests/valid/rfc9112_target_asterisk_options_01.py
@@ -1,0 +1,14 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 3.2.4: asterisk-form, only valid with OPTIONS.
+request = {
+    "method": "OPTIONS",
+    "uri": uri("*"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com"),
+    ],
+    "body": b"",
+}

--- a/tests/requests/valid/rfc9112_target_authority_connect_01.http
+++ b/tests/requests/valid/rfc9112_target_authority_connect_01.http
@@ -1,0 +1,3 @@
+CONNECT example.com:443 HTTP/1.1\r\n
+Host: example.com:443\r\n
+\r\n

--- a/tests/requests/valid/rfc9112_target_authority_connect_01.py
+++ b/tests/requests/valid/rfc9112_target_authority_connect_01.py
@@ -1,0 +1,14 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 3.2.3: authority-form, only valid with CONNECT.
+request = {
+    "method": "CONNECT",
+    "uri": uri("example.com:443"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com:443"),
+    ],
+    "body": b"",
+}


### PR DESCRIPTION
Six new treq fixtures covering current corpus gaps, per the compliance plan:

**valid/**
- `rfc9112_target_absolute_01` — absolute-form URI (§3.2.2)
- `rfc9112_target_asterisk_options_01` — `OPTIONS *` (§3.2.4)
- `rfc9112_target_authority_connect_01` — `CONNECT host:port` (§3.2.3)
- `rfc9112_smuggle_gzip_chunked_01` — `TE: gzip, chunked` (§6.1, chunked last)
- `rfc9112_smuggle_te_identity_chunked_01` — `TE: identity, chunked`

**invalid/**
- `rfc9112_smuggle_cl_te_chunked_01` — CL + TE:chunked → `InvalidHeader` (§6.1, PortSwigger CL.TE)

Fixtures only. First of five planned phases; smuggling, chunked extensions, field syntax, body framing, and DoS-guard vectors follow.