### PR TITLE
test: codify absolute-form and IPv6 authority vectors (phase 2A)

### DIFF
--- a/tests/requests/valid/rfc9112_target_absolute_https_01.http
+++ b/tests/requests/valid/rfc9112_target_absolute_https_01.http
@@ -1,0 +1,3 @@
+GET https://example.com/foo HTTP/1.1\r\n
+Host: example.com\r\n
+\r\n

--- a/tests/requests/valid/rfc9112_target_absolute_https_01.py
+++ b/tests/requests/valid/rfc9112_target_absolute_https_01.py
@@ -1,0 +1,14 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 3.2.2: absolute-form with https scheme (proxy requests).
+request = {
+    "method": "GET",
+    "uri": uri("https://example.com/foo"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com"),
+    ],
+    "body": b"",
+}

--- a/tests/requests/valid/rfc9112_target_absolute_ipv6_01.http
+++ b/tests/requests/valid/rfc9112_target_absolute_ipv6_01.http
@@ -1,0 +1,3 @@
+GET http://[::1]:8080/foo HTTP/1.1\r\n
+Host: [::1]:8080\r\n
+\r\n

--- a/tests/requests/valid/rfc9112_target_absolute_ipv6_01.py
+++ b/tests/requests/valid/rfc9112_target_absolute_ipv6_01.py
@@ -1,0 +1,15 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 3.2.2 + RFC 3986 section 3.2.2: absolute-form with an
+# IP-literal (IPv6) host wrapped in brackets.
+request = {
+    "method": "GET",
+    "uri": uri("http://[::1]:8080/foo"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "[::1]:8080"),
+    ],
+    "body": b"",
+}

--- a/tests/requests/valid/rfc9112_target_absolute_userinfo_01.http
+++ b/tests/requests/valid/rfc9112_target_absolute_userinfo_01.http
@@ -1,0 +1,3 @@
+GET http://user:pass@example.com:8080/foo?q=1 HTTP/1.1\r\n
+Host: example.com:8080\r\n
+\r\n

--- a/tests/requests/valid/rfc9112_target_absolute_userinfo_01.py
+++ b/tests/requests/valid/rfc9112_target_absolute_userinfo_01.py
@@ -1,0 +1,14 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 3.2.2: absolute-form with userinfo and explicit port.
+request = {
+    "method": "GET",
+    "uri": uri("http://user:pass@example.com:8080/foo?q=1"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com:8080"),
+    ],
+    "body": b"",
+}

--- a/tests/requests/valid/rfc9112_target_authority_ipv6_01.http
+++ b/tests/requests/valid/rfc9112_target_authority_ipv6_01.http
@@ -1,0 +1,3 @@
+CONNECT [::1]:443 HTTP/1.1\r\n
+Host: [::1]:443\r\n
+\r\n

--- a/tests/requests/valid/rfc9112_target_authority_ipv6_01.py
+++ b/tests/requests/valid/rfc9112_target_authority_ipv6_01.py
@@ -1,0 +1,14 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 3.2.3: authority-form with IPv6 literal, used by CONNECT.
+request = {
+    "method": "CONNECT",
+    "uri": uri("[::1]:443"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "[::1]:443"),
+    ],
+    "body": b"",
+}


### PR DESCRIPTION
Four valid treq fixtures documenting absolute-form and authority-form variants:

- `rfc9112_target_absolute_userinfo_01` — userinfo + port
- `rfc9112_target_absolute_ipv6_01` — IPv6 literal host
- `rfc9112_target_absolute_https_01` — https scheme
- `rfc9112_target_authority_ipv6_01` — CONNECT with IPv6 literal

Fixtures only. Parser-gap rejection rules (e.g. `GET *`, authority-form with non-CONNECT) land via TDD in follow-up PRs.