### PR TITLE
test: codify chunked size/extension edge cases (RFC 9112 §7.1)

### DIFF
--- a/tests/requests/invalid/rfc9112_chunked_size_minus_sign_01.http
+++ b/tests/requests/invalid/rfc9112_chunked_size_minus_sign_01.http
@@ -1,0 +1,8 @@
+POST /upload HTTP/1.1\r\n
+Host: example.com\r\n
+Transfer-Encoding: chunked\r\n
+\r\n
+-5\r\n
+hello\r\n
+0\r\n
+\r\n

--- a/tests/requests/invalid/rfc9112_chunked_size_minus_sign_01.py
+++ b/tests/requests/invalid/rfc9112_chunked_size_minus_sign_01.py
@@ -1,0 +1,7 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 7.1: chunk-size = 1*HEXDIG; negative sign is invalid.
+from gunicorn.http.errors import InvalidChunkSize
+request = InvalidChunkSize

--- a/tests/requests/invalid/rfc9112_chunked_size_plus_sign_01.http
+++ b/tests/requests/invalid/rfc9112_chunked_size_plus_sign_01.http
@@ -1,0 +1,8 @@
+POST /upload HTTP/1.1\r\n
+Host: example.com\r\n
+Transfer-Encoding: chunked\r\n
+\r\n
++5\r\n
+hello\r\n
+0\r\n
+\r\n

--- a/tests/requests/invalid/rfc9112_chunked_size_plus_sign_01.py
+++ b/tests/requests/invalid/rfc9112_chunked_size_plus_sign_01.py
@@ -1,0 +1,8 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 7.1: chunk-size = 1*HEXDIG; a leading sign ("+" or "-")
+# is not valid and has been used in request-smuggling vectors.
+from gunicorn.http.errors import InvalidChunkSize
+request = InvalidChunkSize

--- a/tests/requests/valid/rfc9112_chunked_ext_quoted_01.http
+++ b/tests/requests/valid/rfc9112_chunked_ext_quoted_01.http
@@ -1,0 +1,8 @@
+POST /upload HTTP/1.1\r\n
+Host: example.com\r\n
+Transfer-Encoding: chunked\r\n
+\r\n
+5;foo="bar baz"\r\n
+hello\r\n
+0\r\n
+\r\n

--- a/tests/requests/valid/rfc9112_chunked_ext_quoted_01.py
+++ b/tests/requests/valid/rfc9112_chunked_ext_quoted_01.py
@@ -1,0 +1,15 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 7.1.1: chunk-ext-val can be token or quoted-string.
+request = {
+    "method": "POST",
+    "uri": uri("/upload"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com"),
+        ("TRANSFER-ENCODING", "chunked"),
+    ],
+    "body": b"hello",
+}

--- a/tests/requests/valid/rfc9112_chunked_size_leading_zeros_01.http
+++ b/tests/requests/valid/rfc9112_chunked_size_leading_zeros_01.http
@@ -1,0 +1,8 @@
+POST /upload HTTP/1.1\r\n
+Host: example.com\r\n
+Transfer-Encoding: chunked\r\n
+\r\n
+0005\r\n
+hello\r\n
+0\r\n
+\r\n

--- a/tests/requests/valid/rfc9112_chunked_size_leading_zeros_01.py
+++ b/tests/requests/valid/rfc9112_chunked_size_leading_zeros_01.py
@@ -1,0 +1,16 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 7.1: chunk-size is 1*HEXDIG. Leading zeros are permitted
+# but have been used in smuggling vectors; fixture pins accepted behavior.
+request = {
+    "method": "POST",
+    "uri": uri("/upload"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com"),
+        ("TRANSFER-ENCODING", "chunked"),
+    ],
+    "body": b"hello",
+}

--- a/tests/requests/valid/rfc9112_chunked_size_uppercase_hex_01.http
+++ b/tests/requests/valid/rfc9112_chunked_size_uppercase_hex_01.http
@@ -1,0 +1,8 @@
+POST /upload HTTP/1.1\r\n
+Host: example.com\r\n
+Transfer-Encoding: chunked\r\n
+\r\n
+A\r\n
+0123456789\r\n
+0\r\n
+\r\n

--- a/tests/requests/valid/rfc9112_chunked_size_uppercase_hex_01.py
+++ b/tests/requests/valid/rfc9112_chunked_size_uppercase_hex_01.py
@@ -1,0 +1,15 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 7.1: chunk-size = 1*HEXDIG, which allows both cases.
+request = {
+    "method": "POST",
+    "uri": uri("/upload"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com"),
+        ("TRANSFER-ENCODING", "chunked"),
+    ],
+    "body": b"0123456789",
+}


### PR DESCRIPTION
Five fixtures pinning current chunked parser behavior against RFC 9112 §7.1:

**valid/**
- \`rfc9112_chunked_size_uppercase_hex_01\` — single hex digit \`A\` (=10).
- \`rfc9112_chunked_size_leading_zeros_01\` — \`0005\` (leading zeros permitted).
- \`rfc9112_chunked_ext_quoted_01\` — chunk-ext with quoted-string value.

**invalid/**
- \`rfc9112_chunked_size_plus_sign_01\` — \`+5\` rejected as \`InvalidChunkSize\`.
- \`rfc9112_chunked_size_minus_sign_01\` — \`-5\` rejected as \`InvalidChunkSize\`.

Fixtures only, pure regression pinning.