### PR TITLE
fix: decrement nr_conns on server-initiated close in the ASGI worker (#3661)

### DIFF
--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -5,6 +5,15 @@
 
 ### Bug Fixes
 
+- **ASGI connection count leaked on server-initiated close**: `nr_conns` was
+  only decremented in `connection_lost()`, behind a guard keyed on the same
+  flag `_close_transport()` sets first. Every close the server started (a
+  `Connection: close` response, a keepalive timeout, an error abort) leaked one
+  count, so `ASGIWorker._shutdown()` ran the full `graceful_timeout` and warned
+  about connections that were already gone. The guard now uses its own flag, so
+  the decrement and the rest of the cleanup run exactly once whichever side
+  closes first ([#3661](https://github.com/benoitc/gunicorn/issues/3661)).
+
 - **Inotify reloader on cwd-relative extra files**: `reload_extra_files` entries
   with no directory part (for example `.env`) produced an empty dirname, and
   watching it raised `InotifyError` with `ENOENT`. The current directory is now

--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -365,6 +365,11 @@ class ASGIProtocol(asyncio.Protocol):
 
         # Connection state
         self._closed = False
+        # Guards the connection_lost() cleanup so it runs exactly once. Kept
+        # separate from ``_closed`` because a server-initiated close sets
+        # ``_closed`` early (in _close_transport), and connection_lost() must
+        # still run its cleanup (e.g. decrement nr_conns) afterwards.
+        self._conn_lost_handled = False
         self._body_receiver = None  # Set per-request for disconnect signaling
 
         # Response buffering for write batching
@@ -682,10 +687,14 @@ class ASGIProtocol(asyncio.Protocol):
 
         See: https://github.com/benoitc/gunicorn/issues/3484
         """
-        # Guard against multiple calls (idempotent)
-        if self._closed:
+        # Guard against multiple calls (idempotent). Use a dedicated flag rather
+        # than ``_closed``: a server-initiated close sets ``_closed`` in
+        # _close_transport() before the transport reports the loss, and the
+        # cleanup below (notably decrementing nr_conns) must still run.
+        if self._conn_lost_handled:
             return
 
+        self._conn_lost_handled = True
         self._closed = True
         self.worker.nr_conns -= 1
 

--- a/tests/test_asgi_disconnect.py
+++ b/tests/test_asgi_disconnect.py
@@ -103,6 +103,28 @@ class TestASGIGracefulDisconnect:
         assert mock_worker.nr_conns == 1  # Should not decrement again
         # Closed flag is still set
 
+    def test_server_initiated_close_still_decrements_nr_conns(self, mock_worker):
+        """A server-initiated close must not leak the connection count (#3661).
+
+        _close_transport() sets ``_closed`` before asyncio reports the transport
+        loss, so connection_lost() must still run its cleanup and decrement
+        nr_conns. Otherwise every graceful stop waits out the full timeout.
+        """
+        protocol = ASGIProtocol(mock_worker)
+        protocol.reader = mock.Mock()
+        protocol.transport = mock.Mock()
+        mock_worker.nr_conns = 1
+
+        # Server closes the connection (e.g. `Connection: close`, keepalive
+        # timeout), which sets ``_closed`` early.
+        protocol._close_transport()
+        assert protocol._closed is True
+        assert mock_worker.nr_conns == 1
+
+        # asyncio then reports the transport loss.
+        protocol.connection_lost(None)
+        assert mock_worker.nr_conns == 0
+
     def test_disconnect_does_not_cancel_immediately(self, mock_worker):
         """Test that connection_lost doesn't cancel task immediately."""
         protocol = ASGIProtocol(mock_worker)

--- a/tests/test_asgi_nr_conns_shutdown.py
+++ b/tests/test_asgi_nr_conns_shutdown.py
@@ -1,0 +1,192 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+"""Connection accounting across server-initiated closes.
+
+Issue: https://github.com/benoitc/gunicorn/issues/3661
+
+``connection_made()`` increments ``worker.nr_conns``.  A server-initiated
+close goes through ``_close_transport()``, which sets ``_closed`` before
+asyncio delivers ``connection_lost()``.  If the idempotence guard in
+``connection_lost()`` keys off ``_closed``, the decrement never runs and the
+counter leaks one per connection the server closed first: every
+``Connection: close`` response, every keepalive timeout, every error abort.
+
+``ASGIWorker._shutdown()`` waits on that counter, so a leaked count means
+every graceful stop runs to the full ``graceful_timeout`` deadline and then
+logs "Forcing close of N connections" for connections that are long gone.
+"""
+
+import asyncio
+import logging
+import types
+from unittest import mock
+
+import pytest
+
+from gunicorn.asgi.protocol import ASGIProtocol
+from gunicorn.config import Config
+from gunicorn.workers.gasgi import ASGIWorker
+
+
+class FakeTransport:
+    """Plain HTTP/1.x transport: no ssl_object, close() is a no-op."""
+
+    def __init__(self):
+        self.closed = False
+
+    def get_extra_info(self, name, default=None):
+        return default
+
+    def set_write_buffer_limits(self, high=None, low=None):
+        pass
+
+    def can_write_eof(self):
+        return False
+
+    def write_eof(self):
+        pass
+
+    def close(self):
+        self.closed = True
+
+    def is_closing(self):
+        return self.closed
+
+
+def make_worker(graceful_timeout=1):
+    cfg = Config()
+    cfg.set("graceful_timeout", graceful_timeout)
+    return types.SimpleNamespace(
+        cfg=cfg,
+        loop=asyncio.get_running_loop(),
+        nr_conns=0,
+        alive=True,
+        log=logging.getLogger("test.asgi.nr_conns"),
+        asgi=None,
+    )
+
+
+def open_connection(worker):
+    proto = ASGIProtocol(worker)
+    proto.connection_made(FakeTransport())
+    return proto
+
+
+@pytest.mark.asyncio
+async def test_server_initiated_close_decrements_nr_conns():
+    """A close the server starts must still be counted down exactly once."""
+    worker = make_worker()
+    proto = open_connection(worker)
+    assert worker.nr_conns == 1
+
+    # Server closes first: Connection: close, keepalive timeout, error abort.
+    proto._close_transport()
+    # asyncio then reports the transport loss.
+    proto.connection_lost(None)
+
+    assert worker.nr_conns == 0
+
+
+@pytest.mark.asyncio
+async def test_client_initiated_close_decrements_nr_conns():
+    """The already-working direction must keep working (no double decrement)."""
+    worker = make_worker()
+    proto = open_connection(worker)
+    assert worker.nr_conns == 1
+
+    proto.connection_lost(None)
+    proto._close_transport()
+
+    assert worker.nr_conns == 0
+
+
+@pytest.mark.asyncio
+async def test_keepalive_timeout_close_decrements_nr_conns():
+    """The keepalive path closes server-side too and must stay balanced."""
+    worker = make_worker()
+    proto = open_connection(worker)
+    assert worker.nr_conns == 1
+
+    proto._keepalive_timeout()
+    proto.connection_lost(None)
+
+    assert worker.nr_conns == 0
+
+
+@pytest.mark.asyncio
+async def test_repeated_close_is_idempotent():
+    """Extra close/lost callbacks must not drive the counter negative."""
+    worker = make_worker()
+    proto = open_connection(worker)
+
+    proto._close_transport()
+    proto._close_transport()
+    proto.connection_lost(None)
+    proto.connection_lost(None)
+
+    assert worker.nr_conns == 0
+
+
+@pytest.mark.asyncio
+async def test_server_initiated_close_still_runs_full_cleanup():
+    """The counter is not the only casualty of the early return.
+
+    ``connection_lost()`` also cancels the keepalive timer, feeds EOF to the
+    reader and tells the body receiver the peer is gone (see #3484).  A fix
+    that only rebalances ``nr_conns`` leaves those undone, so pin them here.
+    """
+    worker = make_worker()
+    proto = open_connection(worker)
+
+    proto.reader = mock.Mock()
+    proto._body_receiver = mock.Mock()
+    proto._cancel_keepalive_timer = mock.Mock()
+
+    proto._close_transport()
+    proto.connection_lost(None)
+
+    assert worker.nr_conns == 0
+    assert proto._cancel_keepalive_timer.called, "keepalive timer left running"
+    assert proto.reader.feed_eof.called, "reader never got EOF"
+    assert proto._body_receiver.signal_disconnect.called, (
+        "app never told the peer disconnected"
+    )
+
+
+@pytest.mark.asyncio
+async def test_graceful_shutdown_does_not_wait_out_timeout(caplog):
+    """The reported symptom: an idle worker must not burn graceful_timeout.
+
+    Serve a few connections that the server closes first, then shut down.
+    With the counter leaking, ``_shutdown()`` blocks until the deadline and
+    warns about connections that no longer exist.
+    """
+    graceful_timeout = 1
+    worker = make_worker(graceful_timeout=graceful_timeout)
+
+    for _ in range(3):
+        proto = open_connection(worker)
+        proto._close_transport()
+        proto.connection_lost(None)
+
+    # Drive the real shutdown loop with the worker state we just produced.
+    shutdown = ASGIWorker._shutdown.__get__(worker, ASGIWorker)
+    worker.servers = []
+    worker.lifespan = None
+    worker._quick_shutdown = False
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    with caplog.at_level(logging.INFO, logger="test.asgi.nr_conns"):
+        await shutdown()
+    elapsed = loop.time() - started
+
+    forced = [r.getMessage() for r in caplog.records if "Forcing close" in r.getMessage()]
+    assert elapsed < graceful_timeout, (
+        "graceful shutdown took %.2fs of a %ds timeout with no live "
+        "connections (nr_conns=%d, %s)"
+        % (elapsed, graceful_timeout, worker.nr_conns, forced or "no warning")
+    )
+    assert not forced, "forced close of connections that were already gone: %s" % forced


### PR DESCRIPTION
Supersedes #3664, whose commit is carried over unchanged and still authored by @apoorvdarshan. Fixes #3661.

`nr_conns` is only decremented in `connection_lost()`, behind an idempotence guard keyed on `_closed`. `_close_transport()` sets `_closed` before asyncio delivers the transport loss, so every close the server starts returns at the guard and leaks one count for good. That covers `Connection: close` responses, keepalive timeouts and error aborts. Client-initiated closes stay balanced because `connection_lost()` runs first.

The early return also skips the rest of the cleanup: the keepalive timer, `reader.feed_eof()` and the body receiver's `signal_disconnect()`, so the app is never told the peer has gone (#3484).

`ASGIWorker._shutdown()` polls `nr_conns` against a deadline, so a leaked count makes every graceful stop run the full `graceful_timeout` and then warn about connections that are already gone.

The guard now uses its own flag, so the decrement and the rest of the cleanup run exactly once whichever side closes first.
