### PR TITLE
reloader: treat empty dirname as cwd for inotify watches

### DIFF
--- a/gunicorn/reloader.py
+++ b/gunicorn/reloader.py
@@ -81,7 +81,7 @@ if has_inotify:
         def add_extra_file(self, filename):
             super().add_extra_file(filename)
 
-            dirname = os.path.dirname(filename)
+            dirname = os.path.dirname(filename) or '.'
             if dirname in self._dirs:
                 return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ testing = [
     "pytest-asyncio",
     "uvloop>=0.19.0",
     "httpx[http2]",
+    "inotify>=0.2.10; sys_platform == 'linux'",
 ]
 
 [project.scripts]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,3 +6,4 @@ pytest-asyncio
 gunicorn_h1c>=0.6.5
 h2>=4.1.0
 uvloop>=0.19.0
+inotify>=0.2.10; sys_platform == 'linux'

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -4,6 +4,8 @@
 
 import unittest.mock as mock
 
+import pytest
+
 from gunicorn.app.base import Application
 from gunicorn.workers.base import Worker
 from gunicorn.reloader import reloader_engines
@@ -70,3 +72,32 @@ def test_start_reloader_after_load_wsgi():
         mock.call.load_wsgi(),
         mock.call.reloader_start(),
     ])
+
+
+def test_inotify_extra_file_current_dir():
+    """Relative extra files in the cwd should not crash the inotify reloader."""
+    pytest.importorskip("inotify", reason="inotify reloader requires the inotify package")
+
+    from gunicorn import reloader as reloader_mod
+
+    if not reloader_mod.has_inotify:
+        pytest.skip("inotify reloader is only available on Linux")
+
+    calls = []
+
+    # Build a reloader and force the dirname('') path through add_extra_file.
+    r = reloader_mod.InotifyReloader(callback=lambda f: None)
+
+    # Replace watcher with a mock-like object that records add_watch dirs.
+    class FakeWatcher:
+        def add_watch(self, dirname, mask=None):
+            calls.append(dirname)
+
+        def event_gen(self):
+            return []
+
+    r._watcher = FakeWatcher()
+    r.add_extra_file('.env')
+    assert calls == ['.']
+    assert '.env' in r._extra_files
+    assert '.' in r._dirs


### PR DESCRIPTION
#### Description
Watching an extra file in the current directory (for example `.env`) makes `os.path.dirname(filename)` return an empty string. Passing that to inotify crashes.

Normalize empty dirname to `.` so cwd-relative extra files work, matching absolute/`./.env` paths that already work.

Closes #3377

#### Checklist
- [x] `pytest tests/test_reload.py`
