### PR TITLE
feat: opt-in prior-knowledge h2c support for the gthread worker

### DIFF
--- a/docs/content/guides/http2.md
+++ b/docs/content/guides/http2.md
@@ -29,7 +29,8 @@ gunicorn myapp:app \
 HTTP/2 support requires:
 
 - **SSL/TLS**: HTTP/2 uses ALPN (Application-Layer Protocol Negotiation) which
-  requires an encrypted connection
+  requires an encrypted connection (see [Cleartext HTTP/2](#cleartext-http2-h2c)
+  for the proxy-only exception)
 - **h2 library**: Install with `pip install gunicorn[http2]` or `pip install h2`
 - **Compatible worker**: gthread, gevent, or ASGI workers
 
@@ -79,6 +80,29 @@ certfile = "/path/to/server.crt"
 keyfile = "/path/to/server.key"
 http_protocols = "h2, h1"
 ```
+
+### Cleartext HTTP/2 (h2c)
+
+When TLS is terminated in front of Gunicorn — Cloud Run, fly.io, a
+service-mesh sidecar — the proxy can speak HTTP/2 to the upstream over
+plain TCP. Enable it with the `--h2c` flag (gthread worker):
+
+```bash
+gunicorn myapp:app -k gthread --http-protocols h2,h1 --h2c
+```
+
+Connections that start with the HTTP/2 connection preface are served as
+HTTP/2; everything else falls back to HTTP/1.1 on the same port. Only the
+RFC 9113 prior-knowledge form is supported — the deprecated
+`Upgrade: h2c` handshake is not. Test with:
+
+```bash
+curl --http2-prior-knowledge http://localhost:8000/
+```
+
+!!! warning
+    h2c is cleartext. Only enable it behind a trusted, TLS-terminating
+    proxy. Never expose an h2c port directly to the internet.
 
 ### HTTP/2 Settings
 

--- a/docs/content/guides/http2.md
+++ b/docs/content/guides/http2.md
@@ -83,17 +83,25 @@ http_protocols = "h2, h1"
 
 ### Cleartext HTTP/2 (h2c)
 
-When TLS is terminated in front of Gunicorn — Cloud Run, fly.io, a
-service-mesh sidecar — the proxy can speak HTTP/2 to the upstream over
-plain TCP. Enable it with the `--h2c` flag (gthread worker):
+When TLS is terminated in front of Gunicorn - Cloud Run, fly.io, a
+service-mesh sidecar - the proxy can speak HTTP/2 to the upstream over
+plain TCP. Enable it with the `--http2-prior-knowledge` flag (gthread
+worker):
 
 ```bash
-gunicorn myapp:app -k gthread --http-protocols h2,h1 --h2c
+gunicorn myapp:app -k gthread --http-protocols h2,h1 --http2-prior-knowledge
 ```
 
-Connections that start with the HTTP/2 connection preface are served as
-HTTP/2; everything else falls back to HTTP/1.1 on the same port. Only the
-RFC 9113 prior-knowledge form is supported — the deprecated
+h2c is only accepted from peers in `forwarded_allow_ips` - the same
+trust list used for forwarded headers, which in this deployment shape is
+exactly the TLS-terminating proxy. A trusted peer that opens a
+connection with the HTTP/2 connection preface is served HTTP/2; anything
+else from a trusted peer (an HTTP/1.x request, a malformed or stalled
+preface) is rejected with a 400 rather than silently downgraded, so a
+misconfigured proxy fails loudly instead of quietly losing HTTP/2.
+Untrusted peers are served HTTP/1.1 exactly as if the flag were off.
+
+Only the RFC 9113 prior-knowledge form is supported - the deprecated
 `Upgrade: h2c` handshake is not. Test with:
 
 ```bash

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -2460,25 +2460,31 @@ class HTTPProtocols(Setting):
         .. note::
            HTTP/2 cleartext (h2c) is disabled by default. Deployments behind
            a TLS-terminating proxy can enable prior-knowledge h2c with
-           :ref:`h2c`.
+           :ref:`http2-prior-knowledge`.
 
         .. versionadded:: 25.0.0
         """
 
 
-class HTTP2Cleartext(Setting):
-    name = "h2c"
+class HTTP2PriorKnowledge(Setting):
+    name = "http2_prior_knowledge"
     section = "HTTP/2"
-    cli = ["--h2c"]
+    cli = ["--http2-prior-knowledge"]
     validator = validate_bool
     action = "store_true"
     default = False
     desc = """\
         Accept HTTP/2 over cleartext TCP (h2c) with prior knowledge.
 
-        When enabled and no TLS is configured, connections that start with
-        the HTTP/2 connection preface (``PRI * HTTP/2.0``) are served as
-        HTTP/2. All other connections fall back to HTTP/1.1 as usual.
+        When enabled and no TLS is configured, connections from peers in
+        :ref:`forwarded-allow-ips` that start with the HTTP/2 connection
+        preface (``PRI * HTTP/2.0``) are served as HTTP/2. Anything else
+        from a trusted peer (an HTTP/1.x request, a malformed or stalled
+        preface) is rejected with a 400 response: a peer on a
+        prior-knowledge port is expected to speak HTTP/2, and a silent
+        downgrade would only hide misconfiguration. Peers outside
+        ``forwarded_allow_ips`` are served HTTP/1.1 exactly as if this
+        setting were off.
 
         Only the RFC 9113 prior-knowledge form is supported. The HTTP/1.1
         ``Upgrade: h2c`` mechanism was deprecated by RFC 9113 and is not

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -2458,10 +2458,42 @@ class HTTPProtocols(Setting):
         * ALPN-capable TLS client
 
         .. note::
-           HTTP/2 cleartext (h2c) is not supported due to security concerns
-           and lack of browser support.
+           HTTP/2 cleartext (h2c) is disabled by default. Deployments behind
+           a TLS-terminating proxy can enable prior-knowledge h2c with
+           :ref:`h2c`.
 
         .. versionadded:: 25.0.0
+        """
+
+
+class HTTP2Cleartext(Setting):
+    name = "h2c"
+    section = "HTTP/2"
+    cli = ["--h2c"]
+    validator = validate_bool
+    action = "store_true"
+    default = False
+    desc = """\
+        Accept HTTP/2 over cleartext TCP (h2c) with prior knowledge.
+
+        When enabled and no TLS is configured, connections that start with
+        the HTTP/2 connection preface (``PRI * HTTP/2.0``) are served as
+        HTTP/2. All other connections fall back to HTTP/1.1 as usual.
+
+        Only the RFC 9113 prior-knowledge form is supported. The HTTP/1.1
+        ``Upgrade: h2c`` mechanism was deprecated by RFC 9113 and is not
+        implemented.
+
+        This is intended for deployments where TLS is terminated by a
+        trusted proxy that speaks HTTP/2 to the upstream (e.g. Cloud Run,
+        fly.io, or a service-mesh sidecar). Do not expose a cleartext
+        HTTP/2 port directly to the internet.
+
+        Requires ``h2`` in :ref:`http-protocols` and the h2 library
+        (``pip install gunicorn[http2]``). Ignored when TLS is configured;
+        with TLS, HTTP/2 is negotiated via ALPN instead.
+
+        .. versionadded:: 26.0.0
         """
 
 

--- a/gunicorn/http/errors.py
+++ b/gunicorn/http/errors.py
@@ -172,3 +172,11 @@ class ForbiddenProxyRequest(ParseException):
 class InvalidSchemeHeaders(ParseException):
     def __str__(self):
         return "Contradictory scheme headers"
+
+
+class InvalidH2CPreface(ParseException):
+    def __init__(self, data):
+        self.data = data
+
+    def __str__(self):
+        return "Expected HTTP/2 connection preface, got %r" % (self.data,)

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -21,6 +21,7 @@ from gunicorn.http.errors import (
     LimitRequestHeaders, LimitRequestLine,
     UnsupportedTransferCoding, ExpectationFailed,
     ConfigurationProblem, ObsoleteFolding,
+    InvalidH2CPreface,
 )
 from gunicorn.http.wsgi import Response, default_environ
 from gunicorn.reloader import reloader_engines
@@ -207,7 +208,7 @@ class Worker:
             InvalidProxyLine, ForbiddenProxyRequest,
             InvalidSchemeHeaders, UnsupportedTransferCoding,
             ConfigurationProblem, ObsoleteFolding, ExpectationFailed,
-            SSLError,
+            InvalidH2CPreface, SSLError,
         )):
 
             status_int = 400
@@ -248,6 +249,8 @@ class Worker:
                 mesg = "Request forbidden"
                 status_int = 403
             elif isinstance(exc, InvalidSchemeHeaders):
+                mesg = "%s" % str(exc)
+            elif isinstance(exc, InvalidH2CPreface):
                 mesg = "%s" % str(exc)
             elif isinstance(exc, SSLError):
                 reason = "Forbidden"

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -37,6 +37,14 @@ _DEFER = object()
 # the main poller to prevent thread pool exhaustion from slow clients.
 DEFAULT_WORKER_DATA_TIMEOUT = 5.0
 
+# HTTP/2 connection preface sent by clients using prior-knowledge h2c
+# (RFC 9113 section 3.4).
+H2C_PREFACE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+
+# How long (in seconds) to wait for the full connection preface once the
+# first bytes of a candidate h2c connection have arrived.
+H2C_PREFACE_TIMEOUT = 1.0
+
 
 class TConn:
 
@@ -82,8 +90,61 @@ class TConn:
                     self.parser.initiate_connection()
                     return
 
+            elif (
+                self.cfg.h2c
+                and "h2" in self.cfg.http_protocols
+                and getattr(self.cfg, "protocol", "http") == "http"
+            ):
+                # HTTP/2 cleartext (h2c) with prior knowledge (RFC 9113
+                # section 3.4): the client opens a plain TCP connection and
+                # immediately sends the HTTP/2 connection preface.
+                matched, buf = self._read_h2c_preface()
+                if matched:
+                    self.is_http2 = True
+                    self.parser = http.get_parser(
+                        self.cfg, self.sock, self.client, http2_connection=True
+                    )
+                    self.parser.initiate_connection()
+                    # The consumed preface bytes still need to reach the
+                    # HTTP/2 state machine. The preface alone cannot
+                    # complete a request, so nothing is dropped here.
+                    self.parser.receive_data(buf)
+                    return
+                if buf:
+                    # Not an HTTP/2 preface: serve as HTTP/1.x, returning
+                    # the consumed bytes to the parser.
+                    self.parser = http.get_parser(self.cfg, self.sock, self.client)
+                    self.parser.unreader.unread(buf)
+                    return
+
             # initialize the HTTP/1.x parser
             self.parser = http.get_parser(self.cfg, self.sock, self.client)
+
+    def _read_h2c_preface(self):
+        """Read up to the length of the HTTP/2 connection preface.
+
+        Consumes bytes from the socket until the preface is complete, a
+        byte diverges from it, the peer closes, or the preface timeout
+        expires. Returns a tuple ``(matched, consumed_bytes)``; on a
+        non-match the consumed bytes must be handed back to the HTTP/1.x
+        parser by the caller.
+        """
+        buf = b""
+        self.sock.settimeout(H2C_PREFACE_TIMEOUT)
+        try:
+            while len(buf) < len(H2C_PREFACE):
+                try:
+                    chunk = self.sock.recv(len(H2C_PREFACE) - len(buf))
+                except TimeoutError:
+                    return False, buf
+                if not chunk:
+                    return False, buf
+                buf += chunk
+                if not H2C_PREFACE.startswith(buf):
+                    return False, buf
+            return True, buf
+        finally:
+            self.sock.settimeout(None)
 
     def set_timeout(self):
         # Use monotonic clock for reliability (time.time() can jump due to NTP)

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -27,6 +27,8 @@ from .. import http
 from .. import util
 from .. import sock
 from ..http import wsgi
+from ..http.errors import InvalidH2CPreface
+from ..http.message import _ip_in_allow_list
 
 
 # Sentinel value to indicate connection should be deferred back to poller
@@ -91,13 +93,16 @@ class TConn:
                     return
 
             elif (
-                self.cfg.h2c
+                self.cfg.http2_prior_knowledge
                 and "h2" in self.cfg.http_protocols
                 and getattr(self.cfg, "protocol", "http") == "http"
+                and self._peer_trusted_for_h2c()
             ):
                 # HTTP/2 cleartext (h2c) with prior knowledge (RFC 9113
                 # section 3.4): the client opens a plain TCP connection and
-                # immediately sends the HTTP/2 connection preface.
+                # immediately sends the HTTP/2 connection preface. Peers
+                # outside forwarded_allow_ips never reach this branch and
+                # are served HTTP/1.x as if the setting were off.
                 matched, buf = self._read_h2c_preface()
                 if matched:
                     self.is_http2 = True
@@ -110,24 +115,37 @@ class TConn:
                     # complete a request, so nothing is dropped here.
                     self.parser.receive_data(buf)
                     return
-                if buf:
-                    # Not an HTTP/2 preface: serve as HTTP/1.x, returning
-                    # the consumed bytes to the parser.
-                    self.parser = http.get_parser(self.cfg, self.sock, self.client)
-                    self.parser.unreader.unread(buf)
-                    return
+                # A trusted peer on a prior-knowledge port must speak
+                # HTTP/2. Anything else (an HTTP/1.x request, a malformed
+                # or stalled preface) is rejected with a 400 rather than
+                # silently downgraded.
+                raise InvalidH2CPreface(buf)
 
             # initialize the HTTP/1.x parser
             self.parser = http.get_parser(self.cfg, self.sock, self.client)
+
+    def _peer_trusted_for_h2c(self):
+        """Whether the peer may speak prior-knowledge h2c.
+
+        Reuses the ``forwarded_allow_ips`` trust list: h2c is only ever
+        expected from the TLS-terminating proxy in front of Gunicorn,
+        which is the same peer trusted to set forwarded headers. Unix
+        socket peers are trusted, matching the forwarded-header policy.
+        """
+        if not isinstance(self.client, tuple):
+            return True
+        return _ip_in_allow_list(
+            self.client[0],
+            self.cfg.forwarded_allow_ips,
+            self.cfg.forwarded_allow_networks(),
+        )
 
     def _read_h2c_preface(self):
         """Read up to the length of the HTTP/2 connection preface.
 
         Consumes bytes from the socket until the preface is complete, a
         byte diverges from it, the peer closes, or the preface timeout
-        expires. Returns a tuple ``(matched, consumed_bytes)``; on a
-        non-match the consumed bytes must be handed back to the HTTP/1.x
-        parser by the caller.
+        expires. Returns a tuple ``(matched, consumed_bytes)``.
         """
         buf = b""
         self.sock.settimeout(H2C_PREFACE_TIMEOUT)

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -19,11 +19,17 @@ except ImportError:
     H2_AVAILABLE = False
 
 from gunicorn.config import Config
+from gunicorn.http.errors import InvalidH2CPreface
 from gunicorn.http.parser import RequestParser
 from gunicorn.workers import gthread
 
+# An address inside the default forwarded_allow_ips ("127.0.0.1,::1").
+TRUSTED_ADDR = ("127.0.0.1", 0)
+# TEST-NET-3 (RFC 5737), never inside the default trust list.
+UNTRUSTED_ADDR = ("203.0.113.7", 0)
 
-def make_conn(cfg, client_data=None):
+
+def make_conn(cfg, client_data=None, addr=TRUSTED_ADDR):
     """Build a TConn around one end of a socketpair.
 
     Returns (conn, client_sock). Bytes in client_data are sent before
@@ -32,25 +38,25 @@ def make_conn(cfg, client_data=None):
     server_sock, client_sock = socket.socketpair()
     if client_data:
         client_sock.sendall(client_data)
-    conn = gthread.TConn(cfg, server_sock, ("127.0.0.1", 0), None)
+    conn = gthread.TConn(cfg, server_sock, addr, None)
     return conn, client_sock
 
 
 def h2c_config():
     cfg = Config()
     cfg.set("http_protocols", "h2,h1")
-    cfg.set("h2c", True)
+    cfg.set("http2_prior_knowledge", True)
     return cfg
 
 
 class TestH2CConfig:
     def test_disabled_by_default(self):
-        assert Config().h2c is False
+        assert Config().http2_prior_knowledge is False
 
     def test_can_be_enabled(self):
         cfg = Config()
-        cfg.set("h2c", True)
-        assert cfg.h2c is True
+        cfg.set("http2_prior_knowledge", True)
+        assert cfg.http2_prior_knowledge is True
 
 
 class TestH2CDisabled:
@@ -70,7 +76,8 @@ class TestH2CDisabled:
     def test_no_peek_when_h2_not_in_protocols(self):
         """h2c flag alone is not enough; h2 must be an enabled protocol."""
         cfg = Config()
-        cfg.set("h2c", True)  # http_protocols left at default "h1"
+        # http_protocols left at default "h1"
+        cfg.set("http2_prior_knowledge", True)
         conn, client = make_conn(cfg, gthread.H2C_PREFACE)
         try:
             conn.init()
@@ -113,12 +120,67 @@ class TestH2CPriorKnowledge:
             client.close()
 
 
-class TestH2CFallback:
-    def test_http1_request_falls_back_and_parses(self):
-        """A plain HTTP/1.1 request must be served untouched, including
-        the bytes consumed while sniffing the preface."""
+class TestH2CTrustedPeerRejection:
+    """A trusted peer on a prior-knowledge port must speak HTTP/2.
+
+    Anything else is rejected with InvalidH2CPreface (mapped to a 400 by
+    the worker) instead of being silently downgraded to HTTP/1.x.
+    """
+
+    def test_http1_request_rejected(self):
         request = b"GET /ping HTTP/1.1\r\nHost: example.com\r\n\r\n"
         conn, client = make_conn(h2c_config(), request)
+        try:
+            with pytest.raises(InvalidH2CPreface):
+                conn.init()
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_diverging_bytes_rejected_immediately(self):
+        """First byte differs from the preface: no waiting occurs."""
+        request = b"XGET /nope HTTP/1.1\r\n"
+        conn, client = make_conn(h2c_config(), request)
+        try:
+            start = time.monotonic()
+            with pytest.raises(InvalidH2CPreface):
+                conn.init()
+            assert time.monotonic() - start < gthread.H2C_PREFACE_TIMEOUT
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_partial_preface_times_out_rejected(self, monkeypatch):
+        """A client that stalls mid-preface is rejected, not downgraded."""
+        monkeypatch.setattr(gthread, "H2C_PREFACE_TIMEOUT", 0.05)
+        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE[:10])
+        try:
+            with pytest.raises(InvalidH2CPreface):
+                conn.init()
+        finally:
+            conn.sock.close()
+            client.close()
+
+
+class TestH2CUntrustedPeer:
+    """Peers outside forwarded_allow_ips never get the preface sniffed."""
+
+    def test_preface_from_untrusted_peer_gets_http1(self):
+        conn, client = make_conn(
+            h2c_config(), gthread.H2C_PREFACE, addr=UNTRUSTED_ADDR
+        )
+        try:
+            conn.init()
+            assert conn.is_http2 is False
+            assert isinstance(conn.parser, RequestParser)
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_http1_from_untrusted_peer_parses(self):
+        """Untrusted h1 traffic is byte-for-byte unaffected by the flag."""
+        request = b"GET /ping HTTP/1.1\r\nHost: example.com\r\n\r\n"
+        conn, client = make_conn(h2c_config(), request, addr=UNTRUSTED_ADDR)
         try:
             conn.init()
             assert conn.is_http2 is False
