### PR TITLE
chore: require gunicorn_h1c >= 0.6.6

### DIFF
--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -109,6 +109,14 @@
   termination message in `Arbiter.reap_workers()`
   ([#3678](https://github.com/benoitc/gunicorn/pull/3678)).
 
+### Changes
+
+- **Fast HTTP Parser**: Require `gunicorn_h1c >= 0.6.6`, which rejects duplicate
+  `Host` and `Content-Type` headers in the C parser itself. Gunicorn already
+  refuses them on both the WSGI and ASGI paths, so this changes nothing that is
+  reachable; it moves the rejection to where the bytes are read and lets the
+  ASGI corpus exercise those cases against the fast parser directly.
+
 ## 26.0.0 - 2026-05-05
 
 ### Breaking Changes

--- a/gunicorn/asgi/parser.py
+++ b/gunicorn/asgi/parser.py
@@ -925,8 +925,10 @@ class CallbackRequest:
         ]
 
         # RFC 9110 section 5.3, enforced here because this is where both
-        # parsers converge: PythonProtocol also checks in _finalize_headers(),
-        # but H1CProtocol validates internally and does not cover these two.
+        # parsers converge. Both reject these on their own now (PythonProtocol
+        # in _finalize_headers(), H1CProtocol since 0.6.6), so this is a
+        # backstop: the pip requirement is not enforced at runtime, and an
+        # older gunicorn_h1c would otherwise let duplicates through.
         seen_singletons = set()
         for name, _value in parser.headers:
             lowered = name.lower()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ tornado = ["tornado>=6.5.0"]
 gthread = []
 setproctitle = ["setproctitle"]
 http2 = ["h2>=4.1.0"]
-fast = ["gunicorn_h1c>=0.6.5"]
+fast = ["gunicorn_h1c>=0.6.6"]
 testing = [
     "gevent>=24.10.1",
     "h2>=4.1.0",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,7 @@ packaging
 pytest>=7.2.0
 pytest-cov
 pytest-asyncio
-gunicorn_h1c>=0.6.5
+gunicorn_h1c>=0.6.6
 h2>=4.1.0
 uvloop>=0.19.0
 inotify>=0.2.10; sys_platform == 'linux'

--- a/tests/test_asgi_invalid_requests.py
+++ b/tests/test_asgi_invalid_requests.py
@@ -50,12 +50,6 @@ FAST_PARSER_SKIP_TESTS = {
     '024.http',      # InvalidHeader - fast parser accepts
     'prefix_03.http',  # InvalidHeader - fast parser accepts
     'prefix_04.http',  # InvalidHeader - fast parser accepts
-    # Duplicate singleton fields: H1CProtocol accepts them, and gunicorn
-    # rejects them in CallbackRequest.from_parser(), which this harness
-    # bypasses by driving the parser directly. Covered instead by
-    # TestSingletonHeadersFromParser below, which exercises that path.
-    '041.http',
-    '042.http',
 }
 
 
@@ -97,11 +91,11 @@ def test_asgi_parser(fname, http_parser):
 class TestSingletonHeadersFromParser:
     """Duplicate singleton fields are rejected where both parsers converge.
 
-    The corpus harness above drives the parser directly, so it never reaches
-    CallbackRequest.from_parser(). Production does, via
-    ASGIProtocol._on_headers_complete(), and H1CProtocol accepts duplicate Host
-    and Content-Type on its own, so this is the only place the fast path is
-    covered.
+    The corpus cases above cover rejection during parsing. This covers the
+    backstop in CallbackRequest.from_parser(), which production reaches via
+    ASGIProtocol._on_headers_complete() and the corpus harness never does,
+    since it drives the parser directly. Either outcome is accepted: the
+    parser refusing the bytes outright, or from_parser() catching it.
     """
 
     DUPLICATES = [


### PR DESCRIPTION
0.6.6 rejects duplicate `Host` and `Content-Type` in the C parser, with the same
`InvalidHeader: Duplicate <Field> header` shape it already used for
`Content-Length`. `Transfer-Encoding` is still accepted, so the framing path is
untouched.

Gunicorn already refuses both on the WSGI and ASGI paths as of #3691, so nothing
reachable changes here. What it buys is that the two ASGI corpus cases added in
that PR no longer need skipping for the fast parser: they were skipped only
because the ASGI harness drives the parser directly and never reaches
`CallbackRequest.from_parser()`, where gunicorn's own check lives.

That check stays as a backstop. The pip requirement is not enforced at runtime,
so an older gunicorn_h1c would otherwise let duplicates through.
