### PR TITLE
fix: don't warn about dropped body bytes when sendfile has none

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -185,6 +185,7 @@ Thomas Steinacher <tom@eggdrop.ch>
 Travis Cline <travis.cline@gmail.com>
 Travis Swicegood <development@domain51.com>
 Trey Long <trey@ktrl.com>
+vjymisal0 <vijay.looprai@gmail.com>
 W. Trevor King <wking@tremily.us>
 Wojtek <wojtek@monodev.com>
 Wolfgang Schnerring <wosc@wosc.de>

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -480,17 +480,6 @@ class Response:
         if self.cfg.is_ssl or not self.can_sendfile():
             return False
 
-        if self._omits_body:
-            self.send_headers()
-            if not self._omits_body_warned:
-                log.warning(
-                    "WSGI app sent body bytes on a no-body response "
-                    "(method=%s status=%s); dropping per RFC 9110.",
-                    self.req.method, self.status_code,
-                )
-                self._omits_body_warned = True
-            return True
-
         if not util.has_fileno(respiter.filelike):
             return False
 
@@ -504,6 +493,19 @@ class Response:
                 nbytes = self.response_length
         except (OSError, io.UnsupportedOperation):
             return False
+
+        if self._omits_body:
+            self.send_headers()
+            # Only complain when there really are body bytes to drop, the
+            # same way write() only warns for a non-empty argument.
+            if nbytes > 0 and not self._omits_body_warned:
+                log.warning(
+                    "WSGI app sent body bytes on a no-body response "
+                    "(method=%s status=%s); dropping per RFC 9110.",
+                    self.req.method, self.status_code,
+                )
+                self._omits_body_warned = True
+            return True
 
         self.send_headers()
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -373,7 +373,7 @@ def test_file_wrapper_iterable():
     assert chunks == [b"ab", b"c"]
 
 
-def _make_response(method="GET", version=(1, 1)):
+def _make_response(method="GET", version=(1, 1), sendfile=False):
     sock = mock.MagicMock()
     req = mock.MagicMock()
     req.method = method
@@ -381,7 +381,7 @@ def _make_response(method="GET", version=(1, 1)):
     req.should_close.return_value = False
     cfg = mock.MagicMock()
     cfg.is_ssl = False
-    cfg.sendfile = False
+    cfg.sendfile = sendfile
     return Response(req, sock, cfg), sock
 
 
@@ -421,6 +421,49 @@ def test_no_body_response_drops_body_and_warns(caplog):
         resp.write(b"hello")
         resp.write(b"again")
     assert resp.sent == 0
+    assert sum(
+        1 for r in caplog.records
+        if "no-body response" in r.getMessage()
+    ) == 1
+
+
+@pytest.mark.parametrize("status,method,extra_headers", [
+    ("200 OK", "HEAD", [("Content-Length", "0")]),
+    ("204 No Content", "GET", []),
+    ("304 Not Modified", "GET", []),
+])
+def test_no_body_sendfile_empty_file_does_not_warn(
+        caplog, tmp_path, status, method, extra_headers):
+    """An empty file wrapper has no body bytes to drop, so no warning."""
+    path = tmp_path / "empty.txt"
+    path.write_bytes(b"")
+    resp, sock = _make_response(method=method, sendfile=True)
+    resp.start_response(status, [("Content-Type", "text/plain")] + extra_headers)
+    with open(path, "rb") as filelike:
+        with caplog.at_level("WARNING", logger="gunicorn.http.wsgi"):
+            resp.write_file(FileWrapper(filelike))
+    assert resp.sent == 0
+    sock.sendfile.assert_not_called()
+    assert [
+        r for r in caplog.records if "no-body response" in r.getMessage()
+    ] == []
+
+
+def test_no_body_sendfile_non_empty_file_warns_once(caplog, tmp_path):
+    """A non-empty file wrapper really loses bytes, so it still warns once."""
+    path = tmp_path / "data.txt"
+    path.write_bytes(b"hello")
+    resp, sock = _make_response(method="HEAD", sendfile=True)
+    resp.start_response("200 OK", [
+        ("Content-Type", "text/plain"),
+        ("Content-Length", "5"),
+    ])
+    with open(path, "rb") as filelike:
+        with caplog.at_level("WARNING", logger="gunicorn.http.wsgi"):
+            resp.write_file(FileWrapper(filelike))
+            resp.write_file(FileWrapper(filelike))
+    assert resp.sent == 0
+    sock.sendfile.assert_not_called()
     assert sum(
         1 for r in caplog.records
         if "no-body response" in r.getMessage()


### PR DESCRIPTION
### Problem

`Response.sendfile()` logs a `WARNING` unconditionally on its no-body branch:

    if self._omits_body:
        self.send_headers()
        if not self._omits_body_warned:
            log.warning(
                "WSGI app sent body bytes on a no-body response "
                "(method=%s status=%s); dropping per RFC 9110.", ...)
        return True

It never inspects whether the file wrapper actually has any bytes. Its sibling
`write()` does — it warns only `if arg and not self._omits_body_warned`, i.e.
only when something is genuinely being discarded.

Any WSGI app serving static files via the standard `environ['wsgi.file_wrapper']`
idiom reaches this path through `write_file()`, which is called from every worker
type (`sync.py`, `gthread.py`, `base_async.py`). So a `HEAD` request, or a `204`
or `304` response, on such a route emits one spurious "WSGI app sent body bytes"
WARNING per request — even when the wrapper is empty and nothing is dropped. That
is log spam for entirely correct behavior, plus a misleading diagnostic that
points the finger at the application.

Introduced in 9bc5891 ("fix: drop body framing on HEAD/1xx/204/304 in WSGI
responses").

### Fix

Move the `_omits_body` branch below the existing `has_fileno` / `lseek` / `fstat`
block so the pending byte count is known, then gate the warning on `nbytes > 0` —
mirroring `write()`'s `if arg` guard. A genuinely non-empty wrapper still warns
exactly once per response.

One behavioural note: a no-body response over a file-like object with no usable
`fileno` now returns `False` and falls back to the `write()` loop, which drops the
bytes and applies the same guard. The bytes on the wire are unchanged; it just
collapses two near-identical drop paths into one.

### Tests

`tests/test_http.py`:

- `test_no_body_sendfile_empty_file_does_not_warn` — parametrized over
  `(200 OK, HEAD)`, `(204 No Content, GET)` and `(304 Not Modified, GET)` with a
  zero-byte file wrapper. Fails on master with the spurious warning captured,
  passes with this change.
- `test_no_body_sendfile_non_empty_file_warns_once` — pins that a wrapper which
  really does lose bytes still warns, and still only once per response.

`_make_response()` gained a `sendfile` keyword; it previously hard-coded
`cfg.sendfile = False`, which made `can_sendfile()` short-circuit so `sendfile()`
had no coverage at all.

### Verification

- `pytest tests/test_http.py` — 3 failed / 37 passed before the fix, 40 passed after.
- `tox -e lint` equivalent (pylint 3.3.2, `--max-line-length=120`) — 10.00/10.
- `tox -e pycodestyle` — clean.
- Full `pytest tests/` passes apart from 166 `tests/requests/*.http` fixture
  failures that are identical on a stashed/clean tree; they are an artifact of my
  local Windows checkout normalising CRLF in those raw protocol fixtures, not of
  this change.
