### PR TITLE
dirty: close the worker connection on request timeout

### DIFF
--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -5,6 +5,15 @@
 
 ### Bug Fixes
 
+- **Dirty arbiter returned stale responses after a worker timeout**: when a
+  request reached `dirty_timeout` the arbiter answered the client with a timeout
+  error but kept the worker connection open. The worker's late response was then
+  the first message waiting on that socket, so the next request routed to the
+  same worker received the previous request's result, and every request after it
+  stayed one response behind. The connection is now closed on timeout, so the
+  late answer is discarded with it
+  ([#3626](https://github.com/benoitc/gunicorn/pull/3626)).
+
 - **ASGI connection count leaked on server-initiated close**: `nr_conns` was
   only decremented in `connection_lost()`, behind a guard keyed on the same
   flag `_close_transport()` sets first. Every close the server started (a

--- a/gunicorn/dirty/arbiter.py
+++ b/gunicorn/dirty/arbiter.py
@@ -542,6 +542,10 @@ class DirtyArbiter:
                         timeout=self.cfg.dirty_timeout
                     )
                 except asyncio.TimeoutError:
+                    # The worker may still write its response later. Drop the
+                    # connection so that response is not read as the answer to
+                    # the next request routed to this worker.
+                    self._close_worker_connection(worker_pid)
                     response = make_error_response(
                         request_id,
                         DirtyTimeoutError("Worker timeout", self.cfg.dirty_timeout)

--- a/tests/test_dirty_arbiter.py
+++ b/tests/test_dirty_arbiter.py
@@ -751,18 +751,21 @@ class TestDirtyArbiterTimeoutConnection:
         slow_id, fast_id = 1, 2
 
         async def handle_worker(reader, writer):
+            # One request per connection: a handler parked in a read keeps the
+            # server alive on 3.12, where wait_closed() waits for handlers.
             try:
-                while True:
-                    message = await DirtyProtocol.read_message_async(reader)
-                    request_id = message.get("id")
-                    if request_id == slow_id:
-                        # Answer only after the arbiter has given up.
-                        await asyncio.sleep(1.5)
-                    await DirtyProtocol.write_message_async(
-                        writer, make_response(request_id, {"for": request_id})
-                    )
+                message = await DirtyProtocol.read_message_async(reader)
+                request_id = message.get("id")
+                if request_id == slow_id:
+                    # Answer only after the arbiter has given up.
+                    await asyncio.sleep(1.5)
+                await DirtyProtocol.write_message_async(
+                    writer, make_response(request_id, {"for": request_id})
+                )
             except Exception:
-                return
+                pass
+            finally:
+                writer.close()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             socket_path = os.path.join(tmpdir, "worker.sock")
@@ -800,7 +803,10 @@ class TestDirtyArbiterTimeoutConnection:
                 # connection keeps its handler alive and wait_closed() blocks.
                 arbiter._close_worker_connection(fake_pid)
                 server.close()
-                await server.wait_closed()
+                try:
+                    await asyncio.wait_for(server.wait_closed(), timeout=10)
+                except (asyncio.TimeoutError, TimeoutError):
+                    pass
 
         arbiter._cleanup_sync()
 

--- a/tests/test_dirty_arbiter.py
+++ b/tests/test_dirty_arbiter.py
@@ -18,6 +18,7 @@ from gunicorn.dirty.protocol import (
     DirtyProtocol,
     BinaryProtocol,
     make_request,
+    make_response,
     HEADER_SIZE,
 )
 
@@ -694,6 +695,112 @@ class TestDirtyArbiterWorkerConnection:
             await arbiter._get_worker_connection(99999)
 
         assert "Worker socket not ready" in str(exc_info.value)
+
+        arbiter._cleanup_sync()
+
+
+class TestDirtyArbiterTimeoutConnection:
+    """Tests that a timed out worker connection is not reused."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_closes_worker_connection(self):
+        """_execute_on_worker drops the cached connection on timeout."""
+        cfg = Config()
+        cfg.set("dirty_timeout", 1)
+        log = MockLog()
+
+        arbiter = DirtyArbiter(cfg=cfg, log=log)
+        fake_pid = 99999
+
+        # A reader that never yields a message forces the timeout path.
+        worker_reader = asyncio.StreamReader()
+        worker_writer = MockStreamWriter()
+        arbiter.worker_connections[fake_pid] = (worker_reader, worker_writer)
+
+        client = MockStreamWriter()
+        await arbiter._execute_on_worker(
+            fake_pid,
+            make_request(request_id=1, app_path="test:App",
+                         action="slow_action"),
+            client,
+        )
+
+        assert client.messages[-1]["type"] == DirtyProtocol.MSG_TYPE_ERROR
+        assert fake_pid not in arbiter.worker_connections
+        assert worker_writer.closed
+
+        arbiter._cleanup_sync()
+
+    @pytest.mark.asyncio
+    async def test_late_response_not_given_to_next_request(self):
+        """A response arriving after the timeout is not reused.
+
+        Without dropping the connection, the worker's late answer to the
+        timed out request is the first message waiting on the socket, so the
+        next request routed to that worker receives it instead of its own.
+        """
+        cfg = Config()
+        cfg.set("dirty_timeout", 1)
+        log = MockLog()
+
+        arbiter = DirtyArbiter(cfg=cfg, log=log)
+        fake_pid = 99999
+
+        # Request ids travel in the header as uint64, so use ints here:
+        # a str id is hashed and would not compare equal on the way back.
+        slow_id, fast_id = 1, 2
+
+        async def handle_worker(reader, writer):
+            try:
+                while True:
+                    message = await DirtyProtocol.read_message_async(reader)
+                    request_id = message.get("id")
+                    if request_id == slow_id:
+                        # Answer only after the arbiter has given up.
+                        await asyncio.sleep(1.5)
+                    await DirtyProtocol.write_message_async(
+                        writer, make_response(request_id, {"for": request_id})
+                    )
+            except Exception:
+                return
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            socket_path = os.path.join(tmpdir, "worker.sock")
+            server = await asyncio.start_unix_server(
+                handle_worker, path=socket_path
+            )
+            arbiter.workers[fake_pid] = "fake_worker"
+            arbiter.worker_sockets[fake_pid] = socket_path
+
+            try:
+                first = MockStreamWriter()
+                await arbiter._execute_on_worker(
+                    fake_pid,
+                    make_request(request_id=slow_id, app_path="test:App",
+                                 action="slow_action"),
+                    first,
+                )
+                assert len(first.messages) == 1
+                assert first.messages[0]["type"] == DirtyProtocol.MSG_TYPE_ERROR
+
+                second = MockStreamWriter()
+                await arbiter._execute_on_worker(
+                    fake_pid,
+                    make_request(request_id=fast_id, app_path="test:App",
+                                 action="fast_action"),
+                    second,
+                )
+
+                assert len(second.messages) == 1
+                assert second.messages[0]["id"] == fast_id
+                assert (second.messages[0]["type"] ==
+                        DirtyProtocol.MSG_TYPE_RESPONSE)
+            finally:
+                # Drop the arbiter side first, otherwise the still open
+                # connection keeps its handler alive and wait_closed() blocks.
+                arbiter._close_worker_connection(fake_pid)
+                server.close()
+                await server.wait_closed()
 
         arbiter._cleanup_sync()
 


### PR DESCRIPTION
Supersedes #3626, same fix with tests. Original diagnosis and patch by @razumau.

When a request reaches `dirty_timeout` the arbiter answers the client with a
`DirtyTimeoutError` but leaves the worker connection cached and open. The worker
still writes its response afterwards, so that late message is the first thing
waiting on the socket when the next request is routed to the same worker: that
request gets the previous one's result, and every request after it stays one
response behind.

Closing the connection on the timeout path discards the late answer with it.
