### PR TITLE
http2: apply the same header policy as HTTP/1

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -177,43 +177,31 @@ def _ip_in_allow_list(ip_str, allow_list, networks):
     return False
 
 
-class Message:
-    def __init__(self, cfg, unreader, peer_addr):
-        self.cfg = cfg
-        self.unreader = unreader
-        self.peer_addr = peer_addr
-        self.remote_addr = peer_addr
-        self.version = None
-        self.headers = []
-        self.trailers = []
-        self.body = None
-        self.scheme = "https" if cfg.is_ssl else "http"
-        self.must_close = False
-        self._expected_100_continue = False
+class HeaderPolicy:
+    """Header policy shared by every request path.
 
-        # set headers limits
-        self.limit_request_fields = cfg.limit_request_fields
-        if (self.limit_request_fields <= 0
-                or self.limit_request_fields > MAX_HEADERS):
-            self.limit_request_fields = MAX_HEADERS
-        self.limit_request_field_size = cfg.limit_request_field_size
-        if self.limit_request_field_size <= 0:
-            self.limit_request_field_size = DEFAULT_MAX_HEADERFIELD_SIZE
+    Applies to HTTP/1 (both parsers) and HTTP/2 alike, so a rule added here
+    cannot be enforced on one protocol and quietly skipped on another.
+    Requires ``self.cfg``, ``self.peer_addr``, ``self.scheme`` and
+    ``self.version`` to be set before any header is applied.
+    """
 
-        # set max header buffer size
-        max_header_field_size = self.limit_request_field_size or DEFAULT_MAX_HEADERFIELD_SIZE
-        self.max_buffer_headers = self.limit_request_fields * \
-            (max_header_field_size + 2) + 4
+    #: Set by whichever class mixes this in, before headers are applied.
+    scheme = None
+    version = None
+    _expected_100_continue = False
 
-        unused = self.parse(self.unreader)
-        self.unreader.unread(unused)
-        self.set_body_reader()
+    #: HTTP/2 has no 100-continue handshake on the wire the way HTTP/1 does,
+    #: and gunicorn answers one by writing HTTP/1 bytes straight to the socket
+    #: (see wsgi.create), which would corrupt an HTTP/2 connection.
+    _policy_expect_continue = True
 
-    def force_close(self):
-        self.must_close = True
-
-    def parse(self, unreader):
-        raise NotImplementedError()
+    def _peer_is_trusted_proxy(self):
+        """Whether the peer may set forwarding and scheme headers."""
+        cfg = self.cfg
+        return (not isinstance(self.peer_addr, tuple)
+                or _ip_in_allow_list(self.peer_addr[0], cfg.forwarded_allow_ips,
+                                     cfg.forwarded_allow_networks()))
 
     def _peer_trusted_for_forwarded(self):
         """Return the (secure_scheme_headers, forwarder_headers) the peer is allowed to set.
@@ -223,9 +211,7 @@ class Message:
         spoofing.  Returns ``({}, [])`` when the peer is untrusted.
         """
         cfg = self.cfg
-        if (not isinstance(self.peer_addr, tuple)
-                or _ip_in_allow_list(self.peer_addr[0], cfg.forwarded_allow_ips,
-                                     cfg.forwarded_allow_networks())):
+        if self._peer_is_trusted_proxy():
             return cfg.secure_scheme_headers, cfg.forwarder_headers
         return {}, []
 
@@ -253,7 +239,8 @@ class Message:
                 raise InvalidHeader(name, req=self)
             seen.add(name)
 
-        if not from_trailer and name == "EXPECT":
+        if (self._policy_expect_continue and not from_trailer
+                and name == "EXPECT"):
             # https://datatracker.ietf.org/doc/html/rfc9110#section-10.1.1
             # "The Expect field value is case-insensitive."
             if value.lower() == "100-continue":
@@ -299,6 +286,45 @@ class Message:
                 raise InvalidHeaderName(name)
 
         return (name, value)
