### PR TITLE
Honor forwarded_allow_ips in fast parser

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -206,6 +206,16 @@ class Message:
     def parse(self, unreader):
         raise NotImplementedError()
 
+    def _source_is_trusted_proxy(self):
+        return (
+            not isinstance(self.peer_addr, tuple)
+            or _ip_in_allow_list(
+                self.peer_addr[0],
+                self.cfg.forwarded_allow_ips,
+                self.cfg.forwarded_allow_networks(),
+            )
+        )
+
     def parse_headers(self, data, from_trailer=False):
         cfg = self.cfg
         headers = []
@@ -221,9 +231,7 @@ class Message:
             # nonsense. either a request is https from the beginning
             #  .. or we are just behind a proxy who does not remove conflicting trailers
             pass
-        elif (not isinstance(self.peer_addr, tuple)
-              or _ip_in_allow_list(self.peer_addr[0], cfg.forwarded_allow_ips,
-                                   cfg.forwarded_allow_networks())):
+        elif self._source_is_trusted_proxy():
             secure_scheme_headers = cfg.secure_scheme_headers
             forwarder_headers = cfg.forwarder_headers
 
@@ -518,13 +526,15 @@ class Request(Message):
         # gunicorn_h1c returns headers as (bytes, bytes) tuples
         # Header name/value validation done by C parser
         self.headers = []
+        forwarder_headers = []
+        if self._source_is_trusted_proxy():
+            forwarder_headers = self.cfg.forwarder_headers
         for name_bytes, value_bytes in result['headers']:
             name = bytes_to_str(name_bytes).upper()
             value = bytes_to_str(value_bytes)
 
             # Handle underscore in header names (policy decision, not validation)
             if "_" in name:
-                forwarder_headers = self.cfg.forwarder_headers
                 if name in forwarder_headers or "*" in forwarder_headers:
                     pass
                 elif self.cfg.header_map == "dangerous":

--- a/tests/test_http_forwarder_headers.py
+++ b/tests/test_http_forwarder_headers.py
@@ -1,0 +1,34 @@
+import pytest
+
+from gunicorn.config import Config
+from gunicorn.http.parser import RequestParser
+
+
+REQUEST = (
+    b"GET /admin/environ HTTP/1.1\r\n"
+    b"Host: localhost\r\n"
+    b"SCRIPT_NAME: /admin\r\n"
+    b"\r\n"
+)
+
+
+def parse_request(http_parser, peer_addr):
+    cfg = Config()
+    cfg.set("http_parser", http_parser)
+    cfg.set("forwarded_allow_ips", "10.0.0.1")
+    cfg.set("forwarder_headers", "SCRIPT_NAME,PATH_INFO")
+    return next(iter(RequestParser(cfg, [REQUEST], peer_addr)))
+
+
+@pytest.mark.parametrize(
+    ("peer_addr", "expected_headers"),
+    [
+        (("127.0.0.1", 12345), [("HOST", "localhost")]),
+        (("10.0.0.1", 12345), [("HOST", "localhost"), ("SCRIPT_NAME", "/admin")]),
+    ],
+)
+def test_forwarder_headers_respect_forwarded_allow_ips(
+    http_parser, peer_addr, expected_headers
+):
+    req = parse_request(http_parser, peer_addr)
+    assert req.headers == expected_headers


### PR DESCRIPTION
## Summary
- make the fast HTTP parser honor `forwarded_allow_ips` before accepting underscore `forwarder_headers`
- align fast-parser behavior with the existing Python parser
- add a regression test covering trusted and untrusted peers under both parser modes

## Testing
- `uv run --extra testing --extra fast pytest tests/test_http_forwarder_headers.py tests/test_valid_requests.py tests/test_invalid_requests.py`

