### PR TITLE
test: codify rejection of Content-Length list form (RFC 9112 §6.3)

### DIFF
--- a/tests/requests/invalid/rfc9112_smuggle_cl_list_form_01.http
+++ b/tests/requests/invalid/rfc9112_smuggle_cl_list_form_01.http
@@ -1,0 +1,5 @@
+POST /p HTTP/1.1\r\n
+Host: example.com\r\n
+Content-Length: 5, 5\r\n
+\r\n
+hello

--- a/tests/requests/invalid/rfc9112_smuggle_cl_list_form_01.py
+++ b/tests/requests/invalid/rfc9112_smuggle_cl_list_form_01.py
@@ -1,0 +1,12 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+# RFC 9112 section 6.3 allows Content-Length list form when all values
+# match, but gunicorn takes the safer strict view and rejects any list
+# form outright to avoid proxy/origin desync. PortSwigger HTTP Desync,
+# CL list variant.
+from gunicorn.http.errors import InvalidHeader
+request = InvalidHeader
+# The C parser (gunicorn_h1c) does not yet enforce this rule.
+python_only = True


### PR DESCRIPTION
Adds a fixture pinning gunicorn's strict rejection of `Content-Length: 5, 5`. RFC 9112 §6.3 allows the list form when all values match, but gunicorn takes the safer strict view to avoid proxy/origin desync — this fixture makes that stance explicit and regression-proof. PortSwigger CL list variant. Marked `python_only` since the C parser does not yet enforce the rule.