### PR TITLE
test: catch every transport error in the docker health check

### DIFF
--- a/tests/docker/asgi_framework_compat/conftest.py
+++ b/tests/docker/asgi_framework_compat/conftest.py
@@ -83,7 +83,7 @@ def wait_for_service(url: str, timeout: int = 180) -> bool:
             response = httpx.get(f"{url}/health", timeout=5.0)
             if response.status_code == 200:
                 return True
-        except (httpx.ConnectError, httpx.TimeoutException):
+        except httpx.RequestError:
             pass
         time.sleep(1)
     return False
@@ -105,7 +105,7 @@ def docker_services(docker_compose_file, request):
             if response.status_code != 200:
                 all_healthy = False
                 break
-        except (httpx.ConnectError, httpx.TimeoutException):
+        except httpx.RequestError:
             all_healthy = False
             break
 


### PR DESCRIPTION
Follow-up to the docker harness work in #3693, which fixed the wrong half of
this.

Running the framework-compat suite cold gave 438 errors in 15 seconds. The
readiness timeout I raised there never came into play: the fixture caught only
`ConnectError` and `TimeoutException`, and a container sitting behind a
bound-but-not-ready Docker port proxy resets the connection, which httpx raises
as `ReadError`. That escaped the handler and took the fixture down before any
waiting happened.

`httpx.RequestError` is the base of every transport failure, so it covers the
reset as well as the cases already handled. The other two docker conftests catch
`OSError`, which already includes connection resets, which is why
`asgi_compliance` passed cold while this one did not.

Cold run with containers torn down first: 438 passed, 6 skipped.
