### PR TITLE
fix: reject authority-form request-target outside CONNECT (RFC 9112 §3.2.3)

### DIFF
--- a/gunicorn/asgi/parser.py
+++ b/gunicorn/asgi/parser.py
@@ -460,6 +460,13 @@ class PythonProtocol:
         if self.path == b'*' and self.method != b'OPTIONS':
             raise InvalidRequestLine("Invalid request line")
 
+        # RFC 9112 section 3.2.3: authority-form is only valid with CONNECT.
+        if (self.method != b'CONNECT'
+                and self.path != b'*'
+                and not self.path.startswith(b'/')
+                and b'://' not in self.path):
+            raise InvalidRequestLine("Invalid request line")
+
         # Parse version
         version = parts[2]
         if version == b'HTTP/1.1':

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -811,6 +811,15 @@ class Request(Message):
         if self.uri == "*" and self.method != "OPTIONS":
             raise InvalidRequestLine(bytes_to_str(line_bytes))
 
+        # RFC 9112 section 3.2.3: authority-form ("host:port") is only valid
+        # with CONNECT. origin-form starts with "/"; absolute-form contains
+        # "://". Anything else on a non-CONNECT request is authority-form.
+        if (self.method != "CONNECT"
+                and self.uri != "*"
+                and not self.uri.startswith("/")
+                and "://" not in self.uri):
+            raise InvalidRequestLine(bytes_to_str(line_bytes))
+
         try:
             parts = split_request_uri(self.uri)
         except ValueError:

--- a/tests/requests/invalid/rfc9112_target_authority_non_connect_01.http
+++ b/tests/requests/invalid/rfc9112_target_authority_non_connect_01.http
@@ -1,0 +1,3 @@
+GET example.com:443 HTTP/1.1\r\n
+Host: example.com:443\r\n
+\r\n

--- a/tests/requests/invalid/rfc9112_target_authority_non_connect_01.py
+++ b/tests/requests/invalid/rfc9112_target_authority_non_connect_01.py
@@ -1,0 +1,10 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 3.2.3: authority-form ("host:port") is only valid with
+# the CONNECT method. Any other method carrying it must be rejected.
+from gunicorn.http.errors import InvalidRequestLine
+request = InvalidRequestLine
+# The C parser (gunicorn_h1c) does not yet enforce this rule.
+python_only = True


### PR DESCRIPTION
The Python WSGI and ASGI parsers previously accepted `GET example.com:443` and parsed it as an unusual origin-form (scheme=example.com, path=443). RFC 9112 §3.2.3 restricts authority-form to CONNECT.

TDD-style commits: the first adds the failing fixture, the second adds the detection in both parsers.

Detection rule: a non-CONNECT request whose target is neither origin-form (`/…`), nor absolute-form (`…://…`), nor asterisk (`*`), is authority-form and rejected with `InvalidRequestLine`.

The C parser does not yet enforce this; fixture is `python_only`.