### PR TITLE
fix: reject control characters in header field-value (RFC 9110 §5.5)

### DIFF
--- a/gunicorn/asgi/parser.py
+++ b/gunicorn/asgi/parser.py
@@ -804,8 +804,11 @@ class PythonProtocol:
         return True
 
     def _has_invalid_header_chars(self, value):
-        """Check for NUL, CR, LF in header value."""
-        return b'\x00' in value or b'\r' in value or b'\n' in value
+        """RFC 9110 section 5.5: only VCHAR, SP, HTAB, and obs-text allowed."""
+        for c in value:
+            if c <= 0x08 or 0x0a <= c <= 0x1f or c == 0x7f:
+                return True
+        return False
 
 
 class CallbackRequest:

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -130,7 +130,10 @@ TOKEN_RE = re.compile(r"[%s0-9a-zA-Z]+" % (re.escape(RFC9110_5_6_2_TOKEN_SPECIAL
 METHOD_BADCHAR_RE = re.compile("[a-z#]")
 # usually 1.0 or 1.1 - RFC9112 permits restricting to single-digit versions
 VERSION_RE = re.compile(r"HTTP/(\d)\.(\d)")
-RFC9110_5_5_INVALID_AND_DANGEROUS = re.compile(r"[\0\r\n]")
+# RFC 9110 section 5.5: field-vchar = VCHAR / obs-text; SP and HTAB are the
+# only non-VCHAR bytes allowed in a field-value. Anything else in the
+# control range (0x00-0x1F except HTAB, plus DEL 0x7F) must be rejected.
+RFC9110_5_5_INVALID_AND_DANGEROUS = re.compile(r"[\x00-\x08\x0a-\x1f\x7f]")
 
 # RFC 9110 section 6.5.1: fields forbidden in trailers because they alter
 # routing, framing, or authentication. Using the uppercased names stored

--- a/tests/requests/invalid/rfc9110_field_value_ctl_bel_01.http
+++ b/tests/requests/invalid/rfc9110_field_value_ctl_bel_01.http
@@ -1,0 +1,4 @@
+GET /foo HTTP/1.1\r\n
+Host: example.com\r\n
+X-Value: plain\x07injected\r\n
+\r\n

--- a/tests/requests/invalid/rfc9110_field_value_ctl_bel_01.py
+++ b/tests/requests/invalid/rfc9110_field_value_ctl_bel_01.py
@@ -1,0 +1,10 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9110 section 5.5: field-value characters are field-vchar (VCHAR +
+# obs-text) plus SP/HTAB. Control characters other than HTAB must not
+# appear, to prevent log/response injection and parser confusion.
+from gunicorn.http.errors import InvalidHeader
+request = InvalidHeader
+python_only = True

--- a/tests/requests/invalid/rfc9110_field_value_ctl_del_01.http
+++ b/tests/requests/invalid/rfc9110_field_value_ctl_del_01.http
@@ -1,0 +1,4 @@
+GET /foo HTTP/1.1\r\n
+Host: example.com\r\n
+X-Value: plain\x7finjected\r\n
+\r\n

--- a/tests/requests/invalid/rfc9110_field_value_ctl_del_01.py
+++ b/tests/requests/invalid/rfc9110_field_value_ctl_del_01.py
@@ -1,0 +1,9 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9110 section 5.5: DEL (0x7F) is a control character and not a VCHAR;
+# it must not appear in a field-value.
+from gunicorn.http.errors import InvalidHeader
+request = InvalidHeader
+python_only = True


### PR DESCRIPTION
Header-value validation only caught NUL/CR/LF; BEL, DEL, FF, and other C0/C1 controls were accepted. RFC 9110 §5.5 defines field-vchar as VCHAR or obs-text, permitting SP and HTAB beyond that — nothing else. Both WSGI and ASGI Python parsers now reject any control character except HTAB.

TDD commits: two failing fixtures (BEL and DEL), then the regex/validator widening.

The C parser does not yet enforce this; fixtures are \`python_only\`.