### PR TITLE
fix: close dirty worker connection on TimeoutError

### DIFF
--- a/gunicorn/dirty/arbiter.py
+++ b/gunicorn/dirty/arbiter.py
@@ -542,6 +542,7 @@ class DirtyArbiter:
                         timeout=self.cfg.dirty_timeout
                     )
                 except asyncio.TimeoutError:
+                    self._close_worker_connection(worker_pid)
                     response = make_error_response(
                         request_id,
                         DirtyTimeoutError("Worker timeout", self.cfg.dirty_timeout)


### PR DESCRIPTION
When a request processed by a dirty worker reaches dirty_timeout, arbiter responds to a client before that worker writes its response. However, the client still writes its response, and arbiter will later return that response to wrong requests and clients.

Example timeline:
T=0: client sends a request R1.
T=0 (more or less): R1 gets put to a worker’s W1 queue.
T=0: worker starts processing R1.
T=1: client sends R2.
T=120 (our dirty_timeout value): arbiter gets to asyncio.TimeoutError in _execute_on_worker, returns DirtyTimeoutError to a client for R1.
T=120.0001: worker writes its response to R1 to the socket.
T=120.0002: worker starts processing R2.
T=125: arbiter reads response to R1 from the socket.
T=125: arbiter returns this R1 response to a R2 client.

Etc.: now arbiter will continue returning R(N) responses to an R(N+1) client.

This has fixed the problem in tests in our app, but I don’t know if it is the best possible approach (maybe this breaks other use cases where this connection should stay open on timeout errors?). 

Alternative, I guess, there could be a check (in lines 555 and below) if `request_id` matches what’s been written by a worker.