### PR TITLE
fix: control socket leaks fds and threads on SIGHUP reload (#3648)

### DIFF
--- a/gunicorn/ctl/server.py
+++ b/gunicorn/ctl/server.py
@@ -96,6 +96,10 @@ class ControlSocketServer:
         self._thread = None
         self._running = False
         self._was_running_before_fork = False
+        # Set by the loop thread once self._loop and self._server are live.
+        # The stop paths wait on it so a shutdown is never scheduled against a
+        # not-yet-initialized loop (which would leak the thread + its fds).
+        self._ready = threading.Event()
 
         # Ensure fork handlers are registered
         _register_fork_handlers()
@@ -106,6 +110,7 @@ class ControlSocketServer:
             return
 
         self._running = True
+        self._ready = threading.Event()
         self._thread = threading.Thread(target=self._run_loop, daemon=True)
         self._thread.start()
 
@@ -122,7 +127,9 @@ class ControlSocketServer:
 
         self._running = False
 
-        if self._loop and self._server:
+        # Wait until the loop is live so the shutdown is actually delivered.
+        self._ready.wait(timeout=2.0)
+        if self._loop is not None:
             # Schedule server close in the loop
             self._loop.call_soon_threadsafe(self._shutdown)
 
@@ -146,7 +153,12 @@ class ControlSocketServer:
         self._was_running_before_fork = True
         self._running = False
 
-        if self._loop and self._server:
+        # Wait until the loop is live before scheduling shutdown. Without this,
+        # a fork that lands while the thread is still starting up skips the
+        # shutdown, join() times out, and the thread is dropped while still
+        # holding its selector fd and the unix socket (the #3648 leak).
+        self._ready.wait(timeout=2.0)
+        if self._loop is not None:
             try:
                 self._loop.call_soon_threadsafe(self._shutdown)
             except RuntimeError:
@@ -155,6 +167,9 @@ class ControlSocketServer:
 
         if self._thread:
             self._thread.join(timeout=2.0)
+            if self._thread.is_alive() and self.arbiter.log:
+                self.arbiter.log.warning(
+                    "control socket thread did not stop before fork")
             self._thread = None
 
         self._loop = None
@@ -167,6 +182,7 @@ class ControlSocketServer:
 
         self._was_running_before_fork = False
         self._running = True
+        self._ready = threading.Event()
         self._thread = threading.Thread(target=self._run_loop, daemon=True)
         self._thread.start()
 
@@ -182,6 +198,10 @@ class ControlSocketServer:
         except Exception as e:
             if self._running and self.arbiter.log:
                 self.arbiter.log.error("Control server error: %s", e)
+        finally:
+            # Release any stop path waiting on readiness, even if the thread
+            # never became ready (eg the server failed to bind).
+            self._ready.set()
 
     async def _serve(self):
         """Main async server loop."""
@@ -208,6 +228,9 @@ class ControlSocketServer:
         if self.arbiter.log:
             self.arbiter.log.info("Control socket listening at %s",
                                   self.socket_path)
+
+        # Loop and server are live; let the stop paths schedule shutdown.
+        self._ready.set()
 
         try:
             async with self._server:

--- a/tests/ctl/test_server.py
+++ b/tests/ctl/test_server.py
@@ -164,6 +164,56 @@ class TestControlSocketServerLifecycle:
         server.stop()
 
 
+class TestControlSocketServerForkLeak:
+    """Regression tests for the SIGHUP fd/thread leak (#3648)."""
+
+    def test_stop_for_fork_joins_thread_started_immediately(self):
+        """_stop_for_fork must stop the thread even with no startup delay.
+
+        Calling _stop_for_fork right after start() lands in the window before
+        the loop thread has set _loop/_server. Before the fix this skipped the
+        shutdown, join() timed out, and the thread was orphaned while still
+        holding its selector fd and the unix socket.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            socket_path = os.path.join(tmpdir, "test.sock")
+            server = ControlSocketServer(MockArbiter(), socket_path)
+
+            server.start()
+            thread = server._thread  # capture before stop drops the reference
+            try:
+                server._stop_for_fork()
+
+                assert not thread.is_alive(), "control thread leaked after fork"
+                assert server._thread is None
+                assert server._loop is None
+                assert server._server is None
+            finally:
+                server.stop()
+
+    def test_repeated_fork_cycles_do_not_leak_threads(self):
+        """A reload spawns workers back to back; no cycle may orphan a thread."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            socket_path = os.path.join(tmpdir, "test.sock")
+            server = ControlSocketServer(MockArbiter(), socket_path)
+
+            threads = []
+            server.start()
+            threads.append(server._thread)
+            try:
+                # Mimic the tight spawn_worker() loop in Arbiter.reload().
+                for _ in range(8):
+                    server._stop_for_fork()
+                    server._restart_after_fork()
+                    threads.append(server._thread)
+            finally:
+                server.stop()
+
+            time.sleep(0.2)
+            alive = [t for t in threads if t is not None and t.is_alive()]
+            assert not alive, f"{len(alive)} control thread(s) leaked"
+
+
 class TestControlSocketServerIntegration:
     """Integration tests for server with client."""
 

--- a/tests/test_control_socket_integration.py
+++ b/tests/test_control_socket_integration.py
@@ -89,12 +89,13 @@ def app_module(tmp_path):
     return str(app_file.parent), "app:application"
 
 
-def start_gunicorn(app_dir, app_name, worker_class, port, control_socket_path):
+def start_gunicorn(app_dir, app_name, worker_class, port, control_socket_path,
+                   workers=2):
     """Start a gunicorn server with specified worker class and control socket."""
     cmd = [
         sys.executable, '-m', 'gunicorn',
         '--bind', f'127.0.0.1:{port}',
-        '--workers', '2',
+        '--workers', str(workers),
         '--worker-class', worker_class,
         '--access-logfile', '-',
         '--error-logfile', '-',
@@ -390,6 +391,69 @@ class TestControlSocketAfterReload:
             # poll for it instead of asserting on a fixed sleep.
             assert wait_for_socket(control_socket, timeout=10), \
                 "Control socket was not re-created after reload"
+
+        finally:
+            cleanup_gunicorn(proc)
+            if os.path.exists(control_socket):
+                os.unlink(control_socket)
+
+
+def _proc_fd_count(pid):
+    """Number of open fds for a process (Linux /proc)."""
+    return len(os.listdir(f"/proc/{pid}/fd"))
+
+
+def _proc_thread_count(pid):
+    """Number of threads for a process (Linux /proc)."""
+    return len(os.listdir(f"/proc/{pid}/task"))
+
+
+@pytest.mark.skipif(
+    not os.path.isdir("/proc/self/fd"),
+    reason="fd/thread counting needs Linux /proc",
+)
+class TestControlSocketReloadLeak:
+    """Regression test for the SIGHUP fd/thread leak (#3648)."""
+
+    def test_repeated_sighup_does_not_leak_fds_or_threads(self, app_module):
+        app_dir, app_name = app_module
+        port = find_free_port()
+        control_socket = get_short_socket_path("leak")
+
+        # More workers widens the back-to-back fork window that triggered the
+        # leak during reload().
+        proc = start_gunicorn(app_dir, app_name, 'sync', port, control_socket,
+                              workers=6)
+        master = proc.pid
+
+        try:
+            assert wait_for_server('127.0.0.1', port, timeout=15), \
+                "server failed to start"
+            assert wait_for_socket(control_socket, timeout=5), \
+                "control socket was not created"
+            time.sleep(1)  # let things settle after boot
+
+            base_fds = _proc_fd_count(master)
+            base_threads = _proc_thread_count(master)
+
+            for _ in range(5):
+                proc.send_signal(signal.SIGHUP)
+                time.sleep(2)  # let the reload complete
+                assert proc.poll() is None, "master died during reload"
+                assert b'Hello, World!' in make_request('127.0.0.1', port)
+
+            # Give any straggler threads a chance to exit.
+            time.sleep(1)
+            final_fds = _proc_fd_count(master)
+            final_threads = _proc_thread_count(master)
+
+            # Before the fix each reload orphaned ~workers threads and their
+            # selector/socket fds; counts grew by dozens. With the fix they stay
+            # flat (allow small slack for timing).
+            assert final_threads <= base_threads + 1, (
+                f"thread leak: {base_threads} -> {final_threads}")
+            assert final_fds <= base_fds + 4, (
+                f"fd leak: {base_fds} -> {final_fds}")
 
         finally:
             cleanup_gunicorn(proc)

--- a/tests/test_control_socket_integration.py
+++ b/tests/test_control_socket_integration.py
@@ -416,15 +416,20 @@ class TestControlSocketReloadLeak:
     """Regression test for the SIGHUP fd/thread leak (#3648)."""
 
     def test_repeated_sighup_does_not_leak_fds_or_threads(self, app_module):
+        n_workers = 6  # more workers widens the back-to-back fork race window
         app_dir, app_name = app_module
         port = find_free_port()
         control_socket = get_short_socket_path("leak")
 
-        # More workers widens the back-to-back fork window that triggered the
-        # leak during reload().
         proc = start_gunicorn(app_dir, app_name, 'sync', port, control_socket,
-                              workers=6)
+                              workers=n_workers)
         master = proc.pid
+
+        def reload_once():
+            proc.send_signal(signal.SIGHUP)
+            time.sleep(2)  # let the reload complete
+            assert proc.poll() is None, "master died during reload"
+            assert b'Hello, World!' in make_request('127.0.0.1', port)
 
         try:
             assert wait_for_server('127.0.0.1', port, timeout=15), \
@@ -433,27 +438,30 @@ class TestControlSocketReloadLeak:
                 "control socket was not created"
             time.sleep(1)  # let things settle after boot
 
-            base_fds = _proc_fd_count(master)
             base_threads = _proc_thread_count(master)
 
-            for _ in range(5):
-                proc.send_signal(signal.SIGHUP)
-                time.sleep(2)  # let the reload complete
-                assert proc.poll() is None, "master died during reload"
-                assert b'Hello, World!' in make_request('127.0.0.1', port)
+            # A couple of reloads to reach steady state. PyPy has no refcounting
+            # GC, so a small constant number of already-closed fds (log reopen,
+            # asyncio self-pipe) can linger until the next collection; measuring
+            # after warmup absorbs that bounded offset.
+            for _ in range(2):
+                reload_once()
+            time.sleep(1)
+            warm_fds = _proc_fd_count(master)
 
-            # Give any straggler threads a chance to exit.
+            # The leak orphaned a thread plus its selector/socket fds on every
+            # worker fork, so a regression keeps climbing by ~workers per reload.
+            # Many more reloads must not grow the counts; a GC offset does not.
+            for _ in range(8):
+                reload_once()
             time.sleep(1)
             final_fds = _proc_fd_count(master)
             final_threads = _proc_thread_count(master)
 
-            # Before the fix each reload orphaned ~workers threads and their
-            # selector/socket fds; counts grew by dozens. With the fix they stay
-            # flat (allow small slack for timing).
             assert final_threads <= base_threads + 1, (
                 f"thread leak: {base_threads} -> {final_threads}")
-            assert final_fds <= base_fds + 4, (
-                f"fd leak: {base_fds} -> {final_fds}")
+            assert final_fds <= warm_fds + n_workers, (
+                f"fd leak: warm {warm_fds} -> final {final_fds} over 8 reloads")
 
         finally:
             cleanup_gunicorn(proc)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -412,7 +412,7 @@ def test_no_body_response_strips_framing(status, method, expect_cl):
 
 
 def test_no_body_response_drops_body_and_warns(caplog):
-    resp, sock = _make_response(method="GET")
+    resp, _ = _make_response(method="GET")
     resp.start_response("204 No Content", [
         ("Content-Type", "text/plain"),
         ("Content-Length", "5"),


### PR DESCRIPTION
Fixes #3648.

With the control socket on, the master leaks fds and threads on every SIGHUP reload and never gives them back. With enough workers and frequent reloads it creeps up until a worker can't open anything and dies with "too many open files". Running with `--no-control-socket` avoids it, and it has been there since the control socket landed in 25.1.0.

The cause is a race in how the control socket handles fork. It runs its asyncio loop in a background thread that gets stopped before each fork and restarted after. A reload spawns the new workers back to back, so the next fork keeps hitting the freshly restarted thread before it has finished coming up. When that happens the stop path can't reach the loop to shut it down, the join times out, and the thread gets dropped while still holding its epoll fd and socket. That orphans one thread and its fds per worker, every reload.

The fix makes the stop path wait until the thread is actually ready before telling it to shut down, so the loop always gets the message and exits cleanly instead of being left running. The stop-before-fork behaviour stays the same, it just becomes reliable.