### PR TITLE
http: reject duplicate Host and Content-Type headers

### DIFF
--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -16,6 +16,15 @@
 
 ### Bug Fixes
 
+- **Duplicate `Host` and `Content-Type` headers accepted**: RFC 9110 section 5.3
+  allows only one of each, and a repeat cannot be merged into a list, so the
+  message means different things to gunicorn and to anything downstream. Both
+  are now rejected with `InvalidHeader`. The check lives in the policy hook
+  shared by both parsers, so the pure-Python and fast parsers agree. Duplicate
+  `Content-Length` was already rejected and is unchanged
+  ([#3366](https://github.com/benoitc/gunicorn/issues/3366),
+  [#3548](https://github.com/benoitc/gunicorn/pull/3548)).
+
 - **Non-worker children reported as failed workers**: `reap_workers()` reaps
   every child through `waitpid(-1)`, including processes the kernel reparented
   onto gunicorn when it runs as PID 1 in a container, but it logged the exit

--- a/gunicorn/asgi/parser.py
+++ b/gunicorn/asgi/parser.py
@@ -103,6 +103,16 @@ class InvalidChunkExtension(ParseError):
     """Invalid chunk extension per RFC 9112."""
 
 
+# RFC 9110 section 5.3: fields whose grammar admits only a single member, so a
+# second occurrence cannot be merged and makes the message ambiguous. Lowercase
+# because that is how _finalize_headers() stores names. content-length belongs
+# to this class too but is validated separately, alongside its value.
+RFC9110_5_3_SINGLETON_FIELDS = frozenset((
+    b'host',
+    b'content-type',
+))
+
+
 class PythonProtocol:
     """Callback-based HTTP/1.1 parser (pure Python fallback).
 
@@ -573,6 +583,7 @@ class PythonProtocol:
 
         Validates headers for request smuggling vulnerabilities:
         - Rejects duplicate Content-Length headers
+        - Rejects duplicate Host and Content-Type headers
         - Rejects requests with both Content-Length and Transfer-Encoding
         - Rejects chunked Transfer-Encoding in HTTP/1.0
         - Rejects stacked chunked encoding
@@ -583,8 +594,18 @@ class PythonProtocol:
         # Extract and validate content-length and transfer-encoding
         content_length = None
         chunked = False
+        seen_singletons = set()
 
         for name, value in self.headers:
+            # RFC 9110 section 5.3: these admit a single member only, so a
+            # repeat cannot be merged and leaves the message ambiguous.
+            # content-length is handled separately just below.
+            if name in RFC9110_5_3_SINGLETON_FIELDS:
+                if name in seen_singletons:
+                    raise InvalidHeader(
+                        "Duplicate %s header" % name.decode('latin-1'))
+                seen_singletons.add(name)
+
             if name == b'content-length':
                 # Reject duplicate Content-Length headers (request smuggling vector)
                 if content_length is not None:
@@ -902,6 +923,18 @@ class CallbackRequest:
             (n.decode('latin-1').upper(), v.decode('latin-1'))
             for n, v in parser.headers
         ]
+
+        # RFC 9110 section 5.3, enforced here because this is where both
+        # parsers converge: PythonProtocol also checks in _finalize_headers(),
+        # but H1CProtocol validates internally and does not cover these two.
+        seen_singletons = set()
+        for name, _value in parser.headers:
+            lowered = name.lower()
+            if lowered in RFC9110_5_3_SINGLETON_FIELDS:
+                if lowered in seen_singletons:
+                    raise InvalidHeader(
+                        "Duplicate %s header" % lowered.decode('latin-1'))
+                seen_singletons.add(lowered)
 
         req.scheme = 'https' if is_ssl else 'http'
         req.content_length = parser.content_length or 0

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -147,6 +147,15 @@ RFC9110_6_5_1_FORBIDDEN_TRAILER = frozenset((
     "TE",
 ))
 
+# RFC 9110 section 5.3: fields whose grammar admits only a single member, so a
+# second occurrence cannot be merged and makes the message ambiguous.
+# CONTENT-LENGTH is deliberately absent: duplicates are already rejected in
+# set_body_reader(), which reports them with the request attached.
+RFC9110_5_3_SINGLETON_FIELDS = frozenset((
+    "HOST",
+    "CONTENT-TYPE",
+))
+
 
 def _ip_in_allow_list(ip_str, allow_list, networks):
     """Check if IP address is in the allow list.
@@ -220,19 +229,30 @@ class Message:
             return cfg.secure_scheme_headers, cfg.forwarder_headers
         return {}, []
 
-    def _apply_header_policy(self, name, value, scheme_state,
+    def _apply_header_policy(self, name, value, scheme_state, seen,
                              secure_scheme_headers, forwarder_headers,
                              from_trailer=False):
         """Apply per-header policy shared between Python and fast parsers.
 
         Mutates ``self._expected_100_continue`` and ``self.scheme`` as needed.
         ``scheme_state`` is a single-element list used as a mutable sentinel
-        so the caller can detect repeated scheme headers.
+        so the caller can detect repeated scheme headers.  ``seen`` is a set of
+        the field names already accepted for this message, used the same way to
+        detect repeated singleton fields.
 
         Returns the (name, value) pair to retain, or ``None`` to drop the
         header (per ``header_map='drop'``).  Raises the same exceptions the
         Python path raises so behavior is identical regardless of parser.
         """
+        # https://datatracker.ietf.org/doc/html/rfc9110#section-5.3
+        # A singleton field cannot be combined into a list, so a repeat leaves
+        # the message ambiguous and open to being read differently by us and by
+        # anything downstream.
+        if name in RFC9110_5_3_SINGLETON_FIELDS:
+            if name in seen:
+                raise InvalidHeader(name, req=self)
+            seen.add(name)
+
         if not from_trailer and name == "EXPECT":
             # https://datatracker.ietf.org/doc/html/rfc9110#section-10.1.1
             # "The Expect field value is case-insensitive."
@@ -288,6 +308,7 @@ class Message:
 
         # handle scheme headers
         scheme_state = [False]
+        seen = set()
         if from_trailer:
             # nonsense. either a request is https from the beginning
             #  .. or we are just behind a proxy who does not remove conflicting trailers
@@ -344,7 +365,7 @@ class Message:
                 raise LimitRequestHeaders("limit request headers fields size")
 
             kept = self._apply_header_policy(
-                name, value, scheme_state,
+                name, value, scheme_state, seen,
                 secure_scheme_headers, forwarder_headers,
                 from_trailer=from_trailer,
             )
@@ -551,13 +572,14 @@ class Request(Message):
         # below so the fast path mirrors parse_headers().
         self.headers = []
         scheme_state = [False]
+        seen = set()
         secure_scheme_headers, forwarder_headers = self._peer_trusted_for_forwarded()
         for name_bytes, value_bytes in result['headers']:
             name = bytes_to_str(name_bytes).upper()
             value = bytes_to_str(value_bytes)
 
             kept = self._apply_header_policy(
-                name, value, scheme_state,
+                name, value, scheme_state, seen,
                 secure_scheme_headers, forwarder_headers,
             )
             if kept is None:

--- a/tests/requests/invalid/041.http
+++ b/tests/requests/invalid/041.http
@@ -1,0 +1,5 @@
+GET /stuff/here?foo=bar HTTP/1.1\r\n
+Host: localhost\r\n
+Content-Type: application/json\r\n
+Content-Type: text/html\r\n
+\r\n

--- a/tests/requests/invalid/041.py
+++ b/tests/requests/invalid/041.py
@@ -1,0 +1,10 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+from gunicorn.config import Config
+from gunicorn.http.errors import InvalidHeader
+
+cfg = Config()
+
+request = InvalidHeader

--- a/tests/requests/invalid/042.http
+++ b/tests/requests/invalid/042.http
@@ -1,0 +1,4 @@
+GET /stuff/here?foo=bar HTTP/1.1\r\n
+Host: localhost\r\n
+Host: evil.example.com\r\n
+\r\n

--- a/tests/requests/invalid/042.py
+++ b/tests/requests/invalid/042.py
@@ -1,0 +1,10 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+from gunicorn.config import Config
+from gunicorn.http.errors import InvalidHeader
+
+cfg = Config()
+
+request = InvalidHeader

--- a/tests/test_asgi_invalid_requests.py
+++ b/tests/test_asgi_invalid_requests.py
@@ -18,6 +18,7 @@ from gunicorn.http.errors import (
     ObsoleteFolding,
 )
 import treq_asgi
+from gunicorn.asgi.parser import CallbackRequest
 
 dirname = os.path.dirname(__file__)
 reqdir = os.path.join(dirname, "requests", "invalid")
@@ -49,6 +50,12 @@ FAST_PARSER_SKIP_TESTS = {
     '024.http',      # InvalidHeader - fast parser accepts
     'prefix_03.http',  # InvalidHeader - fast parser accepts
     'prefix_04.http',  # InvalidHeader - fast parser accepts
+    # Duplicate singleton fields: H1CProtocol accepts them, and gunicorn
+    # rejects them in CallbackRequest.from_parser(), which this harness
+    # bypasses by driving the parser directly. Covered instead by
+    # TestSingletonHeadersFromParser below, which exercises that path.
+    '041.http',
+    '042.http',
 }
 
 
@@ -85,3 +92,47 @@ def test_asgi_parser(fname, http_parser):
 
     req = treq_asgi.badrequest(fname)
     req.check(cfg, expect, http_parser=http_parser)
+
+
+class TestSingletonHeadersFromParser:
+    """Duplicate singleton fields are rejected where both parsers converge.
+
+    The corpus harness above drives the parser directly, so it never reaches
+    CallbackRequest.from_parser(). Production does, via
+    ASGIProtocol._on_headers_complete(), and H1CProtocol accepts duplicate Host
+    and Content-Type on its own, so this is the only place the fast path is
+    covered.
+    """
+
+    DUPLICATES = [
+        pytest.param(
+            b"GET / HTTP/1.1\r\nHost: a\r\nHost: b\r\n\r\n", "host", id="host"
+        ),
+        pytest.param(
+            b"GET / HTTP/1.1\r\nHost: a\r\n"
+            b"Content-Type: application/json\r\n"
+            b"Content-Type: text/html\r\n\r\n",
+            "content-type", id="content-type",
+        ),
+    ]
+
+    @pytest.mark.parametrize("raw,field", DUPLICATES)
+    def test_duplicate_rejected(self, raw, field, http_parser):
+        parser_class = treq_asgi.get_parser_class(http_parser)
+        parser = parser_class()
+        try:
+            parser.feed(raw)
+        except Exception as exc:  # parser rejected it outright, also fine
+            assert field in str(exc).lower()
+            return
+
+        with pytest.raises(Exception) as exc_info:
+            CallbackRequest.from_parser(parser)
+        assert field in str(exc_info.value).lower()
+
+    def test_single_occurrence_accepted(self, http_parser):
+        parser_class = treq_asgi.get_parser_class(http_parser)
+        parser = parser_class()
+        parser.feed(b"GET / HTTP/1.1\r\nHost: a\r\nContent-Type: text/html\r\n\r\n")
+        req = CallbackRequest.from_parser(parser)
+        assert req.get_header("HOST") == "a"


### PR DESCRIPTION
Supersedes #3548. Original report and fix by @Cycloctane.

RFC 9110 section 5.3 allows a single member for `Host` and `Content-Type`, so a
repeat cannot be merged into a list and the message means different things to
gunicorn and to whatever sits downstream.

Two changes from #3548.

**Where the check lives.** #3548 put it in `parse_headers()`, which `_parse_fast()`
never calls, so the fast WSGI parser would still have accepted duplicates and the
PR's own corpus case would have failed on its `fast` variant. It now lives in
`_apply_header_policy()`, the per-header hook both WSGI parsers already share, so
they agree by construction.

The ASGI side needed separate handling: `PythonProtocol` validates during parsing
alongside its existing framing checks, and `CallbackRequest.from_parser()` covers
`H1CProtocol`, which rejects duplicate `Content-Length` on its own but accepts
these two. No `gunicorn_h1c` change is required.

**Content-Length is excluded.** Duplicates are already rejected in
`set_body_reader()`, which raises with the request attached so the access log
keeps its entry. Adding it to the new set would have preempted that and dropped
the entry.

Corpus cases cover both fields against the WSGI python and fast parsers and the
ASGI python parser. The ASGI corpus harness drives the parser directly and never
reaches `from_parser()`, so the ASGI fast path is covered by an explicit test
instead.

Closes #3366.
