### PR TITLE
Support glob patterns in reload_extra_files

### DIFF
--- a/docs/content/reference/settings.md
+++ b/docs/content/reference/settings.md
@@ -153,7 +153,14 @@ Valid engines are:
 Extends [reload](#reload) option to also watch and reload on additional files
 (e.g., templates, configurations, specifications, etc.).
 
+Glob patterns (e.g., ``*.json``) are supported and are expanded to the
+files matching them when gunicorn starts. Files created after startup
+that match a pattern are not picked up until gunicorn is restarted.
+
 !!! info "Added in 19.8"
+
+!!! info "Changed in 26.0.0"
+    Glob patterns are now supported.
 
 ### `spew`
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -6,6 +6,7 @@
 
 import argparse
 import copy
+import glob
 import grp
 import inspect
 import ipaddress
@@ -436,7 +437,13 @@ def validate_list_string(val):
 
 
 def validate_list_of_existing_files(val):
-    return [validate_file_exists(v) for v in validate_list_string(val)]
+    files = []
+    for pattern in validate_list_string(val):
+        if glob.has_magic(pattern):
+            files.extend(sorted(glob.glob(pattern)))
+        else:
+            files.append(validate_file_exists(pattern))
+    return files
 
 
 def validate_string_to_addr_list(val):
@@ -1002,7 +1009,14 @@ class ReloadExtraFiles(Setting):
         Extends :ref:`reload` option to also watch and reload on additional files
         (e.g., templates, configurations, specifications, etc.).
 
+        Glob patterns (e.g., ``*.json``) are supported and are expanded to the
+        files matching them when gunicorn starts. Files created after startup
+        that match a pattern are not picked up until gunicorn is restarted.
+
         .. versionadded:: 19.8
+
+        .. versionchanged:: 26.0.0
+           Glob patterns are now supported.
         """
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -215,6 +215,35 @@ def test_callable_validation():
     pytest.raises(TypeError, c.set, "pre_fork", lambda x: True)
 
 
+def test_reload_extra_files_glob(tmp_path):
+    c = config.Config()
+
+    plain_file = tmp_path / "plain.txt"
+    plain_file.write_text("plain")
+
+    json_dir = tmp_path / "views"
+    json_dir.mkdir()
+    view_configs = [json_dir / "a.json", json_dir / "b.json"]
+    for view_config in view_configs:
+        view_config.write_text("{}")
+    (json_dir / "c.yaml").write_text("")
+
+    c.set("reload_extra_files", [str(plain_file), str(json_dir / "*.json")])
+    assert sorted(c.reload_extra_files) == sorted(
+        [str(plain_file)] + [str(p) for p in view_configs]
+    )
+
+    # A glob pattern that doesn't match anything simply expands to nothing,
+    # it shouldn't raise like a missing literal file path would.
+    c.set("reload_extra_files", [str(json_dir / "*.does-not-exist")])
+    assert c.reload_extra_files == []
+
+    # Non-glob paths must still exist.
+    pytest.raises(
+        ValueError, c.set, "reload_extra_files", [str(tmp_path / "missing.txt")]
+    )
+
+
 def test_reload_engine_validation():
     c = config.Config()
 


### PR DESCRIPTION
### Summary

Resolves #1643.

Currently every entry in `reload_extra_files` / `--reload-extra-file` must be an exact, already-existing file path. This is cumbersome for apps that have many similarly named files to watch (e.g. one `config.json` per view), since a new line has to be added to the config every time a new file is added.

This adds support for glob patterns, e.g.:

```python
reload_extra_files = ["ui/*/config.json", "templates/*.html"]
```

### Implementation

- `validate_list_of_existing_files` now checks each entry with `glob.has_magic()`. Plain paths keep the exact same behavior as before (validated to exist via `validate_file_exists`, raising if missing). Entries containing glob metacharacters are expanded with `glob.glob()` instead.
- A pattern that currently matches no files simply expands to an empty list rather than raising, since that's the expected behavior of a glob (as opposed to a literal path, which is still required to exist).
- Patterns are expanded once, at config validation time (same as before for the existing-files check), so newly created files matching a pattern are picked up on the next gunicorn restart, not live. This matches how the rest of `reload_extra_files` already behaves (it's a list of files handed to the reloader thread at worker boot).
- Regenerated `docs/content/reference/settings.md` via `scripts/build_settings_doc.py` to reflect the updated `reload_extra_files` docstring.

### Testing

- Added `test_reload_extra_files_glob` covering: a glob pattern expanding to the matching files, a glob pattern with zero matches expanding to `[]` instead of raising, and a plain non-existent path still raising `ValueError`.
- `pytest tests/` (1964 passed, 264 skipped), `pylint` (10.00/10), and `pycodestyle` all pass on the changed files.