### PR TITLE
fix: rebind logging on HUP without breaking reopen

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -112,6 +112,10 @@ class Arbiter:
 
         if self.log is None:
             self.log = self.cfg.logger_class(app.cfg)
+        else:
+            # HUP reload reuses the logger; keep it pointed at the reloaded cfg
+            # so reopen_files()/setup() use the current errorlog/accesslog paths.
+            self.log.cfg = self.cfg
 
         # reopen files
         if 'GUNICORN_PID' in os.environ:
@@ -523,7 +527,11 @@ class Arbiter:
         self.app.reload()
         self.setup(self.app)
 
-        # reopen log files
+        # Re-apply logging against the reloaded cfg, then reopen files.
+        # setup() alone does not recreate logger handlers when self.log exists;
+        # without this, HUP keeps stale FileHandlers and post-reload worker
+        # boot lines vanish from --error-logfile (see #3401).
+        self.log.setup(self.cfg)
         self.log.reopen_files()
 
         # do we need to change listener ?

--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -193,30 +193,40 @@ class Logger:
         self.setup(cfg)
 
     def setup(self, cfg):
+        self.cfg = cfg
         self.loglevel = self.LOG_LEVELS.get(cfg.loglevel.lower(), logging.INFO)
         self.error_log.setLevel(self.loglevel)
         self.access_log.setLevel(logging.INFO)
 
         # set gunicorn.error handler
-        if self.cfg.capture_output and cfg.errorlog != "-":
+        if cfg.capture_output and cfg.errorlog != "-":
             for stream in sys.stdout, sys.stderr:
                 stream.flush()
 
-            self.logfile = open(cfg.errorlog, 'a+')
-            os.dup2(self.logfile.fileno(), sys.stdout.fileno())
-            os.dup2(self.logfile.fileno(), sys.stderr.fileno())
+            with self.lock:
+                if self.logfile is not None:
+                    self.logfile.close()
+                self.logfile = open(cfg.errorlog, 'a+')
+                os.dup2(self.logfile.fileno(), sys.stdout.fileno())
+                os.dup2(self.logfile.fileno(), sys.stderr.fileno())
+        elif self.logfile is not None:
+            with self.lock:
+                self.logfile.close()
+                self.logfile = None
 
         self._set_handler(self.error_log, cfg.errorlog,
                           logging.Formatter(self.error_fmt, self.datefmt))
 
-        # set gunicorn.access handler
-        if cfg.accesslog is not None:
-            self._set_handler(
-                self.access_log, cfg.accesslog,
-                fmt=logging.Formatter(self.access_fmt), stream=sys.stdout
-            )
+        # set gunicorn.access handler (None removes a previous gunicorn handler)
+        self._set_handler(
+            self.access_log,
+            cfg.accesslog,
+            fmt=logging.Formatter(self.access_fmt),
+            stream=sys.stdout,
+        )
 
