### PR TITLE
http2: prior-knowledge h2c on the ASGI worker

### DIFF
--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -21,6 +21,7 @@ from gunicorn.asgi.parser import (
 )
 from gunicorn.asgi.uwsgi import AsyncUWSGIRequest
 from gunicorn.http.errors import NoMoreData
+from gunicorn.http2 import negotiation
 from gunicorn.uwsgi.errors import UWSGIParseException
 
 
@@ -359,6 +360,10 @@ class ASGIProtocol(asyncio.Protocol):
 
         self.transport = None
         self.reader = None  # Only used for HTTP/2
+        # Set to a bytes buffer while sniffing for the cleartext HTTP/2
+        # connection preface, before either protocol has been committed to.
+        self._h2c_buffer = None
+        self._h2c_timer = None
         self.writer = None
         self._task = None
         self.req_count = 0
@@ -410,6 +415,21 @@ class ASGIProtocol(asyncio.Protocol):
                     self._handle_http2_connection(transport, ssl_object)
                 )
                 return
+
+        peername = transport.get_extra_info('peername')
+        if negotiation.prior_knowledge_allowed(self.cfg, peername):
+            # Cleartext HTTP/2 with prior knowledge. Unlike the sync workers
+            # we cannot read here, so commit to neither protocol yet: buffer
+            # in data_received() until the preface either matches or cannot.
+            self._is_ssl = False
+            self.writer = transport
+            self._flow_control = FlowControl(transport)
+            transport.set_write_buffer_limits(high=HIGH_WATER_LIMIT)
+            self._h2c_buffer = b""
+            self._h2c_timer = self.worker.loop.call_later(
+                negotiation.H2C_PREFACE_TIMEOUT, self._h2c_undecided_timeout
+            )
+            return
 
         # HTTP/1.x connection - always use callback parser
         self._is_ssl = ssl_object is not None
@@ -595,6 +615,9 @@ class ASGIProtocol(asyncio.Protocol):
             # WebSocket path - forward to WebSocket protocol
             self._websocket.feed_data(data)
             return
+        if self._h2c_buffer is not None:
+            self._h2c_feed(data)
+            return
         if self.reader:
             # HTTP/2 path - use StreamReader
             self.reader.feed_data(data)
@@ -606,6 +629,45 @@ class ASGIProtocol(asyncio.Protocol):
         # Backpressure: pause reading if buffer is too large
         if not self._reading_paused and self._is_buffer_full():
             self._pause_reading()
