### PR TITLE
Fix nr_conns leak when transport is closed by server in ASGI worker

### DIFF
--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -1461,6 +1461,7 @@ class ASGIProtocol(asyncio.Protocol):
                 self.transport.close()
             except Exception:
                 pass
+            self.worker.nr_conns -= 1
             self._closed = True
 
     async def _handle_http2_connection(self, transport, ssl_object):

--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -1454,6 +1454,8 @@ class ASGIProtocol(asyncio.Protocol):
         which helps ensure buffered data is flushed before closing.
         """
         if self.transport and not self._closed:
+            self._closed = True
+            self.worker.nr_conns -= 1
             try:
                 # Signal end of writing to help flush buffers
                 if self.transport.can_write_eof():
@@ -1461,8 +1463,6 @@ class ASGIProtocol(asyncio.Protocol):
                 self.transport.close()
             except Exception:
                 pass
-            self.worker.nr_conns -= 1
-            self._closed = True
 
     async def _handle_http2_connection(self, transport, ssl_object):
         """Handle an HTTP/2 connection."""

--- a/tests/test_asgi_disconnect.py
+++ b/tests/test_asgi_disconnect.py
@@ -103,6 +103,23 @@ class TestASGIGracefulDisconnect:
         assert mock_worker.nr_conns == 1  # Should not decrement again
         # Closed flag is still set
 
+    def test_close_transport_decrements_connection_count_once(self, mock_worker):
+        """Closing the transport should not leak or double-decrement connections."""
+        protocol = ASGIProtocol(mock_worker)
+        protocol.transport = mock.Mock()
+        protocol.transport.can_write_eof.return_value = False
+        mock_worker.nr_conns = 1
+
+        protocol._close_transport()
+
+        assert protocol._closed is True
+        assert mock_worker.nr_conns == 0
+        protocol.transport.close.assert_called_once()
+
+        # asyncio calls connection_lost after transport.close(); it must be a no-op.
+        protocol.connection_lost(None)
+        assert mock_worker.nr_conns == 0
+
     def test_disconnect_does_not_cancel_immediately(self, mock_worker):
         """Test that connection_lost doesn't cancel task immediately."""
         protocol = ASGIProtocol(mock_worker)


### PR DESCRIPTION
When the server initiates a connection close via `_close_transport()`, `self._closed` is set to `True` but `nr_conns` is not decremented. When asyncio subsequently delivers `connection_lost()`, the idempotence guard (`if self._closed: return`) prevents the decrement from ever happening.

This causes every server-initiated close (HTTP/1.0 responses, keepalive timeouts, error aborts) to permanently leak one count. Since `_shutdown()` waits on `nr_conns` to reach zero, every graceful worker stop runs to the full `graceful_timeout` deadline.

Fix: decrement `nr_conns` in `_close_transport()` inside the `if self.transport and not self._closed` guard, so the count stays balanced regardless of which side initiates the close. The `connection_lost()` path handles client-initiated closes and the two paths are mutually exclusive.

Fixes #3661