+
+
+class Message(HeaderPolicy):
+    def __init__(self, cfg, unreader, peer_addr):
+        self.cfg = cfg
+        self.unreader = unreader
+        self.peer_addr = peer_addr
+        self.remote_addr = peer_addr
+        self.version = None
+        self.headers = []
+        self.trailers = []
+        self.body = None
+        self.scheme = "https" if cfg.is_ssl else "http"
+        self.must_close = False
+        self._expected_100_continue = False
+
+        # set headers limits
+        self.limit_request_fields = cfg.limit_request_fields
+        if (self.limit_request_fields <= 0
+                or self.limit_request_fields > MAX_HEADERS):
+            self.limit_request_fields = MAX_HEADERS
+        self.limit_request_field_size = cfg.limit_request_field_size
+        if self.limit_request_field_size <= 0:
+            self.limit_request_field_size = DEFAULT_MAX_HEADERFIELD_SIZE
+
+        # set max header buffer size
+        max_header_field_size = self.limit_request_field_size or DEFAULT_MAX_HEADERFIELD_SIZE
+        self.max_buffer_headers = self.limit_request_fields * \
+            (max_header_field_size + 2) + 4
+
+        unused = self.parse(self.unreader)
+        self.unreader.unread(unused)
+        self.set_body_reader()
+
+    def force_close(self):
+        self.must_close = True
+
+    def parse(self, unreader):
+        raise NotImplementedError()
 
     def parse_headers(self, data, from_trailer=False):
         headers = []

--- a/gunicorn/http2/request.py
+++ b/gunicorn/http2/request.py
@@ -11,6 +11,11 @@ Provides a Request-compatible interface for HTTP/2 streams.
 
 from io import BytesIO
 
+from gunicorn.http.message import (
+    HeaderPolicy,
+    RFC9110_5_5_INVALID_AND_DANGEROUS,
+)
+from gunicorn.http.errors import InvalidHeader
 from gunicorn.util import split_request_uri
 
 
@@ -80,13 +85,17 @@ class HTTP2Body:
         self._data.close()
 
 
-class HTTP2Request:
+class HTTP2Request(HeaderPolicy):
     """HTTP/2 request wrapper compatible with gunicorn Request interface.
 
     Wraps an HTTP2Stream to provide the same interface as the HTTP/1.x
     Request class, allowing workers to handle HTTP/2 requests using
     existing code paths.
     """
+
+    #: HTTP/2 carries no 100-continue handshake gunicorn can answer: the
+    #: response would be written as HTTP/1 bytes onto an HTTP/2 connection.
+    _policy_expect_continue = False
 
     def __init__(self, stream, cfg, peer_addr):
         """Initialize from an HTTP/2 stream.
@@ -107,7 +116,14 @@ class HTTP2Request:
         # Parse pseudo-headers
         pseudo = stream.get_pseudo_headers()
         self.method = pseudo.get(':method', 'GET')
-        self.scheme = pseudo.get(':scheme', 'https')
+        # Derive the scheme from the transport, as HTTP/1 does. A client
+        # supplied :scheme is honoured only from a peer allowed to speak for
+        # the connection; otherwise it is ignored rather than rejected, which
+        # mirrors how an untrusted X-Forwarded-Proto is treated on HTTP/1.
+        self.scheme = "https" if cfg.is_ssl else "http"
+        claimed_scheme = pseudo.get(':scheme')
+        if claimed_scheme and self._peer_is_trusted_proxy():
+            self.scheme = claimed_scheme
         authority = pseudo.get(':authority', '')
         path = pseudo.get(':path', '/')
 
@@ -126,15 +142,30 @@ class HTTP2Request:
         # Store authority for Host header equivalent
         self._authority = authority
 
-        # Convert HTTP/2 headers to HTTP/1.1 style
-        # HTTP/2 headers are lowercase, convert to uppercase for WSGI
+        # Convert HTTP/2 headers to HTTP/1.1 style and put them through the
+        # same policy as HTTP/1, so a rule cannot hold on one protocol and be
+        # skipped on the other.
         self.headers = []
+        scheme_state = [False]
+        seen = set()
+        secure_scheme_headers, forwarder_headers = \
+            self._peer_trusted_for_forwarded()
         for name, value in stream.get_regular_headers():
             # Convert to uppercase for WSGI compatibility
-            self.headers.append((name.upper(), value))
+            name = name.upper()
+            if RFC9110_5_5_INVALID_AND_DANGEROUS.search(value):
+                raise InvalidHeader(name, req=self)
+            kept = self._apply_header_policy(
+                name, value, scheme_state, seen,
+                secure_scheme_headers, forwarder_headers,
+            )
+            if kept is None:
+                continue
+            self.headers.append(kept)
 
         # Set Host header from :authority (RFC 9113 section 8.3.1)
-        # :authority MUST take precedence over Host header
+        # :authority MUST take precedence over Host header. Runs after the
+        # policy so a duplicate Host is still rejected rather than replaced.
         if authority:
             self.headers = [(n, v) for n, v in self.headers if n != 'HOST']
             self.headers.append(('HOST', authority))
@@ -153,6 +184,8 @@ class HTTP2Request:
 
         # Connection state
         self.must_close = False
+        # Never set on HTTP/2: gunicorn answers it with HTTP/1 bytes written
+        # straight to the socket, which would corrupt the connection.
         self._expected_100_continue = False
 
         # Request numbering (for logging)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ tornado = ["tornado>=6.5.7"]
 gthread = []
 setproctitle = ["setproctitle"]
 http2 = ["h2>=4.4.1"]
-fast = ["gunicorn_h1c>=0.6.6"]
+fast = ["gunicorn_h1c>=0.6.8"]
 testing = [
     "gevent>=24.10.1",
     "h2>=4.4.1",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,7 @@ packaging
 pytest>=9.0.3
 pytest-cov
 pytest-asyncio
-gunicorn_h1c>=0.6.6
+gunicorn_h1c>=0.6.8
 h2>=4.4.1
 uvloop>=0.19.0
 inotify>=0.2.10; sys_platform == 'linux'

--- a/tests/test_http2_async_connection.py
+++ b/tests/test_http2_async_connection.py
@@ -7,6 +7,8 @@
 
 import asyncio
 import pytest
+
+from gunicorn.config import Config
 from unittest import mock
 from io import BytesIO
 
@@ -27,14 +29,19 @@ from gunicorn.http2.errors import (
 pytestmark = pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")
 
 
-class MockConfig:
-    """Mock gunicorn configuration for HTTP/2."""
+def MockConfig():
+    """Real gunicorn configuration with the HTTP/2 defaults these tests want.
 
