### PR TITLE
chore: require gunicorn_h1c >=0.6.5 and drop last python_only marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ tornado = ["tornado>=6.5.0"]
 gthread = []
 setproctitle = ["setproctitle"]
 http2 = ["h2>=4.1.0"]
-fast = ["gunicorn_h1c>=0.6.4"]
+fast = ["gunicorn_h1c>=0.6.5"]
 testing = [
     "gevent>=24.10.1",
     "eventlet>=0.40.3",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,4 +3,4 @@ coverage
 pytest>=7.2.0
 pytest-cov
 pytest-asyncio
-gunicorn_h1c>=0.6.4
+gunicorn_h1c>=0.6.5

--- a/tests/requests/invalid/rfc9112_smuggle_cl_list_form_01.py
+++ b/tests/requests/invalid/rfc9112_smuggle_cl_list_form_01.py
@@ -8,5 +8,3 @@
 # CL list variant.
 from gunicorn.http.errors import InvalidHeader
 request = InvalidHeader
-# The C parser (gunicorn_h1c) does not yet enforce this rule.
-python_only = True


### PR DESCRIPTION
gunicorn_h1c 0.6.5 ships the Content-Length list-form rejection landed in h1c#8 (`pico_parse_content_length` now requires purely digits). Removes the last `python_only = True` marker on `rfc9112_smuggle_cl_list_form_01` and bumps the pin.