### PR TITLE
docs: add a roadmap and make the chat easy to find

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Full documentation at https://gunicorn.org
 ## Community
 
 - Report bugs on [GitHub Issues](https://github.com/benoitc/gunicorn/issues)
-- Chat in [#gunicorn](https://web.libera.chat/?channels=#gunicorn) on [Libera.chat](https://libera.chat/)
+- [Chat with us in your browser](https://web.libera.chat/?channels=%23gunicorn) (`#gunicorn` on Libera.Chat, no account needed)
 - See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines
 
 ## Support

--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -16,10 +16,18 @@ GitHub is used for:
 - [Feature planning](https://github.com/benoitc/gunicorn/issues) — development
   and project management topics.
 
-## IRC
+## Chat
 
-Join the Gunicorn channel on [Libera Chat](https://libera.chat/) at
-[`#gunicorn`](https://web.libera.chat/?channels=#gunicorn).
+[**Open the chat in your browser**](https://web.libera.chat/?channels=%23gunicorn)
+— no account, no install, pick a nickname and you are in.
+
+It is the `#gunicorn` channel on [Libera.Chat](https://libera.chat/), so any IRC
+client works too: `irc.libera.chat:6697` over TLS.
+
+Chat is for quick questions and hallway conversation. Nobody is guaranteed to be
+watching, and nothing said there is recorded, so anything worth keeping belongs
+in a [discussion](https://github.com/benoitc/gunicorn/discussions) or an
+[issue](https://github.com/benoitc/gunicorn/issues).
 
 ## Issue tracking
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -110,6 +110,10 @@ title: Gunicorn - Python WSGI HTTP Server
         <strong>FAQ</strong>
         <span>Common questions</span>
       </a>
+      <a class="quick-link" href="roadmap/">
+        <strong>Roadmap</strong>
+        <span>Where the project is going</span>
+      </a>
     </div>
   </div>
 </section>
@@ -134,7 +138,8 @@ title: Gunicorn - Python WSGI HTTP Server
     <p>Questions? Bugs? Ideas? We're here to help.</p>
     <div class="home-footer__links">
       <a href="https://github.com/benoitc/gunicorn/issues">GitHub Issues</a>
-      <a href="https://web.libera.chat/#gunicorn">#gunicorn on Libera</a>
+      <a href="https://web.libera.chat/?channels=%23gunicorn">Chat in your browser</a>
+      <a href="roadmap/">Roadmap</a>
       <a href="community/">Contributing</a>
     </div>
   </div>

--- a/docs/content/roadmap.md
+++ b/docs/content/roadmap.md
@@ -32,7 +32,7 @@ with the compatibility suite as the check on that.
 
 ## Next
 
-Larger pieces of work that are planned but not started.
+Larger pieces of work that are planned, or begun but not landed.
 
 **Serving AI workloads.** Dirty arbiters already give a model its own process
 pool, with per-app worker allocation and streaming responses. The work ahead is
@@ -42,6 +42,17 @@ pinning workers to specific GPUs.
 
 **HTTP/3.** QUIC support, alongside finishing HTTP/2. The protocol is already
 reserved in the configuration and does nothing yet.
+
+**FastCGI.** A FastCGI responder alongside the existing
+[uWSGI protocol](uwsgi.md) support, so gunicorn can sit behind nginx or Apache
+over FCGI instead of HTTP proxying. A working branch exists in
+[#3466](https://github.com/benoitc/gunicorn/pull/3466); it needs finishing and
+review.
+
+None of these are settled. If you have a use case, a design opinion or a
+constraint any of them would break, say so in
+[Ideas](https://github.com/benoitc/gunicorn/discussions/categories/ideas) —
+that is what shapes the order and the shape of the work.
 
 ## Not planned
 
@@ -57,6 +68,6 @@ The ordering is not fixed. Things that move it:
 - [Sponsorship](sponsor.md) converts evenings into days, which is what
   determines how much of the "Next" section happens at all.
 
-Open a [discussion](https://github.com/benoitc/gunicorn/discussions) if
-something important to you is missing here, or come
-[ask in chat](https://web.libera.chat/?channels=%23gunicorn).
+If something important to you is missing here, open an
+[Idea](https://github.com/benoitc/gunicorn/discussions/categories/ideas), or
+come [ask in chat](https://web.libera.chat/?channels=%23gunicorn).

--- a/docs/content/roadmap.md
+++ b/docs/content/roadmap.md
@@ -1,0 +1,68 @@
+# Roadmap
+
+Where gunicorn is going, and what is being worked on now. This is priority
+order, not a schedule: nothing here carries a date, and items move when
+circumstances or funding change.
+
+Gunicorn is maintained in unpaid time. That is the constraint behind every
+ordering decision on this page. See [Support Gunicorn](sponsor.md) for how that
+changes.
+
+## Now
+
+The current focus, roughly in order.
+
+**Release stabilization.** Working through open reports and pull requests,
+reviewing contributions, and getting fixes into releases. This is the bulk of
+the work and the part that goes undone when there is no time.
+
+**Security.** Responding to reported vulnerabilities, and keeping the HTTP
+parsers aligned with RFC 9110 and RFC 9112 on request framing, header syntax
+and smuggling defenses.
+
+**HTTP/2.** Taking what shipped as beta toward something dependable, including
+`h2c` support across the HTTP/2-capable workers.
+
+**ASGI.** Tracking the spec as FastAPI, Starlette, Quart and the rest move,
+with the compatibility suite as the check on that.
+
+**Python compatibility.** Keeping up with new Python releases.
+
+**Documentation.** Keeping the guides and the settings reference current.
+
+## Next
+
+Larger pieces of work that are planned but not started.
+
+**Serving AI workloads.** Dirty arbiters already give a model its own process
+pool, with per-app worker allocation and streaming responses. The work ahead is
+what a model server needs on top of that: batching requests so a single forward
+pass serves many of them, backpressure when the queue outgrows the workers, and
+pinning workers to specific GPUs.
+
+**HTTP/3.** QUIC support, alongside finishing HTTP/2. The protocol is already
+reserved in the configuration and does nothing yet.
+
+## Not planned
+
+Saying no is part of a direction.
+
+- **Windows support.** Gunicorn is a pre-fork UNIX server. The process model is
+  the product, and it does not port.
+- **Becoming an application framework.** Gunicorn runs your app; it does not
+  want to be your router, your ORM or your task queue.
+- **Replacing a reverse proxy.** Run gunicorn behind nginx or similar. TLS
+  termination, static files and request buffering belong there.
+
+## Influencing this
+
+The ordering is not fixed. Things that move it:
+
+- A clear bug report with a reproduction moves the fix up.
+- A pull request with tests moves the feature up further.
+- [Sponsorship](sponsor.md) converts evenings into days, which is what
+  determines how much of the "Next" section happens at all.
+
+Open a [discussion](https://github.com/benoitc/gunicorn/discussions) if
+something important to you is missing here, or come
+[ask in chat](https://web.libera.chat/?channels=%23gunicorn).

--- a/docs/content/roadmap.md
+++ b/docs/content/roadmap.md
@@ -45,14 +45,8 @@ reserved in the configuration and does nothing yet.
 
 ## Not planned
 
-Saying no is part of a direction.
-
-- **Windows support.** Gunicorn is a pre-fork UNIX server. The process model is
-  the product, and it does not port.
-- **Becoming an application framework.** Gunicorn runs your app; it does not
-  want to be your router, your ORM or your task queue.
-- **Replacing a reverse proxy.** Run gunicorn behind nginx or similar. TLS
-  termination, static files and request buffering belong there.
+**Windows support.** Gunicorn is a pre-fork UNIX server. The process model is
+the product, and it does not port.
 
 ## Influencing this
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
       - Design: design.md
   - Community:
       - Overview: community.md
+      - Roadmap: roadmap.md
       - FAQ: faq.md
       - Support Us: sponsor.md
   - Sponsor: sponsor.md


### PR DESCRIPTION
Adds a roadmap page, and fixes the fact that the chat channel is effectively
hidden from anyone who has not used IRC before.

The roadmap is Now / Next / Not planned, in priority order rather than as a
schedule, matching how the sponsor page already frames it so the two cannot
drift apart. The "Not planned" section is the part worth arguing with: it says
no to Windows, to becoming an application framework, and to replacing a reverse
proxy. Tell me if any of those is wrong or too blunt.

On chat, the docs said "IRC, Libera Chat, #gunicorn", which is a set of words
that means nothing if you have never used IRC. The browser client link already
existed, buried at the end of the sentence. It now leads: open it, pick a
nickname, you are in. The IRC host is still there for people who want a real
client.

I had intended to also offer a Matrix address, since Libera used to run an
official bridge. It was taken down in 2023 and has since been sunset for good,
so there is nothing to link. Third-party bridges exist but Libera does not
maintain a directory of them and warns that message ordering is unreliable
across them, so pointing users at one seemed worse than not.