-    def __init__(self):
-        self.http2_max_concurrent_streams = 100
-        self.http2_initial_window_size = 65535
-        self.http2_max_frame_size = 16384
-        self.http2_max_header_list_size = 65536
+    HTTP2Request applies the same header policy as HTTP/1, which reads
+    forwarded_allow_ips, header_map and friends, so a stub with only the
+    http2_* attributes would not exercise the real defaults.
+    """
+    cfg = Config()
+    cfg.set("http2_max_concurrent_streams", 100)
+    cfg.set("http2_initial_window_size", 65535)
+    cfg.set("http2_max_frame_size", 16384)
+    cfg.set("http2_max_header_list_size", 65536)
+    return cfg
 
 
 class MockAsyncReader:
@@ -118,7 +125,7 @@ class TestAsyncHTTP2ConnectionInit:
         from gunicorn.http2.async_connection import AsyncHTTP2Connection
 
         cfg = MockConfig()
-        cfg.http2_max_concurrent_streams = 50
+        cfg.set("http2_max_concurrent_streams", 50)
 
         reader = MockAsyncReader()
         writer = MockAsyncWriter()

--- a/tests/test_http2_connection.py
+++ b/tests/test_http2_connection.py
@@ -6,6 +6,8 @@
 """Tests for HTTP/2 server connection."""
 
 import pytest
+
+from gunicorn.config import Config
 from unittest import mock
 from io import BytesIO
 
@@ -27,14 +29,19 @@ from gunicorn.http2.errors import (
 pytestmark = pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")
 
 
-class MockConfig:
-    """Mock gunicorn configuration for HTTP/2."""
+def MockConfig():
+    """Real gunicorn configuration with the HTTP/2 defaults these tests want.
 
