### PR TITLE
test: codify field-syntax cases (RFC 9110 §5.5 & §5.6.2)

### DIFF
--- a/tests/requests/valid/rfc9110_field_name_special_chars_01.http
+++ b/tests/requests/valid/rfc9110_field_name_special_chars_01.http
@@ -1,0 +1,4 @@
+GET /foo HTTP/1.1\r\n
+Host: example.com\r\n
+X.Custom|Pipe: ok\r\n
+\r\n

--- a/tests/requests/valid/rfc9110_field_name_special_chars_01.py
+++ b/tests/requests/valid/rfc9110_field_name_special_chars_01.py
@@ -1,0 +1,16 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9110 section 5.6.2: token = 1*tchar; tchar includes !#$%&'*+-.^_`|~
+# and alphanumerics. Dot, pipe, and other specials are legal in field-names.
+request = {
+    "method": "GET",
+    "uri": uri("/foo"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com"),
+        ("X.CUSTOM|PIPE", "ok"),
+    ],
+    "body": b"",
+}

--- a/tests/requests/valid/rfc9110_field_value_htab_trim_01.http
+++ b/tests/requests/valid/rfc9110_field_value_htab_trim_01.http
@@ -1,0 +1,4 @@
+GET /foo HTTP/1.1\r\n
+Host: example.com\r\n
+X-Value:\tabc\t\r\n
+\r\n

--- a/tests/requests/valid/rfc9110_field_value_htab_trim_01.py
+++ b/tests/requests/valid/rfc9110_field_value_htab_trim_01.py
@@ -1,0 +1,16 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9110 section 5.5: OWS around field-value is optional and not part
+# of the value; leading and trailing HTAB must be stripped.
+request = {
+    "method": "GET",
+    "uri": uri("/foo"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com"),
+        ("X-VALUE", "abc"),
+    ],
+    "body": b"",
+}

--- a/tests/requests/valid/rfc9110_field_value_obs_text_01.http
+++ b/tests/requests/valid/rfc9110_field_value_obs_text_01.http
@@ -1,0 +1,4 @@
+GET /foo HTTP/1.1\r\n
+Host: example.com\r\n
+X-Value: caf\xc3\xa9\r\n
+\r\n

--- a/tests/requests/valid/rfc9110_field_value_obs_text_01.py
+++ b/tests/requests/valid/rfc9110_field_value_obs_text_01.py
@@ -1,0 +1,17 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9110 section 5.5: field-vchar = VCHAR / obs-text (0x80-0xFF).
+# Value carries two obs-text bytes 0xC3 0xA9 (UTF-8 "e"-acute), stored
+# as latin-1 per the WSGI environ convention.
+request = {
+    "method": "GET",
+    "uri": uri("/foo"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com"),
+        ("X-VALUE", "caf\u00c3\u00a9"),
+    ],
+    "body": b"",
+}


### PR DESCRIPTION
Three valid treq fixtures pinning field-syntax behavior:

- \`rfc9110_field_value_htab_trim_01\` — leading/trailing HTAB trimmed from field-value (RFC 9110 §5.5 OWS rule).
- \`rfc9110_field_value_obs_text_01\` — obs-text bytes (0x80-0xFF) accepted in field-value.
- \`rfc9110_field_name_special_chars_01\` — tchar specials (\`.\`, \`|\`) accepted in field-name.

Fixtures only.