### PR TITLE
asgi: decrement nr_conns on server-initiated connection close (#3661)

### DIFF
--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -362,6 +362,11 @@ class ASGIProtocol(asyncio.Protocol):
 
         # Connection state
         self._closed = False
+        # Guards the connection_lost() cleanup so it runs exactly once. Kept
+        # separate from ``_closed`` because a server-initiated close sets
+        # ``_closed`` early (in _close_transport), and connection_lost() must
+        # still run its cleanup (e.g. decrement nr_conns) afterwards.
+        self._conn_lost_handled = False
         self._body_receiver = None  # Set per-request for disconnect signaling
 
         # Response buffering for write batching
@@ -679,10 +684,14 @@ class ASGIProtocol(asyncio.Protocol):
 
         See: https://github.com/benoitc/gunicorn/issues/3484
         """
-        # Guard against multiple calls (idempotent)
-        if self._closed:
+        # Guard against multiple calls (idempotent). Use a dedicated flag rather
+        # than ``_closed``: a server-initiated close sets ``_closed`` in
+        # _close_transport() before the transport reports the loss, and the
+        # cleanup below (notably decrementing nr_conns) must still run.
+        if self._conn_lost_handled:
             return
 
+        self._conn_lost_handled = True
         self._closed = True
         self.worker.nr_conns -= 1
 

--- a/tests/test_asgi_disconnect.py
+++ b/tests/test_asgi_disconnect.py
@@ -103,6 +103,28 @@ class TestASGIGracefulDisconnect:
         assert mock_worker.nr_conns == 1  # Should not decrement again
         # Closed flag is still set
 
+    def test_server_initiated_close_still_decrements_nr_conns(self, mock_worker):
+        """A server-initiated close must not leak the connection count (#3661).
+
+        _close_transport() sets ``_closed`` before asyncio reports the transport
+        loss, so connection_lost() must still run its cleanup and decrement
+        nr_conns. Otherwise every graceful stop waits out the full timeout.
+        """
+        protocol = ASGIProtocol(mock_worker)
+        protocol.reader = mock.Mock()
+        protocol.transport = mock.Mock()
+        mock_worker.nr_conns = 1
+
+        # Server closes the connection (e.g. `Connection: close`, keepalive
+        # timeout), which sets ``_closed`` early.
+        protocol._close_transport()
+        assert protocol._closed is True
+        assert mock_worker.nr_conns == 1
+
+        # asyncio then reports the transport loss.
+        protocol.connection_lost(None)
+        assert mock_worker.nr_conns == 0
+
     def test_disconnect_does_not_cancel_immediately(self, mock_worker):
         """Test that connection_lost doesn't cancel task immediately."""
         protocol = ASGIProtocol(mock_worker)


### PR DESCRIPTION
## Summary

Fixes #3661. On the ASGI worker, `nr_conns` is never decremented for **server-initiated** connection closes, so it grows with worker age and every graceful stop (`SIGTERM`, `--max-requests` autorestart) blocks for the full `graceful_timeout` — even on an idle worker. This hits any setup with `Connection: close` / HTTP/1.0-per-request (e.g. nginx proxying to the worker).

## Root cause

`ASGIProtocol` used a single `_closed` flag for two different jobs:

- `_close_transport()` sets `_closed = True` to mark the transport closed;
- `connection_lost()` used `if self._closed: return` as its idempotency guard.

A **client**-initiated close calls `connection_lost()` directly (`_closed` is `False`) → the count is decremented. A **server**-initiated close runs `_close_transport()` first, setting `_closed = True`; when asyncio then calls `connection_lost()`, the guard returns early and skips `self.worker.nr_conns -= 1` (and the rest of the cleanup).

## Fix

Introduce a dedicated `_conn_lost_handled` flag for `connection_lost()`'s idempotency guard, independent of the transport's `_closed` state. The cleanup (decrementing `nr_conns`, disconnect signalling, task cancellation) now runs exactly once regardless of who initiated the close.

## Tests

- Added `test_server_initiated_close_still_decrements_nr_conns`: `_close_transport()` then `connection_lost()` must leave `nr_conns == 0`. It fails on `master` (stays `1`) and passes here.
- `tests/test_asgi_disconnect.py` (14) and `tests/test_asgi_worker.py` (32) pass; the full ASGI suite is green (628 passed, 121 skipped); `pycodestyle` clean.

Happy to add a changelog entry if you'd like one.

*Disclosure: prepared with AI assistance; reviewed and verified locally.*