-    def __init__(self):
-        self.http2_max_concurrent_streams = 100
-        self.http2_initial_window_size = 65535
-        self.http2_max_frame_size = 16384
-        self.http2_max_header_list_size = 65536
+    HTTP2Request applies the same header policy as HTTP/1, which reads
+    forwarded_allow_ips, header_map and friends, so a stub with only the
+    http2_* attributes would not exercise the real defaults.
+    """
+    cfg = Config()
+    cfg.set("http2_max_concurrent_streams", 100)
+    cfg.set("http2_initial_window_size", 65535)
+    cfg.set("http2_max_frame_size", 16384)
+    cfg.set("http2_max_header_list_size", 65536)
+    return cfg
 
 
 class MockSocket:
@@ -92,8 +99,8 @@ class TestHTTP2ServerConnectionInit:
         from gunicorn.http2.connection import HTTP2ServerConnection
 
         cfg = MockConfig()
-        cfg.http2_max_concurrent_streams = 50
-        cfg.http2_initial_window_size = 32768
+        cfg.set("http2_max_concurrent_streams", 50)
+        cfg.set("http2_initial_window_size", 32768)
 
         sock = MockSocket()
         conn = HTTP2ServerConnection(cfg, sock, ('127.0.0.1', 12345))

--- a/tests/test_http2_integration.py
+++ b/tests/test_http2_integration.py
@@ -6,6 +6,8 @@
 """Integration tests for HTTP/2 with full request/response cycles."""
 
 import pytest
+
+from gunicorn.config import Config
 from io import BytesIO
 
 # Check if h2 is available
@@ -33,14 +35,19 @@ def get_header_value(headers_list, name):
     return None
 
 
-class MockConfig:
-    """Mock gunicorn configuration for HTTP/2."""
+def MockConfig():
+    """Real gunicorn configuration with the HTTP/2 defaults these tests want.
 
-    def __init__(self):
-        self.http2_max_concurrent_streams = 100
-        self.http2_initial_window_size = 65535
-        self.http2_max_frame_size = 16384
-        self.http2_max_header_list_size = 65536
+    HTTP2Request applies the same header policy as HTTP/1, which reads
+    forwarded_allow_ips, header_map and friends, so a stub with only the
+    http2_* attributes would not exercise the real defaults.
+    """
+    cfg = Config()
+    cfg.set("http2_max_concurrent_streams", 100)
+    cfg.set("http2_initial_window_size", 65535)
+    cfg.set("http2_max_frame_size", 16384)
+    cfg.set("http2_max_header_list_size", 65536)
+    return cfg
 
 
 class MockSocket:

--- a/tests/test_http2_request.py
+++ b/tests/test_http2_request.py
@@ -7,6 +7,8 @@
 
 import pytest
 
+from gunicorn.config import Config
+from gunicorn.http.errors import InvalidHeader
 from gunicorn.http2.request import HTTP2Request, HTTP2Body
 from gunicorn.http2.stream import HTTP2Stream
 
@@ -18,11 +20,14 @@ class MockConnection:
         self.initial_window_size = initial_window_size
 
 
-class MockConfig:
-    """Mock gunicorn configuration."""
+def MockConfig():
+    """Real gunicorn configuration.
 