@@ -129,32 +191,32 @@ class TestH2CFallback:
             conn.sock.close()
             client.close()
 
-    def test_diverging_bytes_fall_back_immediately(self):
-        """First byte differs from the preface: no waiting occurs."""
-        request = b"XGET /nope HTTP/1.1\r\n"
-        conn, client = make_conn(h2c_config(), request)
+    @pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")
+    def test_wildcard_allow_list_trusts_any_peer(self):
+        cfg = h2c_config()
+        cfg.set("forwarded_allow_ips", "*")
+        conn, client = make_conn(cfg, gthread.H2C_PREFACE, addr=UNTRUSTED_ADDR)
         try:
-            start = time.monotonic()
             conn.init()
-            assert time.monotonic() - start < gthread.H2C_PREFACE_TIMEOUT
-            assert conn.is_http2 is False
+            assert conn.is_http2 is True
         finally:
             conn.sock.close()
             client.close()
 
-    def test_partial_preface_times_out_to_http1(self, monkeypatch):
-        """A client that stalls mid-preface ends up on HTTP/1.x."""
-        monkeypatch.setattr(gthread, "H2C_PREFACE_TIMEOUT", 0.05)
-        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE[:10])
+    @pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")
+    def test_unix_socket_peer_is_trusted(self):
+        """Non-tuple peer addresses (unix sockets) follow the
+        forwarded-header policy and are trusted."""
+        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE, addr="")
         try:
             conn.init()
