### PR TITLE
docs: Typo in run example

### DIFF
--- a/docs/content/run.md
+++ b/docs/content/run.md
@@ -35,7 +35,7 @@ def app(environ, start_response):
     status = "200 OK"
     response_headers = [
         ("Content-type", "text/plain"),
-        ("Content-Length", str(len(data.md)))
+        ("Content-Length", str(len(data)))
     ]
     start_response(status, response_headers)
     return iter([data])


### PR DESCRIPTION
Looks like this `.md` crept in as part of the MkDocs migration

Original line: https://github.com/benoitc/gunicorn/blob/f9df39f/docs/source/run.rst?plain=1#L43
New line: https://github.com/benoitc/gunicorn/blob/19a2efe/docs/content/run.md?plain=1#L38