### PR TITLE
fix: propagate CancelledError in ASGI receive() instead of returning http.disconnect (#3627)

### DIFF
--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -242,12 +242,12 @@ class BodyReceiver:
             self._closed = True
             return {"type": "http.disconnect"}
 
-        # Wait for body chunk to arrive via callback
-        try:
-            await self._wait_for_data()
-            return self._build_receive_result()
-        except asyncio.CancelledError:
-            return {"type": "http.disconnect"}
+        # Wait for body chunk to arrive via callback.  A real disconnect or a
+        # body-wait expiry is surfaced by _wait_for_data via _disconnected; a
+        # task cancellation propagates to the app rather than being masked as
+        # http.disconnect (#3627).
+        await self._wait_for_data()
+        return self._build_receive_result()
 
     def _pop_chunk(self):
         """Pop a chunk and return the appropriate message."""
@@ -322,11 +322,14 @@ class BodyReceiver:
         loop = asyncio.get_event_loop()
         self._waiter = loop.create_future()
 
+        # Wait for a real transport disconnect.  If the application's task is
+        # cancelled (eg the framework cancels its disconnect listener once the
+        # response is done), let CancelledError propagate instead of swallowing
+        # it and returning http.disconnect.  Swallowing it makes frameworks like
+        # Django raise RequestAborted in place of running response.close(),
+        # which skips request_finished and leaks DB connections (#3627).
         try:
-            # Wait indefinitely for disconnect (or until cancelled)
             await self._waiter
-        except asyncio.CancelledError:
-            pass
         finally:
             self._waiter = None
             self._closed = True

--- a/tests/test_asgi_compliance.py
+++ b/tests/test_asgi_compliance.py
@@ -1062,13 +1062,17 @@ class TestBodyReceiverDisconnect:
 
     @pytest.mark.asyncio
     async def test_body_receiver_cancellation_during_wait(self):
-        """Test that receive() handles cancellation while waiting for disconnect.
+        """receive() must propagate CancelledError, not mask it as disconnect.
 
-        When the ASGI task is cancelled (e.g., timeout), the waiting receive()
-        catches the CancelledError, marks itself as closed, and the cancellation
-        propagates up from the await. The body receiver is marked as closed
-        to ensure subsequent calls return disconnect immediately.
+        When the ASGI task is cancelled while receive() waits for a disconnect
+        (eg a framework cancels its disconnect listener once the response is
+        done), the cancellation has to propagate. Returning http.disconnect
+        instead makes Django raise RequestAborted in place of running
+        response.close(), skipping request_finished and leaking DB
+        connections (#3627).
         """
+        import asyncio
+
         from gunicorn.asgi.protocol import BodyReceiver
 
         protocol = self._create_protocol()
@@ -1079,10 +1083,8 @@ class TestBodyReceiverDisconnect:
 
         body_receiver = BodyReceiver(mock_request, protocol)
 
-        # Consume body
+        # Consume body so the next receive() waits for disconnect
         await body_receiver.receive()
-
-        import asyncio
 
         receive_task = asyncio.create_task(body_receiver.receive())
 
@@ -1090,18 +1092,8 @@ class TestBodyReceiverDisconnect:
         await asyncio.sleep(0.01)
         assert not receive_task.done()
 
-        # Cancel the task
+        # Cancel the task: the cancellation must propagate, not be swallowed
         receive_task.cancel()
 
-        # Wait for the task to finish - it may raise CancelledError
-        # or return disconnect depending on timing
-        try:
-            msg = await receive_task
-            # If it returns, it should be a disconnect message
-            assert msg == {"type": "http.disconnect"}
-        except asyncio.CancelledError:
-            # Cancellation propagated - this is also valid
-            pass
-
-        # Body receiver should be marked as closed after cancellation
-        assert body_receiver._closed is True
+        with pytest.raises(asyncio.CancelledError):
+            await receive_task


### PR DESCRIPTION
Fixes #3627.

After an ASGI app finishes reading the request body, a call to `receive()` waits for the client to disconnect. That wait was catching `asyncio.CancelledError` and quietly returning `http.disconnect` instead of letting the cancellation through.

That breaks Django. When the response is done, Django cancels its disconnect-listener task. With the cancel swallowed, the listener saw `http.disconnect` and raised `RequestAborted` rather than `CancelledError`, which escaped `handle()` before `response.close()` could run. So `request_finished` never fired, `close_old_connections()` never ran, and idle DB connections piled up. It worked in 25.1.0 and still works under uvicorn because both let the cancel propagate.

The fix is to stop swallowing it. `CancelledError` now propagates out of `receive()`, both while waiting for disconnect and while waiting for body data. A genuine client disconnect is unaffected since it resolves the waiter normally through `signal_disconnect()` and still returns `http.disconnect`, and body-wait timeouts are still handled the same way.

I tightened the existing cancellation test to require the error to propagate. It fails on the old code and passes with this change.