+
+    def _h2c_feed(self, data):
+        """Accumulate bytes until the connection preface resolves."""
+        self._h2c_buffer += data
+        state = negotiation.preface_match(self._h2c_buffer)
+        if state is negotiation.PARTIAL:
+            return
+        buffered, self._h2c_buffer = self._h2c_buffer, None
+        self._h2c_cancel_timer()
+        if state is negotiation.MATCH:
+            self._h2c_start(buffered)
+            return
+        # A trusted peer on a prior-knowledge port must speak HTTP/2.
+        # Anything else is refused rather than silently downgraded.
+        self._send_error_response(400, "Invalid HTTP/2 connection preface")
+        self._close_transport()
+
+    def _h2c_start(self, buffered):
+        """Commit to HTTP/2 and replay the bytes read while undecided."""
+        self.reader = asyncio.StreamReader()
+        self._task = self.worker.loop.create_task(
+            # No ssl_object: this is cleartext. The handler does not use it.
+            self._handle_http2_connection(self.transport, None)
+        )
+        self.reader.feed_data(buffered)
+
+    def _h2c_undecided_timeout(self):
+        """A client that stalls mid-preface is refused, not downgraded."""
+        self._h2c_timer = None
+        if self._h2c_buffer is None:
+            return
+        self._h2c_buffer = None
+        self._send_error_response(400, "Invalid HTTP/2 connection preface")
+        self._close_transport()
+
+    def _h2c_cancel_timer(self):
+        if self._h2c_timer is not None:
+            self._h2c_timer.cancel()
+            self._h2c_timer = None
 
     def _feed_callback_parser(self, data):
         """Feed data to callback parser, handling parse errors.
@@ -696,6 +758,7 @@ class ASGIProtocol(asyncio.Protocol):
 
         self._conn_lost_handled = True
         self._closed = True
+        self._h2c_cancel_timer()
         self.worker.nr_conns -= 1
 
         # Cancel keepalive timer

--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -758,6 +758,8 @@ class ASGIProtocol(asyncio.Protocol):
 
         self._conn_lost_handled = True
         self._closed = True
+        # Drop any half-read preface with the connection it belonged to.
+        self._h2c_buffer = None
         self._h2c_cancel_timer()
         self.worker.nr_conns -= 1
 

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -5,6 +5,7 @@
 
 """Tests for HTTP/2 cleartext (h2c) prior-knowledge support."""
 
+import asyncio
 import contextlib
 import socket
 import threading
@@ -419,3 +420,156 @@ class TestH2CGevent:
         worker = run_async_handle(cfg, b"GET / HTTP/1.1\r\nHost: a\r\n\r\n")
         assert worker.http2_calls == []
         assert worker.errors == []
+
+
+class _FakeTransport:
+    """Minimal asyncio transport for driving ASGIProtocol directly."""
+
+    def __init__(self, peername=TRUSTED_ADDR):
+        self.written = b""
+        self.closed = False
+        self._peername = peername
+
+    def get_extra_info(self, name, default=None):
+        if name == "peername":
+            return self._peername
+        if name == "sockname":
+            return ("127.0.0.1", 8000)
+        return default
+
+    def write(self, data):
+        self.written += data
+
+    def close(self):
+        self.closed = True
+
+    def is_closing(self):
+        return self.closed
+
+    def can_write_eof(self):
+        return True
+
+    def write_eof(self):
+        pass
+
+    def set_write_buffer_limits(self, high=None, low=None):
+        pass
+
+    def pause_reading(self):
+        pass
+
+    def resume_reading(self):
+        pass
+
+
+def make_asgi_protocol(cfg, loop):
+    from gunicorn.asgi.protocol import ASGIProtocol
+
+    worker = mock.Mock()
+    worker.cfg = cfg
+    worker.log = mock.Mock()
+    worker.asgi = mock.Mock()
+    worker.loop = loop
+    worker.nr_conns = 0
+    return ASGIProtocol(worker)
+
+
+class TestH2CASGI:
+    """The ASGI worker cannot read in connection_made, so it buffers."""
+
+    def _connect(self, cfg, peername=TRUSTED_ADDR):
+        loop = asyncio.new_event_loop()
+        # StreamReader and create_task need the loop to be current, which it
+        # is in production because data_received runs inside it.
+        asyncio.set_event_loop(loop)
+        proto = make_asgi_protocol(cfg, loop)
+        transport = _FakeTransport(peername)
+        proto.connection_made(transport)
+        return proto, transport, loop
+
+    def test_undecided_until_the_preface_resolves(self):
+        proto, transport, loop = self._connect(h2c_config())
+        try:
+            assert proto._h2c_buffer == b""
+            assert proto._callback_parser is None
+            assert proto.reader is None
+            # a prefix keeps it undecided, nothing is committed
+            proto.data_received(negotiation.H2C_PREFACE[:8])
+            assert proto._h2c_buffer == negotiation.H2C_PREFACE[:8]
+            assert proto.reader is None
+            assert not transport.closed
+        finally:
+            proto._h2c_cancel_timer()
+            loop.close()
+            asyncio.set_event_loop(None)
+
+    def test_full_preface_commits_to_http2(self):
+        proto, transport, loop = self._connect(h2c_config())
+        try:
+            proto.data_received(negotiation.H2C_PREFACE)
+            assert proto._h2c_buffer is None
+            assert proto.reader is not None
+            assert not transport.closed
+        finally:
+            proto._h2c_cancel_timer()
+            loop.close()
+            asyncio.set_event_loop(None)
+
+    def test_preface_split_across_reads(self):
+        proto, transport, loop = self._connect(h2c_config())
+        try:
+            for byte in negotiation.H2C_PREFACE:
+                proto.data_received(bytes([byte]))
+            assert proto.reader is not None
+            assert not transport.closed
+        finally:
+            proto._h2c_cancel_timer()
+            loop.close()
+            asyncio.set_event_loop(None)
+
+    def test_http1_from_trusted_peer_is_refused(self):
+        proto, transport, loop = self._connect(h2c_config())
+        try:
+            proto.data_received(b"GET / HTTP/1.1\r\n")
+            assert proto.reader is None
+            assert b"400" in transport.written
+            assert transport.closed
+        finally:
+            proto._h2c_cancel_timer()
+            loop.close()
+            asyncio.set_event_loop(None)
+
+    def test_untrusted_peer_takes_the_http1_path(self):
+        proto, transport, loop = self._connect(
+            h2c_config(), peername=UNTRUSTED_ADDR)
+        try:
+            assert proto._h2c_buffer is None
+            assert proto._callback_parser is not None
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+
+    def test_disabled_takes_the_http1_path(self):
+        cfg = Config()
+        cfg.set("http_protocols", "h2,h1")
+        proto, transport, loop = self._connect(cfg)
+        try:
+            assert proto._h2c_buffer is None
+            assert proto._callback_parser is not None
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+
+    def test_stalled_preface_times_out(self):
+        proto, transport, loop = self._connect(h2c_config())
+        try:
+            proto.data_received(negotiation.H2C_PREFACE[:4])
+            assert proto._h2c_buffer is not None
+            proto._h2c_undecided_timeout()          # what call_later would do
+            assert proto.reader is None
+            assert b"400" in transport.written
+            assert transport.closed
+        finally:
+            proto._h2c_cancel_timer()
+            loop.close()
+            asyncio.set_event_loop(None)

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -573,3 +573,42 @@ class TestH2CASGI:
             proto._h2c_cancel_timer()
             loop.close()
             asyncio.set_event_loop(None)
+
+    def test_buffer_cannot_grow_past_the_preface(self):
+        proto, transport, loop = self._connect(h2c_config())
+        try:
+            # A large first chunk that is not a preface is refused at once,
+            # it is never accumulated.
+            proto.data_received(b"x" * 100_000)
+            assert proto._h2c_buffer is None
+            assert b"400" in transport.written
+        finally:
+            proto._h2c_cancel_timer()
+            loop.close()
+            asyncio.set_event_loop(None)
+
+    def test_bytes_after_the_preface_reach_http2(self):
+        proto, transport, loop = self._connect(h2c_config())
+        try:
+            trailing = b"\x00\x00\x00\x04\x00\x00\x00\x00\x00"   # SETTINGS
+            proto.data_received(negotiation.H2C_PREFACE + trailing)
+            assert proto._h2c_buffer is None
+            assert proto.reader is not None
+            # everything read while undecided is handed on, not dropped
+            assert proto.reader._buffer == negotiation.H2C_PREFACE + trailing
+        finally:
+            proto._h2c_cancel_timer()
+            loop.close()
+            asyncio.set_event_loop(None)
+
+    def test_connection_lost_while_undecided_clears_state(self):
+        proto, transport, loop = self._connect(h2c_config())
+        try:
+            proto.data_received(negotiation.H2C_PREFACE[:6])
+            assert proto._h2c_buffer is not None
+            proto.connection_lost(None)
+            assert proto._h2c_buffer is None
+            assert proto._h2c_timer is None
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)


### PR DESCRIPTION
Third worker, and the last one for prior knowledge. Part of #3489.

The ASGI worker is not like the two others. `connection_made()` picks a parser
before a single byte has arrived, so there is nothing to sniff yet. The cleartext
case therefore commits to neither protocol: it keeps the bytes in
`data_received()` until the preface is either complete or impossible, then gives
the buffered bytes to whichever side wins.

A client that starts a preface and stops is refused when the preface budget runs
out, so an undecided connection cannot be kept open. The timer is cancelled if
the connection goes away first.

With this, prior-knowledge h2c works on gthread, gevent and ASGI.

## Breaking changes

None. Off by default, and with it off `connection_made()` takes the same path as
before. Untrusted peers are never buffered and go straight to HTTP/1.
