### PR TITLE
http2: shared h2c negotiation layer

### DIFF
--- a/docs/content/guides/http2.md
+++ b/docs/content/guides/http2.md
@@ -29,7 +29,8 @@ gunicorn myapp:app \
 HTTP/2 support requires:
 
 - **SSL/TLS**: HTTP/2 uses ALPN (Application-Layer Protocol Negotiation) which
-  requires an encrypted connection
+  requires an encrypted connection (see [Cleartext HTTP/2](#cleartext-http2-h2c)
+  for the proxy-only exception)
 - **h2 library**: Install with `pip install gunicorn[http2]` or `pip install h2`
 - **Compatible worker**: gthread, gevent, or ASGI workers
 
@@ -79,6 +80,29 @@ certfile = "/path/to/server.crt"
 keyfile = "/path/to/server.key"
 http_protocols = "h2, h1"
 ```
+
+### Cleartext HTTP/2 (h2c)
+
+When TLS is terminated in front of Gunicorn — Cloud Run, fly.io, a
+service-mesh sidecar — the proxy can speak HTTP/2 to the upstream over
+plain TCP. Enable it with the `--h2c` flag (gthread worker):
+
+```bash
+gunicorn myapp:app -k gthread --http-protocols h2,h1 --h2c
+```
+
+Connections that start with the HTTP/2 connection preface are served as
+HTTP/2; everything else falls back to HTTP/1.1 on the same port. Only the
+RFC 9113 prior-knowledge form is supported — the deprecated
+`Upgrade: h2c` handshake is not. Test with:
+
+```bash
+curl --http2-prior-knowledge http://localhost:8000/
+```
+
+!!! warning
+    h2c is cleartext. Only enable it behind a trusted, TLS-terminating
+    proxy. Never expose an h2c port directly to the internet.
 
 ### HTTP/2 Settings
 

--- a/docs/content/guides/http2.md
+++ b/docs/content/guides/http2.md
@@ -83,17 +83,25 @@ http_protocols = "h2, h1"
 
 ### Cleartext HTTP/2 (h2c)
 
-When TLS is terminated in front of Gunicorn — Cloud Run, fly.io, a
-service-mesh sidecar — the proxy can speak HTTP/2 to the upstream over
-plain TCP. Enable it with the `--h2c` flag (gthread worker):
+When TLS is terminated in front of Gunicorn - Cloud Run, fly.io, a
+service-mesh sidecar - the proxy can speak HTTP/2 to the upstream over
+plain TCP. Enable it with the `--http2-prior-knowledge` flag (gthread
+worker):
 
 ```bash
-gunicorn myapp:app -k gthread --http-protocols h2,h1 --h2c
+gunicorn myapp:app -k gthread --http-protocols h2,h1 --http2-prior-knowledge
 ```
 
-Connections that start with the HTTP/2 connection preface are served as
-HTTP/2; everything else falls back to HTTP/1.1 on the same port. Only the
-RFC 9113 prior-knowledge form is supported — the deprecated
+h2c is only accepted from peers in `forwarded_allow_ips` - the same
+trust list used for forwarded headers, which in this deployment shape is
+exactly the TLS-terminating proxy. A trusted peer that opens a
+connection with the HTTP/2 connection preface is served HTTP/2; anything
+else from a trusted peer (an HTTP/1.x request, a malformed or stalled
+preface) is rejected with a 400 rather than silently downgraded, so a
+misconfigured proxy fails loudly instead of quietly losing HTTP/2.
+Untrusted peers are served HTTP/1.1 exactly as if the flag were off.
+
+Only the RFC 9113 prior-knowledge form is supported - the deprecated
 `Upgrade: h2c` handshake is not. Test with:
 
 ```bash

--- a/docs/content/guides/http2.md
+++ b/docs/content/guides/http2.md
@@ -85,12 +85,16 @@ http_protocols = "h2, h1"
 
 When TLS is terminated in front of Gunicorn - Cloud Run, fly.io, a
 service-mesh sidecar - the proxy can speak HTTP/2 to the upstream over
-plain TCP. Enable it with the `--http2-prior-knowledge` flag (gthread
-worker):
+plain TCP. Enable it with `--http2-cleartext` (gthread worker):
 
 ```bash
-gunicorn myapp:app -k gthread --http-protocols h2,h1 --http2-prior-knowledge
+gunicorn myapp:app -k gthread --http-protocols h2,h1 \
+    --http2-cleartext prior-knowledge
 ```
+
+The value selects which mechanism is accepted: `prior-knowledge`,
+`upgrade`, `both`, or `off` (the default). Each mechanism is enabled
+separately, so turning one on does not turn the other on.
 
 h2c is only accepted from peers in `forwarded_allow_ips` - the same
 trust list used for forwarded headers, which in this deployment shape is
@@ -101,8 +105,11 @@ preface) is rejected with a 400 rather than silently downgraded, so a
 misconfigured proxy fails loudly instead of quietly losing HTTP/2.
 Untrusted peers are served HTTP/1.1 exactly as if the flag were off.
 
