### PR TITLE
docs: disclose the $GUNICORN token and my creator rewards

### DIFF
--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -46,3 +46,21 @@ Start with the
 [contributing guide](https://github.com/benoitc/gunicorn/blob/master/CONTRIBUTING.md)
 for development workflow, code style, and review expectations. New contributors
 are welcome—open a draft pull request early to gather feedback.
+
+## Funding from outside the project
+
+A cryptocurrency token called $GUNICORN trades on
+[pump.fun](https://pump.fun/coin/4xMegMRMd2TFQEXxv39vtMP1r5fFVuA7VcaSmAhLpump).
+It is not operated by, affiliated with, or endorsed by the Gunicorn project, and
+holding it gives you no stake in Gunicorn, no say in its direction and no claim
+on anything. I receive a share of its creator rewards, and that money goes toward
+my work on Gunicorn.
+
+It is named here because it exists and because I benefit from it, not as a
+recommendation. Tokens of this kind are highly speculative and commonly lose all
+of their value. Do not buy it expecting a return, and do not buy it as a way to
+support this project: [sponsorship](sponsor.md) does that directly, and every
+euro of it reaches the work.
+
+Other tokens using the Gunicorn name exist and have no connection to the project
+or to me.

--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -49,17 +49,20 @@ are welcome—open a draft pull request early to gather feedback.
 
 ## Funding from outside the project
 
-A cryptocurrency token called $GUNICORN trades on pump.fun. It is not operated
-by, affiliated with, or endorsed by the Gunicorn project, and holding it gives
-you no ownership or governance rights in Gunicorn.
+A cryptocurrency token called $GUNICORN trades on
+[pump.fun](https://pump.fun/coin/4xMegMRMd2TFQEXxv39vtMP1r5fFVuA7VcaSmAhLpump).
+It was not created by Benoît Chesneau and is not operated by, affiliated with, or
+endorsed by the Gunicorn project. Holding it gives you no ownership or governance
+rights in Gunicorn, no say in its direction, and no claim on the project.
 
 I receive a share of its creator rewards, which helps fund my work maintaining
 and developing Gunicorn.
 
-I mention it here for transparency because it exists and because I benefit from
-it, not as a recommendation. Tokens of this kind are highly speculative and can
-lose most or all of their value. Do not buy it expecting a return, or as a way to
-directly support the Gunicorn project. [Sponsorship](sponsor.md) is the direct
-way to do that.
+It is mentioned here for transparency because it exists and because I benefit
+from it, not as a recommendation. Tokens of this kind are highly speculative and
+can lose most or all of their value. Do not buy it expecting a return, or as a way
+to directly support this project. [Sponsorship](sponsor.md) is the direct way to
+support Gunicorn.
 
-[Market page](https://pump.fun/coin/4xMegMRMd2TFQEXxv39vtMP1r5fFVuA7VcaSmAhLpump)
+Other tokens using the Gunicorn name may exist. They have no connection to the
+Gunicorn project or to me unless explicitly stated here.

--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -56,13 +56,13 @@ endorsed by the Gunicorn project. Holding it gives you no ownership or governanc
 rights in Gunicorn, no say in its direction, and no claim on the project.
 
 I receive a share of its creator rewards, which helps fund my work maintaining
-and developing Gunicorn.
+and developing Gunicorn, and I am grateful for it.
 
-It is mentioned here for transparency because it exists and because I benefit
-from it, not as a recommendation. Tokens of this kind are highly speculative and
-can lose most or all of their value. Do not buy it expecting a return, or as a way
-to directly support this project. [Sponsorship](sponsor.md) is the direct way to
-support Gunicorn.
+It is mentioned here for transparency, because it exists and because I benefit
+from it. It is not a recommendation. $GUNICORN is an independent and highly
+speculative token that can lose most or all of its value, so treat it as you
+would any speculative asset rather than as a way to fund this project.
+[Sponsorship](sponsor.md) is how you do that.
 
 Other tokens using the Gunicorn name may exist. They have no connection to the
 Gunicorn project or to me unless explicitly stated here.

--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -55,14 +55,17 @@ It was not created by Benoît Chesneau and is not operated by, affiliated with, 
 endorsed by the Gunicorn project. Holding it gives you no ownership or governance
 rights in Gunicorn, no say in its direction, and no claim on the project.
 
-I receive a share of its creator rewards, which helps fund my work maintaining
-and developing Gunicorn, and I am grateful for it.
+The token's creator allocated me a share of its creator rewards. These rewards
+help fund my work maintaining and developing Gunicorn, and I am grateful for the
+support.
 
 It is mentioned here for transparency, because it exists and because I benefit
 from it. It is not a recommendation. $GUNICORN is an independent and highly
 speculative token that can lose most or all of its value, so treat it as you
 would any speculative asset rather than as a way to fund this project.
-[Sponsorship](sponsor.md) is how you do that.
+
+If you want to support the development and maintenance of Gunicorn directly,
+you can do so through [sponsorship](sponsor.md).
 
 Other tokens using the Gunicorn name may exist. They have no connection to the
 Gunicorn project or to me unless explicitly stated here.

--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -49,18 +49,17 @@ are welcome—open a draft pull request early to gather feedback.
 
 ## Funding from outside the project
 
-A cryptocurrency token called $GUNICORN trades on
-[pump.fun](https://pump.fun/coin/4xMegMRMd2TFQEXxv39vtMP1r5fFVuA7VcaSmAhLpump).
-It is not operated by, affiliated with, or endorsed by the Gunicorn project, and
-holding it gives you no stake in Gunicorn, no say in its direction and no claim
-on anything. I receive a share of its creator rewards, and that money goes toward
-my work on Gunicorn.
+A cryptocurrency token called $GUNICORN trades on pump.fun. It is not operated
+by, affiliated with, or endorsed by the Gunicorn project, and holding it gives
+you no ownership or governance rights in Gunicorn.
 
-It is named here because it exists and because I benefit from it, not as a
-recommendation. Tokens of this kind are highly speculative and commonly lose all
-of their value. Do not buy it expecting a return, and do not buy it as a way to
-support this project: [sponsorship](sponsor.md) does that directly, and every
-euro of it reaches the work.
+I receive a share of its creator rewards, which helps fund my work maintaining
+and developing Gunicorn.
 
-Other tokens using the Gunicorn name exist and have no connection to the project
-or to me.
+I mention it here for transparency because it exists and because I benefit from
+it, not as a recommendation. Tokens of this kind are highly speculative and can
+lose most or all of their value. Do not buy it expecting a return, or as a way to
+directly support the Gunicorn project. [Sponsorship](sponsor.md) is the direct
+way to do that.
+
+[Market page](https://pump.fun/coin/4xMegMRMd2TFQEXxv39vtMP1r5fFVuA7VcaSmAhLpump)


### PR DESCRIPTION
A token trading under the project's name exists, and I receive a share of its
creator rewards. Rather than leave that for people to find out on their own, the
community page now says so.

It is written as a disclosure, not a recommendation. It names the thing as a
cryptocurrency token rather than as a "community", states plainly that the
project neither operates nor endorses it and that holding it confers no stake in
Gunicorn, warns that tokens of this kind commonly lose all their value, and sends
anyone who wants to fund the work to sponsorship instead.

It also notes that other tokens using the Gunicorn name exist with no connection
to the project, which is the part that protects users from the impostor.
