### PR TITLE
docs: fix the sponsor logo path on the sponsor page

### DIFF
--- a/docs/content/sponsor.md
+++ b/docs/content/sponsor.md
@@ -62,5 +62,5 @@ If gunicorn is part of your infrastructure:
 ## Sponsors
 
 <a href="https://enki-multimedia.eu" target="_blank" rel="noopener">
-  <img src="assets/enki-multimedia.svg" alt="Enki Multimedia" style="height: 50px;" />
+  <img src="../assets/enki-multimedia.svg" alt="Enki Multimedia" style="height: 50px;" />
 </a>


### PR DESCRIPTION
The Enki Multimedia logo on the sponsor page was broken.

`use_directory_urls` serves the page at `/sponsor/`, so `src="assets/..."`
resolved to `/sponsor/assets/enki-multimedia.svg` and 404'd. The file is at
`/assets/enki-multimedia.svg`. mkdocs rewrites paths in markdown links but not
inside raw HTML blocks, so the tag needs the `../` itself.

`index.md` uses the same relative form for the logo and the same image, but it is
served at `/`, so it already resolves and is left alone.

Verified against the built site: the image now returns 200 from `/sponsor/`.
