### PR TITLE
docs: fix typos in changelog, code comments, and test fixture

### DIFF
--- a/docs/content/2024-news.md
+++ b/docs/content/2024-news.md
@@ -10,7 +10,7 @@
 - permit Transfer-Encoding headers specifying multiple encodings. note: no parameters, still ([PR #3261](https://github.com/benoitc/gunicorn/pull/3261))
 - sdist generation now explicitly excludes sphinx build folder ([PR #3257](https://github.com/benoitc/gunicorn/pull/3257))
 - decode bytes-typed status (as can be passed by gevent) as utf-8 instead of raising `TypeError` ([PR #2336](https://github.com/benoitc/gunicorn/pull/2336))
-- raise correct Exception when encounting invalid chunked requests ([PR #3258](https://github.com/benoitc/gunicorn/pull/3258))
+- raise correct Exception when encountering invalid chunked requests ([PR #3258](https://github.com/benoitc/gunicorn/pull/3258))
 - the SCRIPT_NAME and PATH_INFO headers, when received from allowed forwarders, are no longer restricted for containing an underscore ([PR #3192](https://github.com/benoitc/gunicorn/pull/3192))
 - include IPv6 loopback address ``[::1]`` in default for [forwarded-allow-ips](reference/settings.md#forwarded_allow_ips) and [proxy-allow-ips](reference/settings.md#proxy_allow_ips) ([PR #3192](https://github.com/benoitc/gunicorn/pull/3192))
 
@@ -23,7 +23,7 @@
 ### Breaking changes
 
 - refuse requests where the uri field is empty ([PR #3255](https://github.com/benoitc/gunicorn/pull/3255))
-- refuse requests with invalid CR/LR/NUL in heade field values ([PR #3253](https://github.com/benoitc/gunicorn/pull/3253))
+- refuse requests with invalid CR/LR/NUL in header field values ([PR #3253](https://github.com/benoitc/gunicorn/pull/3253))
 - remove temporary ``--tolerate-dangerous-framing`` switch from 22.0 ([PR #3260](https://github.com/benoitc/gunicorn/pull/3260))
 - If any of the breaking changes affect you, be aware that now refused requests can post a security problem, especially so in setups involving request pipe-lining and/or proxies.
 

--- a/docs/content/news.md
+++ b/docs/content/news.md
@@ -439,7 +439,7 @@
 - permit Transfer-Encoding headers specifying multiple encodings. note: no parameters, still ([PR #3261](https://github.com/benoitc/gunicorn/pull/3261))
 - sdist generation now explicitly excludes sphinx build folder ([PR #3257](https://github.com/benoitc/gunicorn/pull/3257))
 - decode bytes-typed status (as can be passed by gevent) as utf-8 instead of raising `TypeError` ([PR #2336](https://github.com/benoitc/gunicorn/pull/2336))
-- raise correct Exception when encounting invalid chunked requests ([PR #3258](https://github.com/benoitc/gunicorn/pull/3258))
+- raise correct Exception when encountering invalid chunked requests ([PR #3258](https://github.com/benoitc/gunicorn/pull/3258))
 - the SCRIPT_NAME and PATH_INFO headers, when received from allowed forwarders, are no longer restricted for containing an underscore ([PR #3192](https://github.com/benoitc/gunicorn/pull/3192))
 - include IPv6 loopback address ``[::1]`` in default for [forwarded-allow-ips](reference/settings.md#forwarded_allow_ips) and [proxy-allow-ips](reference/settings.md#proxy_allow_ips) ([PR #3192](https://github.com/benoitc/gunicorn/pull/3192))
 
@@ -452,7 +452,7 @@
 ### Breaking changes
 
 - refuse requests where the uri field is empty ([PR #3255](https://github.com/benoitc/gunicorn/pull/3255))
-- refuse requests with invalid CR/LR/NUL in heade field values ([PR #3253](https://github.com/benoitc/gunicorn/pull/3253))
+- refuse requests with invalid CR/LR/NUL in header field values ([PR #3253](https://github.com/benoitc/gunicorn/pull/3253))
 - remove temporary ``--tolerate-dangerous-framing`` switch from 22.0 ([PR #3260](https://github.com/benoitc/gunicorn/pull/3260))
 - If any of the breaking changes affect you, be aware that now refused requests can post a security problem, especially so in setups involving request pipe-lining and/or proxies.
 

--- a/gunicorn/http/parser.py
+++ b/gunicorn/http/parser.py
@@ -29,7 +29,7 @@ class Parser:
         self.mesg = None
         self.source_addr = source_addr
 
-        # request counter (for keepalive connetions)
+        # request counter (for keepalive connections)
         self.req_count = 0
 
     def __iter__(self):

--- a/tests/requests/invalid/013.py
+++ b/tests/requests/invalid/013.py
@@ -10,5 +10,5 @@ cfg = Config()
 cfg.set('limit_request_field_size', 14)
 
 # once this option is removed, this test should not be dropped;
-#  rather, add something involving unnessessary padding
+#  rather, add something involving unnecessary padding
 cfg.set('permit_obsolete_folding', True)


### PR DESCRIPTION
## Summary

Small typo cleanup found by running [codespell](https://github.com/codespell-project/codespell) over the repo. All changes are in comments, the changelog, and a test fixture comment — no behavior change.

## Changes

- `docs/content/news.md` and `docs/content/2024-news.md` (23.0.0 entry):
  - "encounting" → "encountering"
  - "heade field values" → "header field values"
- `gunicorn/http/parser.py`: "keepalive connetions" → "keepalive connections" (comment)
- `tests/requests/invalid/013.py`: "unnessessary" → "unnecessary" (comment)

## Verification

- `codespell` reports zero real typos remaining (only known false positives like the HTTP `TE` header, `caf\xe9` test fixtures, `typing_extensions as te` aliases, and contributor names in `THANKS`).
- `pytest tests/test_invalid_requests.py tests/test_valid_requests.py tests/test_http.py` all pass (134 passed, 134 skipped).
- `pycodestyle` clean on `gunicorn/http/parser.py`.

Per CONTRIBUTING.md: "Not sure if that typo is worth a pull request? Do it! We will appreciate it."