### PR TITLE
docs: point CONTRIBUTING at the mkdocs settings reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,8 @@ Make sure you include relevant updates or additions to documentation
 when creating or modifying features.
 
 If you are adding a new configuration option or updating an existing one,
-please do it in `gunicorn/config.py`, then run `make -C docs html` to update
-`docs/source/settings.rst`.
+please do it in `gunicorn/config.py`, then run `mkdocs build` to update
+`docs/content/reference/settings.md`.
 
 Write clean code.
 


### PR DESCRIPTION
`CONTRIBUTING.md` sends a contributor to a file and a build command that were both removed.

## What it says today

```
If you are adding a new configuration option or updating an existing one,
please do it in `gunicorn/config.py`, then run `make -C docs html` to update
`docs/source/settings.rst`.
```

## Why neither works

`docs/source/settings.rst` was deleted in 58d80397 (*"bump version to 24.0.0, remove sphinx docs"*), which removed 29 files under `docs/source/`. `make -C docs html` went with it. There is no `docs/Makefile` in the tree any more.

## What replaced them

- `docs/README.md` documents `mkdocs build` (and `mkdocs serve`) as the way to render the site.
- The settings reference is now `docs/content/reference/settings.md`, produced by `scripts/build_settings_doc.py` through the `gen-files` plugin configured in `mkdocs.yml`.
- That generated file already tells the reader to update `gunicorn/config.py` instead, which is what CONTRIBUTING is trying to say.

So the advice was right and only the command and the path went stale. This changes those two and nothing else.

Found with [docproof](https://github.com/melbinjp/docproof), which checks documentation claims against the repository and calls a path broken only when the history shows the project had it and deleted it. The deleting commit is the receipt, and that is what `58d80397` is doing above.


