### PR TITLE
fix: send zero-valued StatsD metrics

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -97,6 +97,7 @@ Jonas Haag <jonas@lophus.org>
 Jonas Nockert <jonasnockert@gmail.com>
 Jorge Niedbalski <jorge@nimbic.com>
 Jorge Niedbalski R <niedbalski@gmail.com>
+Josu Gorostegui <gorosjosu@gmail.com>
 Justin Quick <justquick@gmail.com>
 keakon <keakon@gmail.com>
 Keegan Carruthers-Smith <keegan.csmith@gmail.com>

--- a/gunicorn/instrument/statsd.py
+++ b/gunicorn/instrument/statsd.py
@@ -74,7 +74,7 @@ class Statsd(Logger):
                 metric = extra.get(METRIC_VAR, None)
                 value = extra.get(VALUE_VAR, None)
                 typ = extra.get(MTYPE_VAR, None)
-                if metric and value and typ:
+                if metric and value is not None and typ:
                     if typ == GAUGE_TYPE:
                         self.gauge(metric, value)
                     elif typ == COUNTER_TYPE:

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -11,6 +11,8 @@ import tempfile
 from datetime import timedelta
 from types import SimpleNamespace
 
+import pytest
+
 from gunicorn.config import Config
 from gunicorn.instrument.statsd import Statsd
 
@@ -119,6 +121,33 @@ def test_instrument():
     assert logger.sock.msgs[0] == b"gunicorn.request.duration:7000.0|ms"
     assert logger.sock.msgs[1] == b"gunicorn.requests:1|c|@1.0"
     assert logger.sock.msgs[2] == b"gunicorn.request.status.200:1|c|@1.0"
+
+
+@pytest.mark.parametrize(
+    ("metric_type", "expected"),
+    [
+        ("gauge", b"gunicorn.test:0|g"),
+        ("counter", b"gunicorn.test:0|c|@1.0"),
+        ("histogram", b"gunicorn.test:0|h"),
+        ("timer", b"gunicorn.test:0|ms"),
+    ],
+)
+def test_instrument_accepts_zero_value(metric_type, expected):
+    logger = Statsd(Config())
+    logger.sock = MockSocket(False)
+
+    logger.debug("", extra={"mtype": metric_type, "metric": "gunicorn.test",
+                            "value": 0})
+    assert logger.sock.msgs == [expected]
+
+
+def test_instrument_ignores_none_value():
+    logger = Statsd(Config())
+    logger.sock = MockSocket(False)
+
+    logger.debug("", extra={"mtype": "histogram", "metric": "gunicorn.test",
+                            "value": None})
+    assert not logger.sock.msgs
 
 
 def test_prefix():


### PR DESCRIPTION
Discussed in #3675.

`Statsd.log()` checks metric values for truthiness, so a valid zero is treated like a missing value. The backlog metric makes this visible on an idle server.

This changes the check to `value is not None` and adds regression tests for zero-valued gauges, counters, histograms and timers. `None` stays ignored and positive values behave as before.