-            assert conn.is_http2 is False
-            # The consumed bytes were handed back to the HTTP/1.x parser
-            assert conn.parser.unreader.buf.getvalue() == gthread.H2C_PREFACE[:10]
+            assert conn.is_http2 is True
         finally:
             conn.sock.close()
             client.close()
 
+
+class TestH2CProtocolGuard:
     def test_uwsgi_protocol_not_sniffed(self):
         """The uwsgi protocol has its own parser; h2c must not touch it."""
         cfg = h2c_config()

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+"""Tests for HTTP/2 cleartext (h2c) prior-knowledge support."""
+
+import socket
+import threading
+import time
+
+import pytest
+
+# Check if h2 is available
+try:
+    import h2.connection  # pylint: disable=unused-import
+    H2_AVAILABLE = True
+except ImportError:
+    H2_AVAILABLE = False
+
+from gunicorn.config import Config
+from gunicorn.http.parser import RequestParser
+from gunicorn.workers import gthread
+
+
+def make_conn(cfg, client_data=None):
+    """Build a TConn around one end of a socketpair.
+
+    Returns (conn, client_sock). Bytes in client_data are sent before
+    TConn.init() runs, mimicking a client that talks first.
+    """
+    server_sock, client_sock = socket.socketpair()
+    if client_data:
+        client_sock.sendall(client_data)
+    conn = gthread.TConn(cfg, server_sock, ("127.0.0.1", 0), None)
+    return conn, client_sock
+
+
+def h2c_config():
+    cfg = Config()
+    cfg.set("http_protocols", "h2,h1")
+    cfg.set("h2c", True)
+    return cfg
+
+
+class TestH2CConfig:
+    def test_disabled_by_default(self):
+        assert Config().h2c is False
+
+    def test_can_be_enabled(self):
+        cfg = Config()
+        cfg.set("h2c", True)
+        assert cfg.h2c is True
+
+
+class TestH2CDisabled:
+    def test_preface_ignored_when_h2c_off(self):
+        """Without the flag, a preface-sending client gets HTTP/1.x."""
+        cfg = Config()
+        cfg.set("http_protocols", "h2,h1")
+        conn, client = make_conn(cfg, gthread.H2C_PREFACE)
+        try:
+            conn.init()
+            assert conn.is_http2 is False
+            assert isinstance(conn.parser, RequestParser)
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_no_peek_when_h2_not_in_protocols(self):
+        """h2c flag alone is not enough; h2 must be an enabled protocol."""
+        cfg = Config()
+        cfg.set("h2c", True)  # http_protocols left at default "h1"
+        conn, client = make_conn(cfg, gthread.H2C_PREFACE)
+        try:
+            conn.init()
+            assert conn.is_http2 is False
+        finally:
+            conn.sock.close()
+            client.close()
+
+
+@pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")
+class TestH2CPriorKnowledge:
+    def test_preface_selects_http2(self):
+        from gunicorn.http2.connection import HTTP2ServerConnection
+
+        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE)
+        try:
+            conn.init()
+            assert conn.is_http2 is True
+            assert isinstance(conn.parser, HTTP2ServerConnection)
+            # initiate_connection() must have sent the server SETTINGS frame
+            client.settimeout(1.0)
+            assert client.recv(1024)
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_split_preface_selects_http2(self):
+        """Preface arriving in two segments is still recognized."""
+        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE[:10])
+        sender = threading.Timer(
+            0.05, client.sendall, args=(gthread.H2C_PREFACE[10:],)
+        )
+        sender.start()
+        try:
+            conn.init()
+            assert conn.is_http2 is True
+        finally:
+            sender.join()
+            conn.sock.close()
+            client.close()
+
+
+class TestH2CFallback:
+    def test_http1_request_falls_back_and_parses(self):
+        """A plain HTTP/1.1 request must be served untouched, including
+        the bytes consumed while sniffing the preface."""
+        request = b"GET /ping HTTP/1.1\r\nHost: example.com\r\n\r\n"
+        conn, client = make_conn(h2c_config(), request)
+        try:
+            conn.init()
+            assert conn.is_http2 is False
+            req = next(conn.parser)
+            assert req.method == "GET"
+            assert req.path == "/ping"
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_diverging_bytes_fall_back_immediately(self):
+        """First byte differs from the preface: no waiting occurs."""
+        request = b"XGET /nope HTTP/1.1\r\n"
+        conn, client = make_conn(h2c_config(), request)
+        try:
+            start = time.monotonic()
+            conn.init()
+            assert time.monotonic() - start < gthread.H2C_PREFACE_TIMEOUT
+            assert conn.is_http2 is False
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_partial_preface_times_out_to_http1(self, monkeypatch):
+        """A client that stalls mid-preface ends up on HTTP/1.x."""
+        monkeypatch.setattr(gthread, "H2C_PREFACE_TIMEOUT", 0.05)
+        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE[:10])
+        try:
+            conn.init()
+            assert conn.is_http2 is False
+            # The consumed bytes were handed back to the HTTP/1.x parser
+            assert conn.parser.unreader.buf.getvalue() == gthread.H2C_PREFACE[:10]
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_uwsgi_protocol_not_sniffed(self):
+        """The uwsgi protocol has its own parser; h2c must not touch it."""
+        cfg = h2c_config()
+        cfg.set("protocol", "uwsgi")
+        conn, client = make_conn(cfg, gthread.H2C_PREFACE)
+        try:
+            conn.init()
+            assert conn.is_http2 is False
+        finally:
+            conn.sock.close()
+            client.close()


