### PR TITLE
test: codify rejection of relative-reference request-target (RFC 9112 §3.2)

### DIFF
--- a/tests/requests/invalid/rfc9112_target_relative_01.http
+++ b/tests/requests/invalid/rfc9112_target_relative_01.http
@@ -1,0 +1,3 @@
+GET foo/bar HTTP/1.1\r\n
+Host: example.com\r\n
+\r\n

--- a/tests/requests/invalid/rfc9112_target_relative_01.py
+++ b/tests/requests/invalid/rfc9112_target_relative_01.py
@@ -1,0 +1,11 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 3.2: request-target must be one of origin-form,
+# absolute-form, authority-form, or asterisk-form. A relative reference
+# like "foo/bar" matches none of these and must be rejected.
+from gunicorn.http.errors import InvalidRequestLine
+request = InvalidRequestLine
+# The C parser (gunicorn_h1c) does not yet enforce this rule.
+python_only = True


### PR DESCRIPTION
Adds a regression fixture for `GET foo/bar HTTP/1.1` → `InvalidRequestLine`. The rejection is already enforced as a side-effect of the authority-form check landed in #3595; this pins the behavior. Fixture marked `python_only` since the C parser does not yet enforce it.