-        # set syslog handler
+        # set syslog handler (idempotent: _set_handler already cleared gunicorn
+        # handlers on error/access; only re-add syslog when still enabled)
         if cfg.syslog:
             self._set_syslog_handler(
                 self.error_log, cfg, self.syslog_fmt, "error"
@@ -378,6 +388,13 @@ class Logger:
         return time.strftime('[%d/%b/%Y:%H:%M:%S %z]')
 
     def reopen_files(self):
+        """Reopen existing log files (logrotate / SIGUSR1).
+
+        This must not re-seed default gunicorn handlers: configs that use
+        ``logconfig`` / ``logconfig_dict`` may have replaced them, and
+        re-adding here would dual-emit on every USR1/HUP. Path changes on
+        SIGHUP are handled by ``Logger.setup()`` from ``Arbiter.reload``.
+        """
         if self.cfg.capture_output and self.cfg.errorlog != "-":
             for stream in sys.stdout, sys.stderr:
                 stream.flush()
@@ -396,7 +413,10 @@ class Logger:
                     try:
                         if handler.stream:
                             handler.close()
+                            # close() marks the handler closed; re-open and clear
+                            # the flag so emit() keeps working on modern Python.
                             handler.stream = handler._open()
+                            handler._closed = False
                     finally:
                         handler.release()
 
@@ -416,11 +436,19 @@ class Logger:
             if getattr(h, "_gunicorn", False):
                 return h
 
+    def _remove_gunicorn_handlers(self, log):
+        """Drop all handlers owned by gunicorn on ``log`` (file and syslog)."""
+        for h in list(log.handlers):
+            if getattr(h, "_gunicorn", False):
+                log.handlers.remove(h)
+                try:
+                    h.close()
+                except Exception:
+                    pass
+
     def _set_handler(self, log, output, fmt, stream=None):
-        # remove previous gunicorn log handler
-        h = self._get_gunicorn_handler(log)
-        if h:
-            log.handlers.remove(h)
+        # remove previous gunicorn log handlers (file and/or syslog)
+        self._remove_gunicorn_handlers(log)
 
         if output is not None:
             if output == "-":

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -485,6 +485,24 @@ class TestSighupReload:
         assert any('Hang up' in str(call) for call in mock_log.call_args_list)
 
 
+    @mock.patch('gunicorn.arbiter.Arbiter.spawn_worker')
+    @mock.patch('gunicorn.arbiter.Arbiter.manage_workers')
+    def test_reload_calls_logger_setup(self, mock_manage, mock_spawn):
+        """HUP reload must re-setup logger so errorlog path stays live (#3401)."""
+        arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
+        arbiter.cfg.set('workers', 1)
+        arbiter.LISTENERS = [mock.Mock()]
+        arbiter.pidfile = None
+        arbiter.app.reload = mock.Mock()
+        # Keep real setup for cfg/log wiring, but avoid env side effects.
+        with mock.patch.object(arbiter.log, 'setup', wraps=arbiter.log.setup) as mock_setup, \
+                mock.patch.object(arbiter.log, 'reopen_files', wraps=arbiter.log.reopen_files) as mock_reopen:
+            arbiter.reload()
+            mock_setup.assert_called()
+            mock_reopen.assert_called()
+            # setup called with reloaded cfg
+            assert mock_setup.call_args[0][0] is arbiter.cfg
+
 # ============================================================================
 # Worker Lifecycle Tests
 # ============================================================================

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -3,6 +3,8 @@
 # See the NOTICE for more information.
 
 import datetime
+import logging
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -93,3 +95,170 @@ def test_get_username_handles_malformed_basic_auth_header():
 
     atoms = logger.atoms(response, request, environ, datetime.timedelta(seconds=1))
     assert atoms['u'] == '-'
+
+
+def test_setup_switches_errorlog_path(tmp_path):
+    """HUP reload re-runs setup so --error-logfile follows cfg (#3401)."""
+    first = tmp_path / "first.log"
+    second = tmp_path / "second.log"
+
+    cfg = Config()
+    cfg.set("errorlog", str(first))
+    logger = Logger(cfg)
+    logger.info("before-reload")
+
+    assert first.exists()
+    assert "before-reload" in first.read_text()
+
+    cfg.set("errorlog", str(second))
+    logger.setup(cfg)
+    logger.reopen_files()
+    logger.info("after-reload")
+
+    assert second.exists()
+    assert "after-reload" in second.read_text()
+    assert "after-reload" not in first.read_text()
+    bases = [
+        Path(getattr(h, "baseFilename")).resolve()
+        for h in logger.error_log.handlers
+        if getattr(h, "_gunicorn", False) and getattr(h, "baseFilename", None)
+    ]
+    assert second.resolve() in bases
+
+
+def test_reopen_files_does_not_reseed_custom_handlers(tmp_path):
+    """USR1/reopen must not re-add default gunicorn handlers over custom ones."""
+    path = tmp_path / "custom.log"
+    cfg = Config()
+    cfg.set("errorlog", "-")
+    logger = Logger(cfg)
+    # Simulate logconfig replacing gunicorn defaults with a custom FileHandler.
+    for h in list(logger.error_log.handlers):
+        logger.error_log.handlers.remove(h)
+        try:
+            h.close()
+        except Exception:
+            pass
+    custom = logging.FileHandler(str(path))
+    custom.setFormatter(logging.Formatter("%(message)s"))
+    logger.error_log.addHandler(custom)
+    logger.error_log.setLevel(logging.INFO)
+    n_before = len(logger.error_log.handlers)
+    logger.reopen_files()
+    n_after = len(logger.error_log.handlers)
+    assert n_after == n_before
+    assert not any(getattr(h, "_gunicorn", False) for h in logger.error_log.handlers)
+    logger.info("custom-only")
+    assert "custom-only" in path.read_text()
+
+
+def test_reopen_files_keeps_logging_after_close(tmp_path):
+    """USR1/logrotate path must still emit after FileHandler.close()."""
+    path = tmp_path / "rotate.log"
+    cfg = Config()
+    cfg.set("errorlog", str(path))
+    logger = Logger(cfg)
+    logger.info("pre-rotate")
+    logger.reopen_files()
+    logger.info("post-rotate")
+    body = path.read_text()
+    assert "pre-rotate" in body
+    assert "post-rotate" in body
+
+
+def test_reload_rebinds_logger_cfg_and_errorlog(tmp_path, monkeypatch):
+    """Arbiter.reload must re-setup logging against reloaded cfg (#3401)."""
+    import gunicorn.arbiter as arbiter_mod
+    from gunicorn.app.base import BaseApplication
+
+    first = tmp_path / "master-before.log"
+    second = tmp_path / "master-after.log"
+
+    class App(BaseApplication):
+        def init(self, parser, opts, args):
+            return {}
+
+        def load(self):
+            return lambda environ, start_response: (
+                start_response("200 OK", [("Content-Type", "text/plain")]),
+                [b"ok"],
+            )[1]
+
+        def load_config(self):
+            self.cfg.set("errorlog", str(first))
+            self.cfg.set("workers", 1)
+            self.cfg.set("bind", "127.0.0.1:0")
+
+        def reload(self):
+            # Simulate config file changing errorlog path on HUP.
+            self.cfg.set("errorlog", str(second))
+
+    app = App()
+    app.load_default_config()
+    app.load_config()
+    arb = arbiter_mod.Arbiter(app)
+    # Avoid real socket/pid/worker side effects.
+    monkeypatch.setattr(arb, "spawn_worker", lambda: None)
+    monkeypatch.setattr(arb, "manage_workers", lambda: None)
+    arb.LISTENERS = []
+    arb.pidfile = None
+    arb.WORKERS = {}
+
+    arb.log.info("pre-hup")
+    assert first.exists()
+    assert "pre-hup" in first.read_text()
+
+    arb.reload()
+    arb.log.info("post-hup")
+
+    assert second.exists()
+    assert "post-hup" in second.read_text()
+    assert arb.log.cfg is arb.cfg
+    assert arb.cfg.errorlog == str(second)
+
+
+def test_setup_is_idempotent_with_syslog(tmp_path):
+    """Repeated setup/HUP must not stack syslog or file handlers."""
+    path = tmp_path / "err.log"
+    cfg = Config()
+    cfg.set("errorlog", str(path))
+    cfg.set("syslog", True)
+    # Use /dev/log if present else UDP localhost sink may fail; skip if can't bind.
+    logger = Logger(cfg)
+    n1 = sum(1 for h in logger.error_log.handlers if getattr(h, "_gunicorn", False))
+    logger.setup(cfg)
+    logger.setup(cfg)
+    n2 = sum(1 for h in logger.error_log.handlers if getattr(h, "_gunicorn", False))
+    assert n2 == n1
+    types = [type(h).__name__ for h in logger.error_log.handlers if getattr(h, "_gunicorn", False)]
+    assert types.count("SysLogHandler") <= 1
+    assert types.count("FileHandler") <= 1
+
+
+def test_accesslog_none_removes_handler(tmp_path):
+    path = tmp_path / "access.log"
+    cfg = Config()
+    cfg.set("accesslog", str(path))
+    logger = Logger(cfg)
+    assert any(isinstance(h, logging.FileHandler) for h in logger.access_log.handlers)
+    cfg.set("accesslog", None)
+    logger.setup(cfg)
+    assert not any(
+        getattr(h, "_gunicorn", False) for h in logger.access_log.handlers
+    )
+
+
+def test_capture_output_setup_closes_previous(tmp_path):
+    first = tmp_path / "cap1.log"
+    second = tmp_path / "cap2.log"
+    cfg = Config()
+    cfg.set("errorlog", str(first))
+    cfg.set("capture_output", True)
+    logger = Logger(cfg)
+    first_fd = logger.logfile
+    assert first_fd is not None and not first_fd.closed
+    cfg.set("errorlog", str(second))
+    logger.setup(cfg)
+    assert first_fd.closed
+    assert logger.logfile is not None and not logger.logfile.closed
+    assert Path(logger.logfile.name).resolve() == second.resolve()


### PR DESCRIPTION
Fixes #3401.

After SIGHUP, new worker boot lines can vanish from the main error log even though the workers are healthy. The master reuses the same `Logger` instance on reload and only calls `reopen_files()`, which is not enough to rebind handlers to the reloaded config.

Reload now keeps `logger.cfg` aligned in `Arbiter.setup()` and re-runs `Logger.setup(cfg)` before `reopen_files()`. The setup is made idempotent: gunicorn-owned handlers are dropped before re-adding, a prior `capture_output` fd is closed, `accesslog=None` stays without handlers, and syslog is reattached without stacking.

`reopen_files()` keeps its USR1/logrotate meaning: it reopens existing `FileHandler`s only and no longer re-seeds default handlers over a `logconfig` configuration.

The regression tests cover the error-log path switch on reload and the logrotate-style reopen; a separate test checks that reopen does not re-seed default handlers over custom ones.
