### PR TITLE
test: codify body-framing cases (RFC 9110 §8.6 & RFC 9112 §6.1)

### DIFF
--- a/tests/requests/valid/rfc9110_body_framing_get_cl_nonzero_01.http
+++ b/tests/requests/valid/rfc9110_body_framing_get_cl_nonzero_01.http
@@ -1,0 +1,5 @@
+GET /foo HTTP/1.1\r\n
+Host: example.com\r\n
+Content-Length: 5\r\n
+\r\n
+hello

--- a/tests/requests/valid/rfc9110_body_framing_get_cl_nonzero_01.py
+++ b/tests/requests/valid/rfc9110_body_framing_get_cl_nonzero_01.py
@@ -1,0 +1,16 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9110 section 8.6: a GET with a non-zero Content-Length is
+# "discouraged" but not forbidden; the body must be preserved.
+request = {
+    "method": "GET",
+    "uri": uri("/foo"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com"),
+        ("CONTENT-LENGTH", "5"),
+    ],
+    "body": b"hello",
+}

--- a/tests/requests/valid/rfc9110_body_framing_get_cl_zero_01.http
+++ b/tests/requests/valid/rfc9110_body_framing_get_cl_zero_01.http
@@ -1,0 +1,4 @@
+GET /foo HTTP/1.1\r\n
+Host: example.com\r\n
+Content-Length: 0\r\n
+\r\n

--- a/tests/requests/valid/rfc9110_body_framing_get_cl_zero_01.py
+++ b/tests/requests/valid/rfc9110_body_framing_get_cl_zero_01.py
@@ -1,0 +1,15 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9110 section 8.6: Content-Length: 0 on GET is valid.
+request = {
+    "method": "GET",
+    "uri": uri("/foo"),
+    "version": (1, 1),
+    "headers": [
+        ("HOST", "example.com"),
+        ("CONTENT-LENGTH", "0"),
+    ],
+    "body": b"",
+}

--- a/tests/requests/valid/rfc9110_body_framing_http10_cl_01.http
+++ b/tests/requests/valid/rfc9110_body_framing_http10_cl_01.http
@@ -1,0 +1,5 @@
+POST /foo HTTP/1.0\r\n
+Host: example.com\r\n
+Content-Length: 5\r\n
+\r\n
+hello

--- a/tests/requests/valid/rfc9110_body_framing_http10_cl_01.py
+++ b/tests/requests/valid/rfc9110_body_framing_http10_cl_01.py
@@ -1,0 +1,16 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 6.1: Content-Length is the only framing option for
+# HTTP/1.0 bodies (chunked was added in HTTP/1.1).
+request = {
+    "method": "POST",
+    "uri": uri("/foo"),
+    "version": (1, 0),
+    "headers": [
+        ("HOST", "example.com"),
+        ("CONTENT-LENGTH", "5"),
+    ],
+    "body": b"hello",
+}


### PR DESCRIPTION
Three valid treq fixtures pinning body-framing behavior:

- \`rfc9110_body_framing_get_cl_zero_01\` — \`GET\` with \`Content-Length: 0\`.
- \`rfc9110_body_framing_get_cl_nonzero_01\` — \`GET\` with a non-zero body (RFC 9110 §8.6 discourages but permits).
- \`rfc9110_body_framing_http10_cl_01\` — HTTP/1.0 \`POST\` with \`Content-Length\`.

Fixtures only.