### PR TITLE
Correct README compatibility metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
   <a href="https://checkout.revolut.com/pay/ac271e5e-172a-408b-947b-2f9f79d3a88a"><img src="https://img.shields.io/badge/Revolut-Donate-191c20?style=for-the-badge" alt="Revolut"></a>
 </p>
 
-[![PyPI version](https://img.shields.io/pypi/v/gunicorn.svg?style=flat)](https://pypi.python.org/pypi/gunicorn)
-[![Supported Python versions](https://img.shields.io/pypi/pyversions/gunicorn.svg)](https://pypi.python.org/pypi/gunicorn)
+[![PyPI version](https://img.shields.io/pypi/v/gunicorn.svg?style=flat)](https://pypi.org/project/gunicorn/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/gunicorn.svg)](https://pypi.org/project/gunicorn/)
 [![Build Status](https://github.com/benoitc/gunicorn/actions/workflows/tox.yml/badge.svg)](https://github.com/benoitc/gunicorn/actions/workflows/tox.yml)
 
 Gunicorn 'Green Unicorn' is a Python WSGI HTTP Server for UNIX. It's a pre-fork
@@ -39,7 +39,7 @@ gunicorn myapp:app --worker-class asgi
 - uWSGI binary protocol for nginx integration
 - Multiple worker types: sync, gthread, gevent, eventlet, asgi
 - Graceful worker process management
-- Compatible with Python 3.9+
+- Compatible with Python 3.10+
 
 ## Documentation
 


### PR DESCRIPTION

**Repo:** benoitc/gunicorn (⭐ 10000)
**Type:** docs
**Files changed:** 1
**Lines:** +3/-3

## What
This change updates `README.md` so the user-facing compatibility information matches the package metadata. It changes the PyPI badge links from the legacy `pypi.python.org` host to the current `pypi.org/project/gunicorn/` URL and corrects the README feature list from `Python 3.9+` to `Python 3.10+`.

## Why
The README is the first place users check before installing or upgrading. Advertising Python 3.9 support while `pyproject.toml` requires `>=3.10` creates avoidable confusion for users and downstream packagers. Updating the badge targets at the same time removes stale links and keeps the project’s primary entry-point documentation aligned with current packaging metadata.

## Testing
Verified the committed diff locally with `git show` and `git diff --stat`. No automated tests were run because this is a documentation-only change.

## Risk
Low / Documentation-only change that aligns README content with existing package metadata.