-Only the RFC 9113 prior-knowledge form is supported - the deprecated
-`Upgrade: h2c` handshake is not. Test with:
+Streams on an HTTP/2 connection are handled one after another, not
+concurrently, so a slow handler holds up the other streams on that
+connection.
+
+Test prior knowledge with:
 
 ```bash
 curl --http2-prior-knowledge http://localhost:8000/

--- a/docs/content/reference/settings.md
+++ b/docs/content/reference/settings.md
@@ -414,10 +414,47 @@ HTTP/2 requires:
 * ALPN-capable TLS client
 
 !!! note
-    HTTP/2 cleartext (h2c) is not supported due to security concerns
-    and lack of browser support.
+    HTTP/2 cleartext (h2c) is disabled by default. Deployments behind
+    a TLS-terminating proxy can enable prior-knowledge h2c with
+    http2-prior-knowledge.
 
 !!! info "Added in 25.0.0"
+
+### `http2_cleartext`
+
+**Command line:** `--http2-cleartext STRING`
+
+**Default:** `'off'`
+
+Accept HTTP/2 over cleartext TCP (h2c), and by which mechanism.
+
+Valid values are:
+
+* ``off`` (default) - no cleartext HTTP/2
+* ``prior-knowledge`` - serve connections that open with the HTTP/2
+  connection preface (``PRI * HTTP/2.0``), RFC 9113 section 3.4
+* ``upgrade`` - honour an HTTP/1.1 ``Upgrade: h2c`` request
+* ``both`` - accept either
+
+The mechanisms are listed separately on purpose: enabling one does not
+enable the other.
+
+Only peers in [forwarded-allow-ips](#forwarded_allow_ips) are considered. Everyone else
+is served HTTP/1.x exactly as if this were ``off``. Anything else from
+a trusted peer on a prior-knowledge port (an HTTP/1.x request, a
+malformed or stalled preface) is rejected with a 400: such a peer is
+expected to speak HTTP/2, and a silent downgrade would only hide a
+misconfiguration.
+
+This is meant for deployments where TLS is terminated by a trusted
+proxy that speaks HTTP/2 upstream (Cloud Run, fly.io, a service-mesh
+sidecar). Do not expose a cleartext HTTP/2 port to the internet.
+
+Requires ``h2`` in http-protocols and the h2 library
+(``pip install gunicorn[http2]``). Ignored when TLS is configured;
+there HTTP/2 is negotiated by ALPN.
+
+!!! info "Added in 26.2.0"
 
 ### `http2_max_concurrent_streams`
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -2498,25 +2498,31 @@ class HTTPProtocols(Setting):
         .. note::
            HTTP/2 cleartext (h2c) is disabled by default. Deployments behind
            a TLS-terminating proxy can enable prior-knowledge h2c with
-           :ref:`h2c`.
+           :ref:`http2-prior-knowledge`.
 
         .. versionadded:: 25.0.0
         """
 
 
-class HTTP2Cleartext(Setting):
-    name = "h2c"
+class HTTP2PriorKnowledge(Setting):
+    name = "http2_prior_knowledge"
     section = "HTTP/2"
-    cli = ["--h2c"]
+    cli = ["--http2-prior-knowledge"]
     validator = validate_bool
     action = "store_true"
     default = False
     desc = """\
         Accept HTTP/2 over cleartext TCP (h2c) with prior knowledge.
 
-        When enabled and no TLS is configured, connections that start with
-        the HTTP/2 connection preface (``PRI * HTTP/2.0``) are served as
-        HTTP/2. All other connections fall back to HTTP/1.1 as usual.
+        When enabled and no TLS is configured, connections from peers in
+        :ref:`forwarded-allow-ips` that start with the HTTP/2 connection
+        preface (``PRI * HTTP/2.0``) are served as HTTP/2. Anything else
+        from a trusted peer (an HTTP/1.x request, a malformed or stalled
+        preface) is rejected with a 400 response: a peer on a
+        prior-knowledge port is expected to speak HTTP/2, and a silent
+        downgrade would only hide misconfiguration. Peers outside
+        ``forwarded_allow_ips`` are served HTTP/1.1 exactly as if this
+        setting were off.
 
         Only the RFC 9113 prior-knowledge form is supported. The HTTP/1.1
         ``Upgrade: h2c`` mechanism was deprecated by RFC 9113 and is not

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -2496,10 +2496,42 @@ class HTTPProtocols(Setting):
         * ALPN-capable TLS client
 
         .. note::
-           HTTP/2 cleartext (h2c) is not supported due to security concerns
-           and lack of browser support.
+           HTTP/2 cleartext (h2c) is disabled by default. Deployments behind
+           a TLS-terminating proxy can enable prior-knowledge h2c with
+           :ref:`h2c`.
 
         .. versionadded:: 25.0.0
+        """
+
+
+class HTTP2Cleartext(Setting):
+    name = "h2c"
+    section = "HTTP/2"
+    cli = ["--h2c"]
+    validator = validate_bool
+    action = "store_true"
+    default = False
+    desc = """\
+        Accept HTTP/2 over cleartext TCP (h2c) with prior knowledge.
+
+        When enabled and no TLS is configured, connections that start with
+        the HTTP/2 connection preface (``PRI * HTTP/2.0``) are served as
+        HTTP/2. All other connections fall back to HTTP/1.1 as usual.
+
+        Only the RFC 9113 prior-knowledge form is supported. The HTTP/1.1
+        ``Upgrade: h2c`` mechanism was deprecated by RFC 9113 and is not
+        implemented.
+
+        This is intended for deployments where TLS is terminated by a
+        trusted proxy that speaks HTTP/2 to the upstream (e.g. Cloud Run,
+        fly.io, or a service-mesh sidecar). Do not expose a cleartext
+        HTTP/2 port directly to the internet.
+
+        Requires ``h2`` in :ref:`http-protocols` and the h2 library
+        (``pip install gunicorn[http2]``). Ignored when TLS is configured;
+        with TLS, HTTP/2 is negotiated via ALPN instead.
+
+        .. versionadded:: 26.0.0
         """
 
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -358,6 +358,20 @@ class Setting:
 Setting = SettingMeta('Setting', (Setting,), {})
 
 
+def validate_http2_cleartext(val):
+    if val is None:
+        return "off"
+    if isinstance(val, bool):
+        # keeps `http2_cleartext = True` in a config file meaning something
+        return "prior-knowledge" if val else "off"
+    if not isinstance(val, str):
+        raise TypeError("Invalid type for casting: %s" % val)
+    val = val.lower().strip()
+    if val in ("off", "prior-knowledge", "upgrade", "both"):
+        return val
+    raise ValueError("Invalid http2_cleartext: %s" % val)
+
+
 def validate_bool(val):
     if val is None:
         return
@@ -2504,40 +2518,43 @@ class HTTPProtocols(Setting):
         """
 
 
-class HTTP2PriorKnowledge(Setting):
-    name = "http2_prior_knowledge"
+class HTTP2Cleartext(Setting):
+    name = "http2_cleartext"
     section = "HTTP/2"
-    cli = ["--http2-prior-knowledge"]
-    validator = validate_bool
-    action = "store_true"
-    default = False
+    cli = ["--http2-cleartext"]
+    meta = "STRING"
+    validator = validate_http2_cleartext
+    default = "off"
     desc = """\
-        Accept HTTP/2 over cleartext TCP (h2c) with prior knowledge.
+        Accept HTTP/2 over cleartext TCP (h2c), and by which mechanism.
 
-        When enabled and no TLS is configured, connections from peers in
-        :ref:`forwarded-allow-ips` that start with the HTTP/2 connection
-        preface (``PRI * HTTP/2.0``) are served as HTTP/2. Anything else
-        from a trusted peer (an HTTP/1.x request, a malformed or stalled
-        preface) is rejected with a 400 response: a peer on a
-        prior-knowledge port is expected to speak HTTP/2, and a silent
-        downgrade would only hide misconfiguration. Peers outside
-        ``forwarded_allow_ips`` are served HTTP/1.1 exactly as if this
-        setting were off.
+        Valid values are:
 
-        Only the RFC 9113 prior-knowledge form is supported. The HTTP/1.1
-        ``Upgrade: h2c`` mechanism was deprecated by RFC 9113 and is not
-        implemented.
+        * ``off`` (default) - no cleartext HTTP/2
+        * ``prior-knowledge`` - serve connections that open with the HTTP/2
+          connection preface (``PRI * HTTP/2.0``), RFC 9113 section 3.4
+        * ``upgrade`` - honour an HTTP/1.1 ``Upgrade: h2c`` request
+        * ``both`` - accept either
 
-        This is intended for deployments where TLS is terminated by a
-        trusted proxy that speaks HTTP/2 to the upstream (e.g. Cloud Run,
-        fly.io, or a service-mesh sidecar). Do not expose a cleartext
-        HTTP/2 port directly to the internet.
+        The mechanisms are listed separately on purpose: enabling one does not
+        enable the other.
+
+        Only peers in :ref:`forwarded-allow-ips` are considered. Everyone else
+        is served HTTP/1.x exactly as if this were ``off``. Anything else from
+        a trusted peer on a prior-knowledge port (an HTTP/1.x request, a
+        malformed or stalled preface) is rejected with a 400: such a peer is
+        expected to speak HTTP/2, and a silent downgrade would only hide a
+        misconfiguration.
+
+        This is meant for deployments where TLS is terminated by a trusted
+        proxy that speaks HTTP/2 upstream (Cloud Run, fly.io, a service-mesh
+        sidecar). Do not expose a cleartext HTTP/2 port to the internet.
 
         Requires ``h2`` in :ref:`http-protocols` and the h2 library
         (``pip install gunicorn[http2]``). Ignored when TLS is configured;
-        with TLS, HTTP/2 is negotiated via ALPN instead.
+        there HTTP/2 is negotiated by ALPN.
 
-        .. versionadded:: 26.0.0
+        .. versionadded:: 26.2.0
         """
 
 

--- a/gunicorn/http/errors.py
+++ b/gunicorn/http/errors.py
@@ -172,3 +172,11 @@ class ForbiddenProxyRequest(ParseException):
 class InvalidSchemeHeaders(ParseException):
     def __str__(self):
         return "Contradictory scheme headers"
+
+
+class InvalidH2CPreface(ParseException):
+    def __init__(self, data):
+        self.data = data
+
+    def __str__(self):
+        return "Expected HTTP/2 connection preface, got %r" % (self.data,)

--- a/gunicorn/http2/negotiation.py
+++ b/gunicorn/http2/negotiation.py
@@ -1,0 +1,121 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+"""Cleartext HTTP/2 (h2c) negotiation, shared by every worker.
+
+The I/O differs per worker: gthread and gevent read from a socket, the ASGI
+worker is handed bytes by asyncio. The decisions do not. Keeping the pure,
+I/O-free part here stops the blocking and push-based paths from drifting apart.
+"""
+
+import time
+
+from gunicorn.http.message import _ip_in_allow_list
+
+#: HTTP/2 connection preface sent by clients using prior knowledge,
+#: RFC 9113 section 3.4.
+H2C_PREFACE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+
+#: How long to wait for the whole preface once the first bytes arrive. This
+#: is a budget for the entire preface, not per read.
+H2C_PREFACE_TIMEOUT = 1.0
+
+MATCH = "match"
+PARTIAL = "partial"
+MISMATCH = "mismatch"
+
+
+def preface_match(buf):
+    """Compare buffered bytes against the connection preface.
+
+    Returns ``MATCH`` when the whole preface is present, ``PARTIAL`` when the
+    bytes so far are a prefix of it and more could still arrive, and
+    ``MISMATCH`` as soon as a byte diverges. Never blocks and never reads.
+    """
+    if len(buf) >= len(H2C_PREFACE):
+        return MATCH if buf.startswith(H2C_PREFACE) else MISMATCH
+    return PARTIAL if H2C_PREFACE.startswith(buf) else MISMATCH
+
+
+def peer_trusted_for_h2c(cfg, peer_addr):
+    """Whether this peer may negotiate cleartext HTTP/2.
+
+    Reuses the ``forwarded_allow_ips`` trust list: h2c is only ever expected
+    from the TLS-terminating proxy in front of gunicorn, which is the same
+    peer already trusted to set forwarded headers. Unix socket peers are
+    trusted, matching that policy.
+    """
+    if not isinstance(peer_addr, tuple):
+        return True
+    return _ip_in_allow_list(
+        peer_addr[0], cfg.forwarded_allow_ips, cfg.forwarded_allow_networks()
+    )
+
+
+def _h2c_available(cfg):
+    """Whether cleartext HTTP/2 could apply to this server at all."""
+    return (
+        "h2" in cfg.http_protocols
+        and getattr(cfg, "protocol", "http") == "http"
+        and not cfg.is_ssl
+    )
+
+
+def prior_knowledge_allowed(cfg, peer_addr):
+    """Whether to sniff for the connection preface from this peer.
+
+    Deliberately separate from :func:`upgrade_allowed`: enabling one mechanism
+    must not quietly enable the other.
+    """
+    if cfg.http2_cleartext not in ("prior-knowledge", "both"):
+        return False
+    return _h2c_available(cfg) and peer_trusted_for_h2c(cfg, peer_addr)
+
+
+def upgrade_allowed(cfg, peer_addr):
+    """Whether to honour an ``Upgrade: h2c`` request from this peer."""
+    if cfg.http2_cleartext not in ("upgrade", "both"):
+        return False
+    return _h2c_available(cfg) and peer_trusted_for_h2c(cfg, peer_addr)
+
+
+def read_preface_blocking(sock, timeout=None):
+    """Read up to the length of the preface from a blocking socket.
+
+    Returns ``(matched, consumed_bytes)``. The caller owns the consumed bytes
+    and must hand them to whichever protocol wins, since they have already
+    left the socket.
+
+    The timeout is an absolute budget for the whole preface, checked before
+    every read. ``socket.settimeout()`` alone would bound each call instead,
+    which lets a client trickle one byte per interval and hold the connection
+    (and, on gthread, a pool slot) for as many intervals as the preface has
+    bytes.
+    """
+    if timeout is None:
+        # read at call time so the module attribute stays adjustable
+        timeout = H2C_PREFACE_TIMEOUT
+    buf = b""
+    deadline = time.monotonic() + timeout
+    original = sock.gettimeout()
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False, buf
+            sock.settimeout(remaining)
+            try:
+                chunk = sock.recv(len(H2C_PREFACE) - len(buf))
+            except (TimeoutError, OSError):
+                return False, buf
+            if not chunk:
+                return False, buf
+            buf += chunk
+            state = preface_match(buf)
+            if state is MATCH:
+                return True, buf
+            if state is MISMATCH:
+                return False, buf
+    finally:
+        sock.settimeout(original)

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -21,6 +21,7 @@ from gunicorn.http.errors import (
     LimitRequestHeaders, LimitRequestLine,
     UnsupportedTransferCoding, ExpectationFailed,
     ConfigurationProblem, ObsoleteFolding,
+    InvalidH2CPreface,
 )
 from gunicorn.http.wsgi import Response, default_environ
 from gunicorn.reloader import reloader_engines
@@ -207,7 +208,7 @@ class Worker:
             InvalidProxyLine, ForbiddenProxyRequest,
             InvalidSchemeHeaders, UnsupportedTransferCoding,
             ConfigurationProblem, ObsoleteFolding, ExpectationFailed,
-            SSLError,
+            InvalidH2CPreface, SSLError,
         )):
 
             status_int = 400
@@ -248,6 +249,8 @@ class Worker:
                 mesg = "Request forbidden"
                 status_int = 403
             elif isinstance(exc, InvalidSchemeHeaders):
+                mesg = "%s" % str(exc)
+            elif isinstance(exc, InvalidH2CPreface):
                 mesg = "%s" % str(exc)
             elif isinstance(exc, SSLError):
                 reason = "Forbidden"

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -37,6 +37,14 @@ _DEFER = object()
 # the main poller to prevent thread pool exhaustion from slow clients.
 DEFAULT_WORKER_DATA_TIMEOUT = 5.0
 
+# HTTP/2 connection preface sent by clients using prior-knowledge h2c
+# (RFC 9113 section 3.4).
+H2C_PREFACE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+
+# How long (in seconds) to wait for the full connection preface once the
+# first bytes of a candidate h2c connection have arrived.
+H2C_PREFACE_TIMEOUT = 1.0
+
 
 class TConn:
 
@@ -82,8 +90,61 @@ class TConn:
                     self.parser.initiate_connection()
                     return
 
+            elif (
+                self.cfg.h2c
+                and "h2" in self.cfg.http_protocols
+                and getattr(self.cfg, "protocol", "http") == "http"
+            ):
+                # HTTP/2 cleartext (h2c) with prior knowledge (RFC 9113
+                # section 3.4): the client opens a plain TCP connection and
+                # immediately sends the HTTP/2 connection preface.
+                matched, buf = self._read_h2c_preface()
+                if matched:
+                    self.is_http2 = True
+                    self.parser = http.get_parser(
+                        self.cfg, self.sock, self.client, http2_connection=True
+                    )
+                    self.parser.initiate_connection()
+                    # The consumed preface bytes still need to reach the
+                    # HTTP/2 state machine. The preface alone cannot
+                    # complete a request, so nothing is dropped here.
+                    self.parser.receive_data(buf)
+                    return
+                if buf:
+                    # Not an HTTP/2 preface: serve as HTTP/1.x, returning
+                    # the consumed bytes to the parser.
+                    self.parser = http.get_parser(self.cfg, self.sock, self.client)
+                    self.parser.unreader.unread(buf)
+                    return
+
             # initialize the HTTP/1.x parser
             self.parser = http.get_parser(self.cfg, self.sock, self.client)
+
+    def _read_h2c_preface(self):
+        """Read up to the length of the HTTP/2 connection preface.
+
+        Consumes bytes from the socket until the preface is complete, a
+        byte diverges from it, the peer closes, or the preface timeout
+        expires. Returns a tuple ``(matched, consumed_bytes)``; on a
+        non-match the consumed bytes must be handed back to the HTTP/1.x
+        parser by the caller.
+        """
+        buf = b""
+        self.sock.settimeout(H2C_PREFACE_TIMEOUT)
+        try:
+            while len(buf) < len(H2C_PREFACE):
+                try:
+                    chunk = self.sock.recv(len(H2C_PREFACE) - len(buf))
+                except TimeoutError:
+                    return False, buf
+                if not chunk:
+                    return False, buf
+                buf += chunk
+                if not H2C_PREFACE.startswith(buf):
+                    return False, buf
+            return True, buf
+        finally:
+            self.sock.settimeout(None)
 
     def set_timeout(self):
         # Use monotonic clock for reliability (time.time() can jump due to NTP)

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -28,7 +28,7 @@ from .. import util
 from .. import sock
 from ..http import wsgi
 from ..http.errors import InvalidH2CPreface
-from ..http.message import _ip_in_allow_list
+from ..http2 import negotiation
 
 
 # Sentinel value to indicate connection should be deferred back to poller
@@ -38,14 +38,6 @@ _DEFER = object()
 # If no data arrives within this timeout, the connection is deferred back to
 # the main poller to prevent thread pool exhaustion from slow clients.
 DEFAULT_WORKER_DATA_TIMEOUT = 5.0
-
-# HTTP/2 connection preface sent by clients using prior-knowledge h2c
-# (RFC 9113 section 3.4).
-H2C_PREFACE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
-
-# How long (in seconds) to wait for the full connection preface once the
-# first bytes of a candidate h2c connection have arrived.
-H2C_PREFACE_TIMEOUT = 1.0
 
 
 class TConn:
@@ -92,18 +84,13 @@ class TConn:
                     self.parser.initiate_connection()
                     return
 
-            elif (
-                self.cfg.http2_prior_knowledge
-                and "h2" in self.cfg.http_protocols
-                and getattr(self.cfg, "protocol", "http") == "http"
-                and self._peer_trusted_for_h2c()
-            ):
-                # HTTP/2 cleartext (h2c) with prior knowledge (RFC 9113
-                # section 3.4): the client opens a plain TCP connection and
-                # immediately sends the HTTP/2 connection preface. Peers
-                # outside forwarded_allow_ips never reach this branch and
-                # are served HTTP/1.x as if the setting were off.
-                matched, buf = self._read_h2c_preface()
+            elif negotiation.prior_knowledge_allowed(self.cfg, self.client):
+                # HTTP/2 cleartext with prior knowledge (RFC 9113 section
+                # 3.4): the client opens a plain TCP connection and sends the
+                # connection preface immediately. Peers outside
+                # forwarded_allow_ips never reach here and are served HTTP/1.x
+                # as if the setting were off.
+                matched, buf = negotiation.read_preface_blocking(self.sock)
                 if matched:
                     self.is_http2 = True
                     self.parser = http.get_parser(
@@ -111,58 +98,16 @@ class TConn:
                     )
                     self.parser.initiate_connection()
                     # The consumed preface bytes still need to reach the
-                    # HTTP/2 state machine. The preface alone cannot
-                    # complete a request, so nothing is dropped here.
+                    # HTTP/2 state machine. The preface alone cannot complete
+                    # a request, so nothing is dropped here.
                     self.parser.receive_data(buf)
                     return
-                # A trusted peer on a prior-knowledge port must speak
-                # HTTP/2. Anything else (an HTTP/1.x request, a malformed
-                # or stalled preface) is rejected with a 400 rather than
-                # silently downgraded.
+                # A trusted peer on a prior-knowledge port must speak HTTP/2.
+                # Anything else is rejected rather than silently downgraded.
                 raise InvalidH2CPreface(buf)
 
             # initialize the HTTP/1.x parser
             self.parser = http.get_parser(self.cfg, self.sock, self.client)
-
-    def _peer_trusted_for_h2c(self):
-        """Whether the peer may speak prior-knowledge h2c.
-
-        Reuses the ``forwarded_allow_ips`` trust list: h2c is only ever
-        expected from the TLS-terminating proxy in front of Gunicorn,
-        which is the same peer trusted to set forwarded headers. Unix
-        socket peers are trusted, matching the forwarded-header policy.
-        """
-        if not isinstance(self.client, tuple):
-            return True
-        return _ip_in_allow_list(
-            self.client[0],
-            self.cfg.forwarded_allow_ips,
-            self.cfg.forwarded_allow_networks(),
-        )
-
-    def _read_h2c_preface(self):
-        """Read up to the length of the HTTP/2 connection preface.
-
-        Consumes bytes from the socket until the preface is complete, a
-        byte diverges from it, the peer closes, or the preface timeout
-        expires. Returns a tuple ``(matched, consumed_bytes)``.
-        """
-        buf = b""
-        self.sock.settimeout(H2C_PREFACE_TIMEOUT)
-        try:
-            while len(buf) < len(H2C_PREFACE):
-                try:
-                    chunk = self.sock.recv(len(H2C_PREFACE) - len(buf))
-                except TimeoutError:
-                    return False, buf
-                if not chunk:
-                    return False, buf
-                buf += chunk
-                if not H2C_PREFACE.startswith(buf):
-                    return False, buf
-            return True, buf
-        finally:
-            self.sock.settimeout(None)
 
     def set_timeout(self):
         # Use monotonic clock for reliability (time.time() can jump due to NTP)

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -27,6 +27,8 @@ from .. import http
 from .. import util
 from .. import sock
 from ..http import wsgi
+from ..http.errors import InvalidH2CPreface
+from ..http.message import _ip_in_allow_list
 
 
 # Sentinel value to indicate connection should be deferred back to poller
@@ -91,13 +93,16 @@ class TConn:
                     return
 
             elif (
-                self.cfg.h2c
+                self.cfg.http2_prior_knowledge
                 and "h2" in self.cfg.http_protocols
                 and getattr(self.cfg, "protocol", "http") == "http"
+                and self._peer_trusted_for_h2c()
             ):
                 # HTTP/2 cleartext (h2c) with prior knowledge (RFC 9113
                 # section 3.4): the client opens a plain TCP connection and
-                # immediately sends the HTTP/2 connection preface.
+                # immediately sends the HTTP/2 connection preface. Peers
+                # outside forwarded_allow_ips never reach this branch and
+                # are served HTTP/1.x as if the setting were off.
                 matched, buf = self._read_h2c_preface()
                 if matched:
                     self.is_http2 = True
@@ -110,24 +115,37 @@ class TConn:
                     # complete a request, so nothing is dropped here.
                     self.parser.receive_data(buf)
                     return
-                if buf:
-                    # Not an HTTP/2 preface: serve as HTTP/1.x, returning
-                    # the consumed bytes to the parser.
-                    self.parser = http.get_parser(self.cfg, self.sock, self.client)
-                    self.parser.unreader.unread(buf)
-                    return
+                # A trusted peer on a prior-knowledge port must speak
+                # HTTP/2. Anything else (an HTTP/1.x request, a malformed
+                # or stalled preface) is rejected with a 400 rather than
+                # silently downgraded.
+                raise InvalidH2CPreface(buf)
 
             # initialize the HTTP/1.x parser
             self.parser = http.get_parser(self.cfg, self.sock, self.client)
+
+    def _peer_trusted_for_h2c(self):
+        """Whether the peer may speak prior-knowledge h2c.
+
+        Reuses the ``forwarded_allow_ips`` trust list: h2c is only ever
+        expected from the TLS-terminating proxy in front of Gunicorn,
+        which is the same peer trusted to set forwarded headers. Unix
+        socket peers are trusted, matching the forwarded-header policy.
+        """
+        if not isinstance(self.client, tuple):
+            return True
+        return _ip_in_allow_list(
+            self.client[0],
+            self.cfg.forwarded_allow_ips,
+            self.cfg.forwarded_allow_networks(),
+        )
 
     def _read_h2c_preface(self):
         """Read up to the length of the HTTP/2 connection preface.
 
         Consumes bytes from the socket until the preface is complete, a
         byte diverges from it, the peer closes, or the preface timeout
-        expires. Returns a tuple ``(matched, consumed_bytes)``; on a
-        non-match the consumed bytes must be handed back to the HTTP/1.x
-        parser by the caller.
+        expires. Returns a tuple ``(matched, consumed_bytes)``.
         """
         buf = b""
         self.sock.settimeout(H2C_PREFACE_TIMEOUT)

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -19,11 +19,17 @@ except ImportError:
     H2_AVAILABLE = False
 
 from gunicorn.config import Config
+from gunicorn.http.errors import InvalidH2CPreface
 from gunicorn.http.parser import RequestParser
 from gunicorn.workers import gthread
 
+# An address inside the default forwarded_allow_ips ("127.0.0.1,::1").
+TRUSTED_ADDR = ("127.0.0.1", 0)
+# TEST-NET-3 (RFC 5737), never inside the default trust list.
+UNTRUSTED_ADDR = ("203.0.113.7", 0)
 
-def make_conn(cfg, client_data=None):
+
+def make_conn(cfg, client_data=None, addr=TRUSTED_ADDR):
     """Build a TConn around one end of a socketpair.
 
     Returns (conn, client_sock). Bytes in client_data are sent before
@@ -32,25 +38,25 @@ def make_conn(cfg, client_data=None):
     server_sock, client_sock = socket.socketpair()
     if client_data:
         client_sock.sendall(client_data)
-    conn = gthread.TConn(cfg, server_sock, ("127.0.0.1", 0), None)
+    conn = gthread.TConn(cfg, server_sock, addr, None)
     return conn, client_sock
 
 
 def h2c_config():
     cfg = Config()
     cfg.set("http_protocols", "h2,h1")
-    cfg.set("h2c", True)
+    cfg.set("http2_prior_knowledge", True)
     return cfg
 
 
 class TestH2CConfig:
     def test_disabled_by_default(self):
-        assert Config().h2c is False
+        assert Config().http2_prior_knowledge is False
 
     def test_can_be_enabled(self):
         cfg = Config()
-        cfg.set("h2c", True)
-        assert cfg.h2c is True
+        cfg.set("http2_prior_knowledge", True)
+        assert cfg.http2_prior_knowledge is True
 
 
 class TestH2CDisabled:
@@ -70,7 +76,8 @@ class TestH2CDisabled:
     def test_no_peek_when_h2_not_in_protocols(self):
         """h2c flag alone is not enough; h2 must be an enabled protocol."""
         cfg = Config()
-        cfg.set("h2c", True)  # http_protocols left at default "h1"
+        # http_protocols left at default "h1"
+        cfg.set("http2_prior_knowledge", True)
         conn, client = make_conn(cfg, gthread.H2C_PREFACE)
         try:
             conn.init()
@@ -113,12 +120,67 @@ class TestH2CPriorKnowledge:
             client.close()
 
 
-class TestH2CFallback:
-    def test_http1_request_falls_back_and_parses(self):
-        """A plain HTTP/1.1 request must be served untouched, including
-        the bytes consumed while sniffing the preface."""
+class TestH2CTrustedPeerRejection:
+    """A trusted peer on a prior-knowledge port must speak HTTP/2.
+
+    Anything else is rejected with InvalidH2CPreface (mapped to a 400 by
+    the worker) instead of being silently downgraded to HTTP/1.x.
+    """
+
+    def test_http1_request_rejected(self):
         request = b"GET /ping HTTP/1.1\r\nHost: example.com\r\n\r\n"
         conn, client = make_conn(h2c_config(), request)
+        try:
+            with pytest.raises(InvalidH2CPreface):
+                conn.init()
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_diverging_bytes_rejected_immediately(self):
+        """First byte differs from the preface: no waiting occurs."""
+        request = b"XGET /nope HTTP/1.1\r\n"
+        conn, client = make_conn(h2c_config(), request)
+        try:
+            start = time.monotonic()
+            with pytest.raises(InvalidH2CPreface):
+                conn.init()
+            assert time.monotonic() - start < gthread.H2C_PREFACE_TIMEOUT
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_partial_preface_times_out_rejected(self, monkeypatch):
+        """A client that stalls mid-preface is rejected, not downgraded."""
+        monkeypatch.setattr(gthread, "H2C_PREFACE_TIMEOUT", 0.05)
+        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE[:10])
+        try:
+            with pytest.raises(InvalidH2CPreface):
+                conn.init()
+        finally:
+            conn.sock.close()
+            client.close()
+
+
+class TestH2CUntrustedPeer:
+    """Peers outside forwarded_allow_ips never get the preface sniffed."""
+
+    def test_preface_from_untrusted_peer_gets_http1(self):
+        conn, client = make_conn(
+            h2c_config(), gthread.H2C_PREFACE, addr=UNTRUSTED_ADDR
+        )
+        try:
+            conn.init()
+            assert conn.is_http2 is False
+            assert isinstance(conn.parser, RequestParser)
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_http1_from_untrusted_peer_parses(self):
+        """Untrusted h1 traffic is byte-for-byte unaffected by the flag."""
+        request = b"GET /ping HTTP/1.1\r\nHost: example.com\r\n\r\n"
+        conn, client = make_conn(h2c_config(), request, addr=UNTRUSTED_ADDR)
         try:
             conn.init()
             assert conn.is_http2 is False
@@ -129,32 +191,32 @@ class TestH2CFallback:
             conn.sock.close()
             client.close()
 
-    def test_diverging_bytes_fall_back_immediately(self):
-        """First byte differs from the preface: no waiting occurs."""
-        request = b"XGET /nope HTTP/1.1\r\n"
-        conn, client = make_conn(h2c_config(), request)
+    @pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")
+    def test_wildcard_allow_list_trusts_any_peer(self):
+        cfg = h2c_config()
+        cfg.set("forwarded_allow_ips", "*")
+        conn, client = make_conn(cfg, gthread.H2C_PREFACE, addr=UNTRUSTED_ADDR)
         try:
-            start = time.monotonic()
             conn.init()
-            assert time.monotonic() - start < gthread.H2C_PREFACE_TIMEOUT
-            assert conn.is_http2 is False
+            assert conn.is_http2 is True
         finally:
             conn.sock.close()
             client.close()
 
-    def test_partial_preface_times_out_to_http1(self, monkeypatch):
-        """A client that stalls mid-preface ends up on HTTP/1.x."""
-        monkeypatch.setattr(gthread, "H2C_PREFACE_TIMEOUT", 0.05)
-        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE[:10])
+    @pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")
+    def test_unix_socket_peer_is_trusted(self):
+        """Non-tuple peer addresses (unix sockets) follow the
+        forwarded-header policy and are trusted."""
+        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE, addr="")
         try:
             conn.init()
-            assert conn.is_http2 is False
-            # The consumed bytes were handed back to the HTTP/1.x parser
-            assert conn.parser.unreader.buf.getvalue() == gthread.H2C_PREFACE[:10]
+            assert conn.is_http2 is True
         finally:
             conn.sock.close()
             client.close()
 
+
+class TestH2CProtocolGuard:
     def test_uwsgi_protocol_not_sniffed(self):
         """The uwsgi protocol has its own parser; h2c must not touch it."""
         cfg = h2c_config()

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+"""Tests for HTTP/2 cleartext (h2c) prior-knowledge support."""
+
+import socket
+import threading
+import time
+
+import pytest
+
+# Check if h2 is available
+try:
+    import h2.connection  # pylint: disable=unused-import
+    H2_AVAILABLE = True
+except ImportError:
+    H2_AVAILABLE = False
+
+from gunicorn.config import Config
+from gunicorn.http.parser import RequestParser
+from gunicorn.workers import gthread
+
+
+def make_conn(cfg, client_data=None):
+    """Build a TConn around one end of a socketpair.
+
+    Returns (conn, client_sock). Bytes in client_data are sent before
+    TConn.init() runs, mimicking a client that talks first.
+    """
+    server_sock, client_sock = socket.socketpair()
+    if client_data:
+        client_sock.sendall(client_data)
+    conn = gthread.TConn(cfg, server_sock, ("127.0.0.1", 0), None)
+    return conn, client_sock
+
+
+def h2c_config():
+    cfg = Config()
+    cfg.set("http_protocols", "h2,h1")
+    cfg.set("h2c", True)
+    return cfg
+
+
+class TestH2CConfig:
+    def test_disabled_by_default(self):
+        assert Config().h2c is False
+
+    def test_can_be_enabled(self):
+        cfg = Config()
+        cfg.set("h2c", True)
+        assert cfg.h2c is True
+
+
+class TestH2CDisabled:
+    def test_preface_ignored_when_h2c_off(self):
+        """Without the flag, a preface-sending client gets HTTP/1.x."""
+        cfg = Config()
+        cfg.set("http_protocols", "h2,h1")
+        conn, client = make_conn(cfg, gthread.H2C_PREFACE)
+        try:
+            conn.init()
+            assert conn.is_http2 is False
+            assert isinstance(conn.parser, RequestParser)
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_no_peek_when_h2_not_in_protocols(self):
+        """h2c flag alone is not enough; h2 must be an enabled protocol."""
+        cfg = Config()
+        cfg.set("h2c", True)  # http_protocols left at default "h1"
+        conn, client = make_conn(cfg, gthread.H2C_PREFACE)
+        try:
+            conn.init()
+            assert conn.is_http2 is False
+        finally:
+            conn.sock.close()
+            client.close()
+
+
+@pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")
+class TestH2CPriorKnowledge:
+    def test_preface_selects_http2(self):
+        from gunicorn.http2.connection import HTTP2ServerConnection
+
+        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE)
+        try:
+            conn.init()
+            assert conn.is_http2 is True
+            assert isinstance(conn.parser, HTTP2ServerConnection)
+            # initiate_connection() must have sent the server SETTINGS frame
+            client.settimeout(1.0)
+            assert client.recv(1024)
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_split_preface_selects_http2(self):
+        """Preface arriving in two segments is still recognized."""
+        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE[:10])
+        sender = threading.Timer(
+            0.05, client.sendall, args=(gthread.H2C_PREFACE[10:],)
+        )
+        sender.start()
+        try:
+            conn.init()
+            assert conn.is_http2 is True
+        finally:
+            sender.join()
+            conn.sock.close()
+            client.close()
+
+
+class TestH2CFallback:
+    def test_http1_request_falls_back_and_parses(self):
+        """A plain HTTP/1.1 request must be served untouched, including
+        the bytes consumed while sniffing the preface."""
+        request = b"GET /ping HTTP/1.1\r\nHost: example.com\r\n\r\n"
+        conn, client = make_conn(h2c_config(), request)
+        try:
+            conn.init()
+            assert conn.is_http2 is False
+            req = next(conn.parser)
+            assert req.method == "GET"
+            assert req.path == "/ping"
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_diverging_bytes_fall_back_immediately(self):
+        """First byte differs from the preface: no waiting occurs."""
+        request = b"XGET /nope HTTP/1.1\r\n"
+        conn, client = make_conn(h2c_config(), request)
+        try:
+            start = time.monotonic()
+            conn.init()
+            assert time.monotonic() - start < gthread.H2C_PREFACE_TIMEOUT
+            assert conn.is_http2 is False
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_partial_preface_times_out_to_http1(self, monkeypatch):
+        """A client that stalls mid-preface ends up on HTTP/1.x."""
+        monkeypatch.setattr(gthread, "H2C_PREFACE_TIMEOUT", 0.05)
+        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE[:10])
+        try:
+            conn.init()
+            assert conn.is_http2 is False
+            # The consumed bytes were handed back to the HTTP/1.x parser
+            assert conn.parser.unreader.buf.getvalue() == gthread.H2C_PREFACE[:10]
+        finally:
+            conn.sock.close()
+            client.close()
+
+    def test_uwsgi_protocol_not_sniffed(self):
+        """The uwsgi protocol has its own parser; h2c must not touch it."""
+        cfg = h2c_config()
+        cfg.set("protocol", "uwsgi")
+        conn, client = make_conn(cfg, gthread.H2C_PREFACE)
+        try:
+            conn.init()
+            assert conn.is_http2 is False
+        finally:
+            conn.sock.close()
+            client.close()

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -21,6 +21,7 @@ except ImportError:
 from gunicorn.config import Config
 from gunicorn.http.errors import InvalidH2CPreface
 from gunicorn.http.parser import RequestParser
+from gunicorn.http2 import negotiation
 from gunicorn.workers import gthread
 
 # An address inside the default forwarded_allow_ips ("127.0.0.1,::1").
@@ -45,18 +46,18 @@ def make_conn(cfg, client_data=None, addr=TRUSTED_ADDR):
 def h2c_config():
     cfg = Config()
     cfg.set("http_protocols", "h2,h1")
-    cfg.set("http2_prior_knowledge", True)
+    cfg.set("http2_cleartext", "prior-knowledge")
     return cfg
 
 
 class TestH2CConfig:
     def test_disabled_by_default(self):
-        assert Config().http2_prior_knowledge is False
+        assert Config().http2_cleartext == "off"
 
     def test_can_be_enabled(self):
         cfg = Config()
-        cfg.set("http2_prior_knowledge", True)
-        assert cfg.http2_prior_knowledge is True
+        cfg.set("http2_cleartext", "prior-knowledge")
+        assert cfg.http2_cleartext == "prior-knowledge"
 
 
 class TestH2CDisabled:
@@ -64,7 +65,7 @@ class TestH2CDisabled:
         """Without the flag, a preface-sending client gets HTTP/1.x."""
         cfg = Config()
         cfg.set("http_protocols", "h2,h1")
-        conn, client = make_conn(cfg, gthread.H2C_PREFACE)
+        conn, client = make_conn(cfg, negotiation.H2C_PREFACE)
         try:
             conn.init()
             assert conn.is_http2 is False
@@ -77,8 +78,8 @@ class TestH2CDisabled:
         """h2c flag alone is not enough; h2 must be an enabled protocol."""
         cfg = Config()
         # http_protocols left at default "h1"
-        cfg.set("http2_prior_knowledge", True)
-        conn, client = make_conn(cfg, gthread.H2C_PREFACE)
+        cfg.set("http2_cleartext", "prior-knowledge")
+        conn, client = make_conn(cfg, negotiation.H2C_PREFACE)
         try:
             conn.init()
             assert conn.is_http2 is False
@@ -92,7 +93,7 @@ class TestH2CPriorKnowledge:
     def test_preface_selects_http2(self):
         from gunicorn.http2.connection import HTTP2ServerConnection
 
-        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE)
+        conn, client = make_conn(h2c_config(), negotiation.H2C_PREFACE)
         try:
             conn.init()
             assert conn.is_http2 is True
@@ -106,9 +107,9 @@ class TestH2CPriorKnowledge:
 
     def test_split_preface_selects_http2(self):
         """Preface arriving in two segments is still recognized."""
-        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE[:10])
+        conn, client = make_conn(h2c_config(), negotiation.H2C_PREFACE[:10])
         sender = threading.Timer(
-            0.05, client.sendall, args=(gthread.H2C_PREFACE[10:],)
+            0.05, client.sendall, args=(negotiation.H2C_PREFACE[10:],)
         )
         sender.start()
         try:
@@ -145,15 +146,15 @@ class TestH2CTrustedPeerRejection:
             start = time.monotonic()
             with pytest.raises(InvalidH2CPreface):
                 conn.init()
-            assert time.monotonic() - start < gthread.H2C_PREFACE_TIMEOUT
+            assert time.monotonic() - start < negotiation.H2C_PREFACE_TIMEOUT
         finally:
             conn.sock.close()
             client.close()
 
     def test_partial_preface_times_out_rejected(self, monkeypatch):
         """A client that stalls mid-preface is rejected, not downgraded."""
-        monkeypatch.setattr(gthread, "H2C_PREFACE_TIMEOUT", 0.05)
-        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE[:10])
+        monkeypatch.setattr(negotiation, "H2C_PREFACE_TIMEOUT", 0.05)
+        conn, client = make_conn(h2c_config(), negotiation.H2C_PREFACE[:10])
         try:
             with pytest.raises(InvalidH2CPreface):
                 conn.init()
@@ -167,7 +168,7 @@ class TestH2CUntrustedPeer:
 
     def test_preface_from_untrusted_peer_gets_http1(self):
         conn, client = make_conn(
-            h2c_config(), gthread.H2C_PREFACE, addr=UNTRUSTED_ADDR
+            h2c_config(), negotiation.H2C_PREFACE, addr=UNTRUSTED_ADDR
         )
         try:
             conn.init()
@@ -195,7 +196,7 @@ class TestH2CUntrustedPeer:
     def test_wildcard_allow_list_trusts_any_peer(self):
         cfg = h2c_config()
         cfg.set("forwarded_allow_ips", "*")
-        conn, client = make_conn(cfg, gthread.H2C_PREFACE, addr=UNTRUSTED_ADDR)
+        conn, client = make_conn(cfg, negotiation.H2C_PREFACE, addr=UNTRUSTED_ADDR)
         try:
             conn.init()
             assert conn.is_http2 is True
@@ -207,7 +208,7 @@ class TestH2CUntrustedPeer:
     def test_unix_socket_peer_is_trusted(self):
         """Non-tuple peer addresses (unix sockets) follow the
         forwarded-header policy and are trusted."""
-        conn, client = make_conn(h2c_config(), gthread.H2C_PREFACE, addr="")
+        conn, client = make_conn(h2c_config(), negotiation.H2C_PREFACE, addr="")
         try:
             conn.init()
             assert conn.is_http2 is True
@@ -221,10 +222,104 @@ class TestH2CProtocolGuard:
         """The uwsgi protocol has its own parser; h2c must not touch it."""
         cfg = h2c_config()
         cfg.set("protocol", "uwsgi")
-        conn, client = make_conn(cfg, gthread.H2C_PREFACE)
+        conn, client = make_conn(cfg, negotiation.H2C_PREFACE)
         try:
             conn.init()
             assert conn.is_http2 is False
         finally:
             conn.sock.close()
             client.close()
+
+
+class TestPrefaceMatch:
+    """The pure matcher, shared by the blocking and push-based paths."""
+
+    def test_complete_preface(self):
+        assert negotiation.preface_match(negotiation.H2C_PREFACE) == negotiation.MATCH
+
+    def test_prefix_is_partial(self):
+        for n in range(1, len(negotiation.H2C_PREFACE)):
+            assert negotiation.preface_match(
+                negotiation.H2C_PREFACE[:n]) == negotiation.PARTIAL
+
+    def test_empty_is_partial(self):
+        assert negotiation.preface_match(b"") == negotiation.PARTIAL
+
+    def test_divergence_is_mismatch(self):
+        assert negotiation.preface_match(b"GET / HT") == negotiation.MISMATCH
+
+    def test_trailing_bytes_after_preface_still_match(self):
+        assert negotiation.preface_match(
+            negotiation.H2C_PREFACE + b"\x00\x00\x00\x04") == negotiation.MATCH
+
+
+class TestNegotiationPredicates:
+    """Prior knowledge and upgrade are enabled separately."""
+
+    def _cfg(self, mode):
+        cfg = h2c_config()
+        cfg.set("http2_cleartext", mode)
+        return cfg
+
+    TRUSTED = ("127.0.0.1", 1234)
+
+    def test_prior_knowledge_only(self):
+        cfg = self._cfg("prior-knowledge")
+        assert negotiation.prior_knowledge_allowed(cfg, self.TRUSTED)
+        assert not negotiation.upgrade_allowed(cfg, self.TRUSTED)
+
+    def test_upgrade_only(self):
+        cfg = self._cfg("upgrade")
+        assert not negotiation.prior_knowledge_allowed(cfg, self.TRUSTED)
+        assert negotiation.upgrade_allowed(cfg, self.TRUSTED)
+
+    def test_both(self):
+        cfg = self._cfg("both")
+        assert negotiation.prior_knowledge_allowed(cfg, self.TRUSTED)
+        assert negotiation.upgrade_allowed(cfg, self.TRUSTED)
+
+    def test_off(self):
+        cfg = self._cfg("off")
+        assert not negotiation.prior_knowledge_allowed(cfg, self.TRUSTED)
+        assert not negotiation.upgrade_allowed(cfg, self.TRUSTED)
+
+    def test_untrusted_peer_never_negotiates(self):
+        cfg = self._cfg("both")
+        untrusted = ("203.0.113.9", 4444)
+        assert not negotiation.prior_knowledge_allowed(cfg, untrusted)
+        assert not negotiation.upgrade_allowed(cfg, untrusted)
+
+
+class TestPrefaceDeadline:
+    """The preface budget covers the whole preface, not each read."""
+
+    def test_trickling_client_cannot_extend_the_budget(self, monkeypatch):
+        monkeypatch.setattr(negotiation, "H2C_PREFACE_TIMEOUT", 0.25)
+        server, client = socket.socketpair()
+        stop = threading.Event()
+
+        def trickle():
+            # One byte every 0.1s: each read alone stays inside the budget,
+            # so a per-read timeout would let this run for 24 intervals.
+            for byte in negotiation.H2C_PREFACE:
+                if stop.is_set():
+                    return
+                try:
+                    client.sendall(bytes([byte]))
+                except OSError:
+                    return
+                time.sleep(0.1)
+
+        t = threading.Thread(target=trickle, daemon=True)
+        t.start()
+        try:
+            started = time.monotonic()
+            matched, _ = negotiation.read_preface_blocking(server)
+            elapsed = time.monotonic() - started
+            assert matched is False
+            assert elapsed < 1.0, "budget was applied per read, not overall"
+        finally:
+            stop.set()
+            server.close()
+            client.close()
+            t.join(timeout=2)


### PR DESCRIPTION
Builds on #3663 by @fluffy-dev, whose two commits are kept as they are. Closes
part of #3489.

The negotiation logic moves to a shared module so the three workers decide the
same way. Only gthread is wired up here; gevent and ASGI come next, and they read
their bytes very differently, which is exactly why the decision has to live in
one place and not be written three times.

Two things change from #3663.

The preface timeout was applied to each read instead of to the preface as a
whole. A client sending one byte at a time stayed under it forever and kept a
thread pool slot busy, which is what the slow-client protection in #3518 exists
to prevent. It is now a deadline for the whole preface.

`http2_prior_knowledge` becomes `http2_cleartext`, which takes `off`,
`prior-knowledge`, `upgrade` or `both`. `Upgrade: h2c` is coming later, and
turning one mechanism on must not turn the other on. A boolean cannot say that.

## Breaking changes

None for anyone: the setting it renames was never released.

`--http2-prior-knowledge` becomes `--http2-cleartext prior-knowledge`. In a
config file, `http2_cleartext = True` is still understood and means
prior-knowledge, so the boolean form does not break silently.
