### PR TITLE
arbiter: establish child ownership before reporting exit status

### DIFF
--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -16,6 +16,24 @@
 
 ### Bug Fixes
 
+- **Non-worker children reported as failed workers**: `reap_workers()` reaps
+  every child through `waitpid(-1)`, including processes the kernel reparented
+  onto gunicorn when it runs as PID 1 in a container, but it logged the exit
+  status before checking whether the pid was ever a worker. An unrelated process
+  produced `Worker (pid:N) exited with code M` and triggered alerts. More
+  seriously, such a process exiting with code 3 or 4 raised `HaltServer` and shut
+  the server down. Ownership is now established first: the dirty arbiter is
+  reported as itself, unknown children are reaped silently at debug level, and
+  only real workers can halt the server
+  ([#3220](https://github.com/benoitc/gunicorn/issues/3220),
+  [#3566](https://github.com/benoitc/gunicorn/pull/3566)).
+
+- **Dirty arbiter exits were invisible on SIGCHLD**: `handle_chld()` called
+  `reap_workers()` first, whose `waitpid(-1)` claimed the dirty arbiter before
+  `reap_dirty_arbiter()` could identify it, so the latter always hit `ECHILD` and
+  its reporting never ran. The dirty arbiter is now reaped first, and
+  `reap_workers()` recognises it if it exits mid-loop.
+
 - **Dirty arbiter returned stale responses after a worker timeout**: when a
   request reached `dirty_timeout` the arbiter answered the client with a timeout
   error but kept the worker connection open. The worker's late response was then

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -268,8 +268,11 @@ class Arbiter:
 
     def handle_chld(self):
         """SIGCHLD handling - called from main loop, safe to log."""
-        self.reap_workers()
+        # Reap the dirty arbiter first: its targeted waitpid identifies the
+        # process, whereas reap_workers() uses waitpid(-1) and would claim it
+        # as an unknown child.
         self.reap_dirty_arbiter()
+        self.reap_workers()
 
     # SIGCLD is an alias for SIGCHLD on Linux. The SIG_NAMES dict may map
     # to either "chld" or "cld" depending on iteration order of dir(signal).
@@ -605,7 +608,22 @@ class Arbiter:
                     break
                 if self.reexec_pid == wpid:
                     self.reexec_pid = 0
+                elif self.dirty_arbiter_pid == wpid:
+                    # Normally claimed by reap_dirty_arbiter(), but it can exit
+                    # while this loop is running.
+                    self.handle_dirty_arbiter_exit(wpid, status)
                 else:
+                    # waitpid(-1) reaps every child, and when gunicorn runs as
+                    # PID 1 the kernel reparents orphans onto it. Those are not
+                    # ours: reap them so they do not linger as zombies, but do
+                    # not report them as workers or let them halt the server.
+                    worker = self.WORKERS.pop(wpid, None)
+                    if worker is None:
+                        self.log.debug(
+                            "Reaped unknown child process (pid:%s, status:%s)",
+                            wpid, status)
+                        continue
+
                     # A worker was terminated. If the termination reason was
                     # that it could not boot, we'll shut it down to avoid
                     # infinite start/stop cycles.
@@ -643,9 +661,6 @@ class Arbiter:
                         reason = "App failed to load."
                         raise HaltServer(reason, self.APP_LOAD_ERROR)
 
-                    worker = self.WORKERS.pop(wpid, None)
-                    if not worker:
-                        continue
                     worker.tmp.close()
                     self.cfg.child_exit(self, worker)
         except OSError as e:
@@ -897,6 +912,28 @@ class Arbiter:
                 self.dirty_arbiter_pid = 0
                 self.dirty_arbiter = None
 
+    def handle_dirty_arbiter_exit(self, wpid, status):
+        """\
+        Report the dirty arbiter exit status and forget the process.
+
+        Called from both reaping paths: the targeted waitpid below, and
+        reap_workers() when its waitpid(-1) claims the process first.
+        """
+        if os.WIFEXITED(status):
+            exitcode = os.WEXITSTATUS(status)
+            if exitcode != 0:
+                self.log.error("Dirty arbiter (pid:%s) exited with code %s",
+                               wpid, exitcode)
+            else:
+                self.log.info("Dirty arbiter (pid:%s) exited", wpid)
+        elif os.WIFSIGNALED(status):
+            sig = os.WTERMSIG(status)
+            self.log.warning("Dirty arbiter (pid:%s) killed by signal %s",
+                             wpid, sig)
+
+        self.dirty_arbiter_pid = 0
+        self.dirty_arbiter = None
+
     def reap_dirty_arbiter(self):
         """\
         Reap the dirty arbiter process if it has exited.
@@ -909,20 +946,7 @@ class Arbiter:
             if not wpid:
                 return
 
-            if os.WIFEXITED(status):
-                exitcode = os.WEXITSTATUS(status)
-                if exitcode != 0:
-                    self.log.error("Dirty arbiter (pid:%s) exited with code %s",
-                                   wpid, exitcode)
-                else:
-                    self.log.info("Dirty arbiter (pid:%s) exited", wpid)
-            elif os.WIFSIGNALED(status):
-                sig = os.WTERMSIG(status)
-                self.log.warning("Dirty arbiter (pid:%s) killed by signal %s",
-                                 wpid, sig)
-
-            self.dirty_arbiter_pid = 0
-            self.dirty_arbiter = None
+            self.handle_dirty_arbiter_exit(wpid, status)
         except OSError as e:
             if e.errno == errno.ECHILD:
                 self.dirty_arbiter_pid = 0

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -432,6 +432,96 @@ class TestReapWorkers:
         log_messages = ' '.join(str(call) for call in mock_log.call_args_list)
         assert 'out of memory' in log_messages.lower()
 
+    @mock.patch('os.waitpid')
+    def test_reap_unknown_child_is_not_reported_as_worker(self, mock_waitpid):
+        """An orphan reparented onto gunicorn is not a worker exit."""
+        # pid 30740 exits with code 23, and was never a worker
+        mock_waitpid.side_effect = [(30740, 23 << 8), (0, 0)]
+
+        arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
+        arbiter.cfg.settings['child_exit'] = mock.Mock()
+        arbiter.WORKERS = {}
+
+        with mock.patch.object(arbiter.log, 'error') as mock_error, \
+             mock.patch.object(arbiter.log, 'debug') as mock_debug:
+            arbiter.reap_workers()
+
+        mock_error.assert_not_called()
+        arbiter.cfg.child_exit.assert_not_called()
+        debug_messages = ' '.join(str(call) for call in mock_debug.call_args_list)
+        assert '30740' in debug_messages
+
+    @mock.patch('os.waitpid')
+    def test_reap_unknown_child_killed_by_signal(self, mock_waitpid):
+        """An orphan killed by SIGKILL does not get the OOM hint."""
+        mock_waitpid.side_effect = [(12345, signal.SIGKILL), (0, 0)]
+
+        arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
+        arbiter.cfg.settings['child_exit'] = mock.Mock()
+        arbiter.WORKERS = {}
+
+        with mock.patch.object(arbiter.log, 'error') as mock_error:
+            arbiter.reap_workers()
+
+        mock_error.assert_not_called()
+
+    @mock.patch('os.waitpid')
+    def test_reap_unknown_child_boot_error_does_not_halt(self, mock_waitpid):
+        """An orphan exiting with WORKER_BOOT_ERROR must not stop the server."""
+        boot_error = gunicorn.arbiter.Arbiter.WORKER_BOOT_ERROR
+        mock_waitpid.side_effect = [(30740, boot_error << 8), (0, 0)]
+
+        arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
+        arbiter.cfg.settings['child_exit'] = mock.Mock()
+        arbiter.WORKERS = {}
+
+        arbiter.reap_workers()
+
+    @mock.patch('os.waitpid')
+    def test_reap_mixed_worker_and_unknown_child(self, mock_waitpid):
+        """A real worker is still reported when an orphan is reaped first."""
+        mock_waitpid.side_effect = [
+            (99999, 1 << 8),   # orphan, exit code 1
+            (42, 1 << 8),      # real worker, exit code 1
+            (0, 0),
+        ]
+
+        arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
+        arbiter.cfg.settings['child_exit'] = mock.Mock()
+        mock_worker = mock.Mock()
+        arbiter.WORKERS = {42: mock_worker}
+
+        with mock.patch.object(arbiter.log, 'error') as mock_error:
+            arbiter.reap_workers()
+
+        errors = ' '.join(str(call) for call in mock_error.call_args_list)
+        assert '99999' not in errors
+        assert '42' in errors
+        mock_worker.tmp.close.assert_called_once()
+        arbiter.cfg.child_exit.assert_called_once_with(arbiter, mock_worker)
+        assert 42 not in arbiter.WORKERS
+
+    @mock.patch('os.waitpid')
+    def test_reap_dirty_arbiter_is_reported_as_itself(self, mock_waitpid):
+        """The dirty arbiter is not a worker and not an unknown child."""
+        mock_waitpid.side_effect = [(777, 23 << 8), (0, 0)]
+
+        arbiter = gunicorn.arbiter.Arbiter(DummyApplication())
+        arbiter.cfg.settings['child_exit'] = mock.Mock()
+        arbiter.WORKERS = {}
+        arbiter.dirty_arbiter_pid = 777
+        arbiter.dirty_arbiter = mock.Mock()
+
+        with mock.patch.object(arbiter.log, 'error') as mock_error:
+            arbiter.reap_workers()
+
+        errors = ' '.join(str(call) for call in mock_error.call_args_list)
+        assert 'Dirty arbiter' in errors
+        assert 'Worker' not in errors
+        assert arbiter.dirty_arbiter_pid == 0
+        assert arbiter.dirty_arbiter is None
+        arbiter.cfg.child_exit.assert_not_called()
+
 
 # ============================================================================
 # SIGHUP Reload Tests


### PR DESCRIPTION
Supersedes #3566. Original report, production evidence and fix by @joho54.

`reap_workers()` reaps every child through `waitpid(-1)`, which includes
processes the kernel reparents onto gunicorn when it runs as PID 1 in a
container. It logged the exit status before checking whether the pid was ever a
worker, so an unrelated process produced `Worker (pid:N) exited with code M`.

That is the reported symptom. The same ordering causes a worse one: a non-worker
exiting with `WORKER_BOOT_ERROR` or `APP_LOAD_ERROR` reached the `HaltServer`
raises and shut the whole server down, blaming a worker that never existed.

Ownership is now established before the exit status is touched. Beyond #3566,
this also handles the dirty arbiter, which is gunicorn's third kind of child and
is not in `WORKERS`: #3566 alone would classify it as an unknown child and drop
its crashes to debug. It is now reported as itself, and `handle_chld()` reaps it
before `reap_workers()` so its own reporting runs rather than always losing the
race to `waitpid(-1)`.

`waitpid(-1)` is unchanged. As PID 1 gunicorn must reap orphans or they become
zombies; only the reporting changes.

Closes #3220.