-    def __init__(self):
-        pass
+    HTTP2Request applies the same header policy as HTTP/1, which reads
+    forwarded_allow_ips, header_map and friends, so a stub with no
+    attributes would not exercise the real defaults.
+    """
+    return Config()
 
 
 class TestHTTP2Body:
@@ -556,6 +561,23 @@ class TestHTTP2RequestDefaults:
         cfg = MockConfig()
         req = HTTP2Request(stream, cfg, ('127.0.0.1', 12345))
 
+        # Derived from the transport, not assumed to be https.
+        assert req.scheme == 'http'
+
+    def test_default_scheme_over_tls(self):
+        conn = MockConnection()
+        stream = HTTP2Stream(stream_id=1, connection=conn)
+        stream.receive_headers([
+            (':method', 'GET'),
+            (':path', '/'),
+            (':authority', 'example.com'),
+        ], end_stream=True)
+
+        cfg = MockConfig()
+        cfg.set('certfile', __file__)
+        cfg.set('keyfile', __file__)
+        req = HTTP2Request(stream, cfg, ('127.0.0.1', 12345))
+
         assert req.scheme == 'https'
 
     def test_default_path(self):
@@ -719,3 +741,67 @@ class TestHTTP2RequestWSGIEnviron:
         # HTTP/1 requests should not have priority keys
         assert 'gunicorn.http2.priority_weight' not in environ
         assert 'gunicorn.http2.priority_depends_on' not in environ
+
+
+class TestHTTP2HeaderPolicy:
+    """HTTP/2 requests go through the same header policy as HTTP/1."""
+
+    UNTRUSTED = ('203.0.113.9', 4444)
+    TRUSTED = ('127.0.0.1', 5555)
+
+    def _request(self, headers, peer, cfg=None):
+        conn = MockConnection()
+        stream = HTTP2Stream(stream_id=1, connection=conn)
+        stream.receive_headers(headers, end_stream=True)
+        return HTTP2Request(stream, cfg or MockConfig(), peer)
+
+    def _base(self, **extra):
+        headers = [
+            (':method', 'GET'), (':path', '/admin/x'),
+            (':scheme', 'https'), (':authority', 'example.com'),
+        ]
+        headers.extend(extra.items())
+        return headers
+
+    def test_underscore_header_dropped_for_untrusted_peer(self):
+        req = self._request(self._base(script_name='/admin'), self.UNTRUSTED)
+        assert not any(n == 'SCRIPT_NAME' for n, _ in req.headers)
+
+    def test_underscore_header_kept_for_trusted_forwarder(self):
+        cfg = MockConfig()
+        cfg.set('forwarded_allow_ips', '127.0.0.1')
+        cfg.set('forwarder_headers', 'SCRIPT_NAME')
+        req = self._request(self._base(script_name='/admin'), self.TRUSTED, cfg)
+        assert ('SCRIPT_NAME', '/admin') in req.headers
+
+    def test_duplicate_content_type_rejected(self):
+        headers = [
+            (':method', 'GET'), (':path', '/'), (':scheme', 'http'),
+            (':authority', 'a'),
+            ('content-type', 'application/json'),
+            ('content-type', 'text/html'),
+        ]
+        with pytest.raises(InvalidHeader):
+            self._request(headers, self.UNTRUSTED)
+
+    def test_control_character_in_value_rejected(self):
+        with pytest.raises(InvalidHeader):
+            self._request(self._base(**{'x-thing': 'a\x00b'}), self.UNTRUSTED)
+
+    def test_untrusted_scheme_claim_ignored(self):
+        req = self._request(self._base(), self.UNTRUSTED)
+        assert req.scheme == 'http'
+
+    def test_trusted_scheme_claim_honoured(self):
+        cfg = MockConfig()
+        cfg.set('forwarded_allow_ips', '127.0.0.1')
+        req = self._request(self._base(), self.TRUSTED, cfg)
+        assert req.scheme == 'https'
+
+    def test_expect_continue_never_set_on_http2(self):
+        req = self._request(self._base(expect='100-continue'), self.UNTRUSTED)
+        assert req._expected_100_continue is False
+
+    def test_authority_precedence_after_policy(self):
+        req = self._request(self._base(host='attacker.example'), self.UNTRUSTED)
+        assert [v for n, v in req.headers if n == 'HOST'] == ['example.com']


### PR DESCRIPTION
HTTP/2 requests never went through the header policy that HTTP/1 requests go
through. `HTTP2Request` built its headers straight from the stream, so over
HTTP/2 nothing applied: the underscore and `header_map` policy, the duplicate
singleton fields, the control characters in values, the `forwarded_allow_ips`
trust gate.

The effect is that an untrusted client over HTTP/2 could set `SCRIPT_NAME` and
forge `HTTP_*` entries in the WSGI environ, and decide `wsgi.url_scheme` itself
through `:scheme`. The same request over HTTP/1 has all of it dropped. This
concerns the ALPN HTTP/2 that ships today, it is not something the h2c work
introduces.

Rather than repeat the checks, the policy moves onto a mixin that both `Message`
and `HTTP2Request` inherit, so a rule cannot apply on one protocol and be
forgotten on the other. This is the first part of the h2c plan; the rest follows.

Also raises the `gunicorn_h1c` floor to 0.6.8, which adds `remaining()`. That
unblocks `Upgrade: h2c` on the ASGI worker later.

## Breaking changes

Three, all of them making HTTP/2 behave as HTTP/1 already does:

- `:scheme` from an untrusted peer is now ignored, and the scheme comes from the
  transport. Before, a plain HTTP/2 request without TLS could announce itself as
  `https`. Behind a proxy in `forwarded_allow_ips` nothing changes.
- Underscore headers over HTTP/2 now follow `header_map`, so they are dropped by
  default. Anyone relying on them must list them in `forwarder_headers`, as on
  HTTP/1.
- A request with no `:scheme` at all defaults to the transport scheme instead of
  always `https`.

Duplicate `Host` or `Content-Type` and control characters in a value are now
refused with 400 over HTTP/2 too.