### PR DESCRIPTION
Closes #3489

Makes #3489 concrete, as asked in the thread - small enough to judge the actual complexity.

HTTP/2 currently only engages over TLS via ALPN. The h2 machinery itself doesn't care about the transport, so this adds the missing cleartext way in:

- New `--http2-prior-knowledge` flag, **off by default**. Only active when `h2` is in `--http-protocols` and no TLS is configured. With TLS, ALPN keeps doing its thing, untouched.
- In the gthread worker, the preface is only sniffed for peers trusted per `forwarded_allow_ips` (i.e. the TLS-terminating proxy; unix socket peers count as trusted, same semantics as the forwarded-header policy). A trusted peer whose first bytes match the HTTP/2 connection preface (`PRI * HTTP/2.0...`) goes down the existing `handle_http2` path. Anything else from a trusted peer (an h1 request, a malformed or stalled preface) gets a 400 - on a prior-knowledge port the proxy is expected to speak h2, and a silent downgrade would only hide misconfiguration. Peers outside the allow list are served HTTP/1.1 byte-for-byte as if the flag were off, no sniff and no preface deadline.
- Prior-knowledge only (RFC 9113 §3.4). The old `Upgrade: h2c` dance was deprecated by RFC 9113, so it's deliberately not implemented - which also sidesteps most of the historical security concern; the docs mark this as trusted-proxy-only either way.

Target use case is the one from the thread: platforms and meshes that terminate TLS and talk h2c upstream (Cloud Run, fly.io, Istio sidecars - @frittentheke's case). Without this, that hop silently drops to HTTP/1.1.

Verified end-to-end: `curl --http2-prior-knowledge` gets HTTP/2 with the flag on, a plain h1 curl from a trusted peer gets a 400 with a warning in the log, and with the flag off a preface is rejected exactly as today. 14 tests in `tests/test_http2_h2c.py` covering the trusted 400 paths, untrusted passthrough, `*` allow list, and unix socket peers; full suite passes.

Scope is gthread only for now - if the approach is acceptable the async workers can follow the same pattern in a follow-up.

@benoitc the docs currently say h2c is intentionally unsupported, so this stays a draft until you weigh in. If opt-in prior-knowledge is still not something you want in core, happy to close.
