### PR TITLE
chore: minimise dependency on the Python package named 'packaging'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,6 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
 requires-python = ">=3.10"
-dependencies = [
-    "packaging",
-]
 dynamic = ["version"]
 
 [project.urls]
@@ -47,7 +44,10 @@ Documentation = "https://gunicorn.org"
 Changelog = "https://gunicorn.org/news/"
 
 [project.optional-dependencies]
-gevent = ["gevent>=24.10.1"]
+gevent = [
+    "gevent>=24.10.1",
+    "packaging",
+]
 tornado = ["tornado>=6.5.0"]
 gthread = []
 setproctitle = ["setproctitle"]
@@ -57,6 +57,7 @@ testing = [
     "gevent>=24.10.1",
     "h2>=4.1.0",
     "coverage",
+    "packaging",
     "pytest",
     "pytest-cov",
     "pytest-asyncio",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,6 @@
 gevent
 coverage
+packaging
 pytest>=7.2.0
 pytest-cov
 pytest-asyncio


### PR DESCRIPTION
The Python package named `packaging` is only required as a runtime dependency by the `gevent` worker of `gunicorn`; in other words, we do not need to install it as a dependency for installations of other worker types.

This changeset relocates the `packaging` requirement from the default dependencies for `gunicorn` to the `gevent` extras set (and also the `requirements_test.txt` requirements file, so that it is available when the unit tests run).

Resolves #3608 (discussion thread).