### PR TITLE
fix: catch BaseException in gthread worker

### DIFF
--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -439,7 +439,7 @@ class ThreadWorker(base.Worker):
             else:
                 self.nr_conns -= 1
                 conn.close(graceful=True)
-        except Exception:
+        except BaseException:
             self.nr_conns -= 1
             conn.close()
 


### PR DESCRIPTION
All exceptions in Python must inherit from `BaseException` and since connections should always be closed it makes sense to catch `BaseException` rather than `Exception`.