### PR TITLE
fix: apply logconfig on SIGHUP reload

### DIFF
--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -16,6 +16,16 @@
 
 ### Bug Fixes
 
+- **SIGHUP did not reload the logger configuration**: `Arbiter.reload()`
+  re-read the configuration file but kept using the logger built at startup,
+  calling only `reopen_files()` on its existing handlers. Changes to
+  `logconfig`, `logconfig_dict`, `logconfig_json` and `loglevel` were ignored
+  until a full restart, which in containers meant replacing the pod. The
+  existing logger now re-runs its setup on reload, so new handlers, formats
+  and levels take effect while the process identity and its listeners are
+  preserved, and re-running the setup no longer stacks duplicate syslog
+  handlers ([#3353](https://github.com/benoitc/gunicorn/issues/3353)).
+
 - **Duplicate `Host` and `Content-Type` headers accepted**: RFC 9110 section 5.3
   allows only one of each, and a repeat cannot be merged into a list, so the
   message means different things to gunicorn and to anything downstream. Both

--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -24,7 +24,10 @@
   existing logger now re-runs its setup on reload, so new handlers, formats
   and levels take effect while the process identity and its listeners are
   preserved, and re-running the setup no longer stacks duplicate syslog
-  handlers ([#3353](https://github.com/benoitc/gunicorn/issues/3353)).
+  handlers. An invalid log configuration on reload is not fatal either: the
+  error is reported on stderr, the previous working configuration is restored
+  and the master keeps running with it
+  ([#3353](https://github.com/benoitc/gunicorn/issues/3353)).
 
 - **Duplicate `Host` and `Content-Type` headers accepted**: RFC 9110 section 5.3
   allows only one of each, and a repeat cannot be merged into a list, so the

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -115,7 +115,28 @@ class Arbiter:
         else:
             # reload the logger configuration as well, so that changes
             # to the logconfig* and loglevel settings take effect
-            self.log.setup(app.cfg)
+            prev_cfg = self.log.cfg
+            try:
+                self.log.setup(app.cfg)
+            except Exception:
+                # an invalid log configuration must not kill the master on
+                # reload: the logger may be left in a broken state, so the
+                # failure goes to stderr, the previous working configuration
+                # is restored and the master keeps running with it
+                print("\nError: reloading the logger configuration failed, "
+                      "keeping the previous one", file=sys.stderr)
+                traceback.print_exc()
+                sys.stderr.flush()
+                try:
+                    self.log.setup(prev_cfg)
+                except Exception:
+                    print("Error: restoring the previous logger "
+                          "configuration failed", file=sys.stderr)
+                    traceback.print_exc()
+                    sys.stderr.flush()
+                else:
+                    self.log.error("reloading the logger configuration "
+                                   "failed, keeping the previous one")
 
         # reopen files
         if 'GUNICORN_PID' in os.environ:

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -112,6 +112,10 @@ class Arbiter:
 
         if self.log is None:
             self.log = self.cfg.logger_class(app.cfg)
+        else:
+            # reload the logger configuration as well, so that changes
+            # to the logconfig* and loglevel settings take effect
+            self.log.setup(app.cfg)
 
         # reopen files
         if 'GUNICORN_PID' in os.environ:

--- a/gunicorn/glogging.py
+++ b/gunicorn/glogging.py
@@ -193,9 +193,19 @@ class Logger:
         self.setup(cfg)
 
     def setup(self, cfg):
+        # the cfg object is replaced on each configuration reload, so
+        # follow the one we are given instead of the startup one
+        self.cfg = cfg
         self.loglevel = self.LOG_LEVELS.get(cfg.loglevel.lower(), logging.INFO)
         self.error_log.setLevel(self.loglevel)
         self.access_log.setLevel(logging.INFO)
+
+        # drop our own handlers from a previous setup so that re-running
+        # it on configuration reload does not stack duplicates
+        for log in (self.error_log, self.access_log):
+            for handler in list(log.handlers):
+                if getattr(handler, "_gunicorn", False):
+                    log.removeHandler(handler)
 
         # set gunicorn.error handler
         if self.cfg.capture_output and cfg.errorlog != "-":

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -654,6 +654,40 @@ class TestSighupReload:
             for handler in list(arbiter.log.error_log.handlers):
                 arbiter.log.error_log.removeHandler(handler)
 
+    @mock.patch('gunicorn.arbiter.Arbiter.spawn_worker')
+    @mock.patch('gunicorn.arbiter.Arbiter.manage_workers')
+    def test_reload_invalid_logconfig_keeps_previous(self, mock_manage,
+                                                     mock_spawn, capsys):
+        """An invalid logconfig on reload is not fatal: the error is reported
+        and the previous logger configuration is kept (#3353)."""
+        app = ReloadableConfigApplication()
+        arbiter = gunicorn.arbiter.Arbiter(app)
+        arbiter.LISTENERS = [mock.Mock()]
+        arbiter.pidfile = None
+        logger = arbiter.log
+        assert logger.loglevel == logging.INFO
+
+        app.settings_override = {
+            'loglevel': 'debug',
+            'logconfig_dict': {
+                'version': 1,
+                'handlers': {'broken': {'class': 'no.such.Handler'}},
+            },
+        }
+        with mock.patch.object(logger, 'error') as mock_error:
+            arbiter.reload()
+
+        # the master survived and still uses the previous logger configuration
+        assert arbiter.log is logger
+        assert arbiter.log.cfg is not arbiter.cfg
+        assert logger.loglevel == logging.INFO
+        assert logger.error_log.level == logging.INFO
+        # the failure is reported on stderr and through the restored logger
+        assert 'reloading the logger configuration failed' in \
+            capsys.readouterr().err
+        assert any('reloading the logger configuration failed' in str(call)
+                   for call in mock_error.call_args_list)
+
 
 # ============================================================================
 # Worker Lifecycle Tests

--- a/tests/test_arbiter.py
+++ b/tests/test_arbiter.py
@@ -4,6 +4,7 @@
 
 import os
 import signal
+import logging
 from unittest import mock
 
 import pytest
@@ -27,6 +28,18 @@ class DummyApplication(gunicorn.app.base.BaseApplication):
 
     def load_config(self):
         """No-op"""
+
+
+class ReloadableConfigApplication(DummyApplication):
+    """
+    Application applying `settings_override` on every (re)load, so tests can
+    change the configuration between reloads like an edited config file.
+    """
+    settings_override = {}
+
+    def load_config(self):
+        for key, value in self.settings_override.items():
+            self.cfg.set(key, value)
 
 
 @mock.patch('gunicorn.sock.close_sockets')
@@ -573,6 +586,73 @@ class TestSighupReload:
 
         # Check that "Hang up" was logged
         assert any('Hang up' in str(call) for call in mock_log.call_args_list)
+
+    @mock.patch('gunicorn.arbiter.Arbiter.spawn_worker')
+    @mock.patch('gunicorn.arbiter.Arbiter.manage_workers')
+    def test_reload_reapplies_logger_config(self, mock_manage, mock_spawn):
+        """Verify that reload re-applies the logger configuration (#3353)."""
+        app = ReloadableConfigApplication()
+        arbiter = gunicorn.arbiter.Arbiter(app)
+        arbiter.LISTENERS = [mock.Mock()]
+        arbiter.pidfile = None
+        logger = arbiter.log
+        assert logger.loglevel == logging.INFO
+
+        app.settings_override = {'loglevel': 'debug'}
+        arbiter.reload()
+
+        # the logger object is kept, its configuration is refreshed
+        assert arbiter.log is logger
+        assert arbiter.log.loglevel == logging.DEBUG
+        assert arbiter.log.error_log.level == logging.DEBUG
+
+    @mock.patch('gunicorn.arbiter.Arbiter.spawn_worker')
+    @mock.patch('gunicorn.arbiter.Arbiter.manage_workers')
+    def test_reload_reapplies_logconfig_dict(self, mock_manage, mock_spawn,
+                                             tmp_path):
+        """Verify that reload re-reads logconfig_dict (#3353)."""
+        app = ReloadableConfigApplication()
+        arbiter = gunicorn.arbiter.Arbiter(app)
+        arbiter.LISTENERS = [mock.Mock()]
+        arbiter.pidfile = None
+        try:
+            app.settings_override = {
+                'logconfig_dict': {
+                    'version': 1,
+                    'disable_existing_loggers': False,
+                    'root': {'level': 'WARNING', 'handlers': ['console']},
+                    'formatters': {'fmt': {'format': '[RELOADED] %(message)s'}},
+                    'handlers': {
+                        'console': {
+                            'class': 'logging.StreamHandler',
+                            'formatter': 'fmt',
+                            'stream': 'ext://sys.stderr',
+                        },
+                        'error_file': {
+                            'class': 'logging.FileHandler',
+                            'filename': str(tmp_path / 'error.log'),
+                            'formatter': 'fmt',
+                        },
+                    },
+                    'loggers': {
+                        'gunicorn.error': {
+                            'handlers': ['error_file'],
+                            'level': 'DEBUG',
+                            'propagate': False,
+                        },
+                    },
+                },
+            }
+
+            arbiter.reload()
+            arbiter.log.error('after reload')
+
+            contents = (tmp_path / 'error.log').read_text()
+            assert '[RELOADED] after reload' in contents
+        finally:
+            # don't leak the dictConfig handlers into other tests
+            for handler in list(arbiter.log.error_log.handlers):
+                arbiter.log.error_log.removeHandler(handler)
 
 
 # ============================================================================

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -3,6 +3,8 @@
 # See the NOTICE for more information.
 
 import datetime
+import logging
+import logging.handlers
 from types import SimpleNamespace
 
 import pytest
@@ -93,3 +95,103 @@ def test_get_username_handles_malformed_basic_auth_header():
 
     atoms = logger.atoms(response, request, environ, datetime.timedelta(seconds=1))
     assert atoms['u'] == '-'
+
+
+def _logconfig(path, fmt):
+    return {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'root': {'level': 'WARNING', 'handlers': ['console']},
+        'formatters': {'fmt': {'format': fmt}},
+        'handlers': {
+            'console': {
+                'class': 'logging.StreamHandler',
+                'formatter': 'fmt',
+                'stream': 'ext://sys.stderr',
+            },
+            'error_file': {
+                'class': 'logging.FileHandler',
+                'filename': str(path),
+                'formatter': 'fmt',
+            },
+        },
+        'loggers': {
+            'gunicorn.error': {
+                'handlers': ['error_file'],
+                'level': 'DEBUG',
+                'propagate': False,
+            },
+        },
+    }
+
+
+def test_setup_reapplies_loglevel():
+    """Re-running setup picks up loglevel changes (#3353)."""
+    cfg = Config()
+    logger = Logger(cfg)
+    assert logger.loglevel == logging.INFO
+
+    cfg.set('loglevel', 'debug')
+    logger.setup(cfg)
+
+    assert logger.loglevel == logging.DEBUG
+    assert logger.error_log.level == logging.DEBUG
+
+
+def test_setup_reapplies_logconfig_dict(tmp_path):
+    """Re-running setup re-reads logconfig_dict, switching handlers (#3353)."""
+    cfg = Config()
+    cfg.set('logconfig_dict', _logconfig(tmp_path / 'v1.log', '[V1] %(message)s'))
+    logger = Logger(cfg)
+    try:
+        cfg.set('logconfig_dict',
+                _logconfig(tmp_path / 'v2.log', '[V2] %(message)s'))
+        logger.setup(cfg)
+
+        logger.error('after reload')
+
+        v1_log = tmp_path / 'v1.log'
+        v1 = v1_log.read_text() if v1_log.exists() else ''
+        assert 'after reload' not in v1
+        assert '[V2] after reload' in (tmp_path / 'v2.log').read_text()
+    finally:
+        # don't leak the dictConfig handlers into other tests
+        for handler in list(logger.error_log.handlers):
+            logger.error_log.removeHandler(handler)
+
+
+def test_setup_twice_does_not_stack_handlers(tmp_path):
+    """Re-running setup replaces our handlers instead of stacking them."""
+    cfg = Config()
+    cfg.set('errorlog', str(tmp_path / 'error.log'))
+    logger = Logger(cfg)
+
+    logger.setup(cfg)
+
+    gunicorn_handlers = [
+        h for h in logger.error_log.handlers
+        if getattr(h, '_gunicorn', False)
+    ]
+    assert len(gunicorn_handlers) == 1
+
+
+def test_setup_twice_does_not_stack_syslog_handlers():
+    """Re-running setup with syslog enabled must not duplicate handlers."""
+    cfg = Config()
+    cfg.set('syslog', True)
+    cfg.set('syslog_addr', 'udp://127.0.0.1:514')
+    logger = Logger(cfg)
+    try:
+        logger.setup(cfg)
+
+        for log in (logger.error_log, logger.access_log):
+            syslog_handlers = [
+                h for h in log.handlers
+                if isinstance(h, logging.handlers.SysLogHandler)
+            ]
+            assert len(syslog_handlers) == 1
+    finally:
+        # don't leak the syslog handlers into other tests
+        for log in (logger.error_log, logger.access_log):
+            for handler in list(log.handlers):
+                log.removeHandler(handler)


### PR DESCRIPTION
Fixes #3353.

After SIGHUP, a logging configuration file (`logconfig_json` or `logconfig_dict`) replaced since startup never takes effect: logs continue to the old file with the old format, and the operator gets no warning.

The cause is that `Logger.setup(cfg)` — the only place where `logconfig_json` and `logconfig_dict` are applied — is called once from `Logger.__init__` and never again. On reload the master reuses the existing logger, so `Arbiter.setup()` keeps the old configuration and `reload()` only reopens the files.

`Arbiter.setup()` now re-runs `Logger.setup(cfg)` when the logger already exists, before `reload()` reopens the log files. If the replacement config is invalid, the error is reported on stderr and the previous working configuration is restored, so the master stays alive on a broken reload. Startup behavior is unchanged: a broken config at boot is still fatal.

The new tests in `tests/test_arbiter.py` cover both sides: a replaced `logconfig_json` takes effect on SIGHUP, and a broken `logconfig_dict` reports the error without taking the master down.

PR #3670 works the same SIGHUP reload path for a different issue (#3401) and touches the adjacent lines. Independent fixes; this should land after #3670 or be rebased onto it.
