### PR TITLE
http2: stream WSGI responses instead of buffering them

### DIFF
--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -185,8 +185,17 @@ def _make_early_hints_callback(req, sock, resp):
     return send_early_hints
 
 
-def create(req, sock, client, server, cfg):
-    resp = Response(req, sock, cfg)
+def create(req, sock, client, server, cfg, response_class=None,
+           response_args=()):
+    """Build the (response, environ) pair for a request.
+
+    ``response_class`` and ``response_args`` let a protocol supply its own
+    writer: HTTP/2 passes HTTP2Response so the body is framed as HTTP/2
+    instead of HTTP/1, while everything else here stays the same.
+    """
+    if response_class is None:
+        response_class = Response
+    resp = response_class(req, sock, cfg, *response_args)
 
     # set initial environ
     environ = default_environ(req, sock, cfg)
@@ -471,7 +480,15 @@ class Response:
             return
 
         self.sent += tosend
-        util.write(self.sock, arg, self.chunked)
+        self._emit_body(arg)
+
+    def _emit_body(self, data):
+        """Put body bytes on the wire.
+
+        The one place body framing happens, so a subclass can frame it
+        differently without reimplementing write()'s bookkeeping.
+        """
+        util.write(self.sock, data, self.chunked)
 
     def can_sendfile(self):
         return self.cfg.sendfile is not False

--- a/gunicorn/http2/connection.py
+++ b/gunicorn/http2/connection.py
@@ -9,6 +9,8 @@ HTTP/2 server connection implementation.
 Uses the hyper-h2 library for HTTP/2 protocol handling.
 """
 
+import collections
+import selectors
 from io import BytesIO
 
 from .errors import (
@@ -74,6 +76,10 @@ class HTTP2ServerConnection:
 
         # Active streams indexed by stream ID
         self.streams = {}
+        # Events pulled off the wire while blocked on a flow-control window.
+        # They have left the h2 state machine already, so they are held here
+        # for the main receive loop rather than discarded.
+        self._deferred_events = collections.deque()
 
         # Completed requests ready for processing
         self._pending_requests = []
@@ -173,8 +179,12 @@ class HTTP2ServerConnection:
             self.close(error_code=HTTP2ErrorCode.PROTOCOL_ERROR)
             raise HTTP2ProtocolError(str(e))
 
-        # Process events
+        # Process events, oldest first: anything set aside during a
+        # flow-control wait arrived before this batch.
         completed_requests = []
+        if self._deferred_events:
+            events = list(self._deferred_events) + list(events)
+            self._deferred_events.clear()
         for event in events:
             request = self._handle_event(event)
             if request is not None:
@@ -388,6 +398,55 @@ class HTTP2ServerConnection:
         self.h2_conn.send_headers(stream_id, response_headers, end_stream=False)
         self._send_pending_data()
 
+    def send_response_headers(self, stream_id, status, headers,
+                              end_stream=False):
+        """Send response headers on a stream without ending it.
+
+        Returns False if the stream is already gone. Split out of
+        send_response() so a response can be streamed: headers first, then
+        any number of data frames, then end_stream().
+        """
+        stream = self.streams.get(stream_id)
+        if stream is None:
+            # Stream was already cleaned up (reset/closed)
+            return False
+
+        # Build response headers with :status pseudo-header
+        response_headers = [(':status', str(status))]
+        for name, value in headers:
+            # HTTP/2 headers must be lowercase
+            response_headers.append((name.lower(), str(value)))
+
+        self.h2_conn.send_headers(stream_id, response_headers,
+                                  end_stream=end_stream)
+        stream.send_headers(response_headers, end_stream=end_stream)
+        self._send_pending_data()
+        return True
+
+    def end_stream(self, stream_id, trailers=None):
+        """Close the sending half of a stream, with trailers if given."""
+        if self.streams.get(stream_id) is None:
+            return False
+        if trailers:
+            self.send_trailers(stream_id, trailers)
+            return True
+        # Not send_data(): it chunks against the flow-control window and an
+        # empty payload skips that loop entirely, so END_STREAM would never
+        # reach the peer and the client would wait for a response that is
+        # already finished.
+        # Not send_data(): it chunks against the flow-control window and an
+        # empty payload skips that loop entirely, so END_STREAM would never
+        # reach the peer and the client would wait for a response that is
+        # already finished.
+        try:
+            self.h2_conn.send_data(stream_id, b"", end_stream=True)
+            self.streams[stream_id].send_data(b"", end_stream=True)
+            self._send_pending_data()
+        except _h2_exceptions.StreamClosedError:
+            self.cleanup_stream(stream_id)
+            return False
+        return True
+
     def send_response(self, stream_id, status, headers, body=None):
         """Send a response on a stream.
 
@@ -403,32 +462,20 @@ class HTTP2ServerConnection:
         Returns:
             bool: True if response sent, False if stream was already closed
         """
-        stream = self.streams.get(stream_id)
-        if stream is None:
-            # Stream was already cleaned up (reset/closed) - return gracefully
-            return False
-
-        # Build response headers with :status pseudo-header
-        response_headers = [(':status', str(status))]
-        for name, value in headers:
-            # HTTP/2 headers must be lowercase
-            response_headers.append((name.lower(), str(value)))
-
         end_stream = body is None or len(body) == 0
-
         try:
-            # Send headers
-            self.h2_conn.send_headers(stream_id, response_headers, end_stream=end_stream)
-            stream.send_headers(response_headers, end_stream=end_stream)
-            self._send_pending_data()
-
+            if not self.send_response_headers(stream_id, status, headers,
+                                              end_stream=end_stream):
+                return False
             # Send body if present
             if body and len(body) > 0:
                 self.send_data(stream_id, body, end_stream=True)
             return True
         except _h2_exceptions.StreamClosedError:
             # Stream was reset by client - clean up gracefully
-            stream.close()
+            stream = self.streams.get(stream_id)
+            if stream is not None:
+                stream.close()
             self.cleanup_stream(stream_id)
             return False
 
@@ -438,7 +485,6 @@ class HTTP2ServerConnection:
         Returns:
             int: Available window size, or -1 if waiting failed
         """
-        import selectors
 
         max_wait_attempts = 50  # ~5 seconds at 100ms per attempt
         try:
@@ -478,6 +524,12 @@ class HTTP2ServerConnection:
                             self._closed = True
                             result = -1
                             break
+                        else:
+                            # Anything else arriving alongside the
+                            # WINDOW_UPDATE belongs to the main loop. It has
+                            # already left the h2 state machine, so dropping
+                            # it here loses a request or its body for good.
+                            self._deferred_events.append(event)
                     else:
                         self._send_pending_data()
                         continue

--- a/gunicorn/http2/response.py
+++ b/gunicorn/http2/response.py
@@ -1,0 +1,59 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+"""WSGI response writer for HTTP/2 streams."""
+
+from gunicorn.http.wsgi import Response
+
+
+class HTTP2Response(Response):
+    """A WSGI Response that frames its output as HTTP/2 instead of HTTP/1.
+
+    Only the wire framing is overridden. Everything the WSGI protocol needs
+    (``start_response``, header processing, the no-body rules for HEAD, 1xx,
+    204 and 304, the Content-Length accounting in ``write()``) is inherited,
+    so HTTP/2 responses obey the same rules as HTTP/1 ones rather than a
+    parallel set that has to be kept in step by hand.
+    """
+
+    def __init__(self, req, sock, cfg, h2_conn, stream_id):
+        # sock is unused: every write goes through the HTTP/2 connection.
+        # The signature matches Response so wsgi.create() can build either.
+        super().__init__(req, sock, cfg)
+        self.h2_conn = h2_conn
+        self.stream_id = stream_id
+        self._stream_ended = False
+
+    def is_chunked(self):
+        # HTTP/2 has its own framing; chunked transfer coding is forbidden
+        # (RFC 9113 section 8.1).
+        return False
+
+    def can_sendfile(self):
+        # sendfile() writes raw bytes to a socket, which would bypass HTTP/2
+        # framing entirely. Base Response guards this with cfg.is_ssl, which
+        # happens to cover HTTP/2 over TLS but not over cleartext.
+        return False
+
+    def send_headers(self):
+        if self.headers_sent:
+            return
+        self.h2_conn.send_response_headers(
+            self.stream_id, self.status_code, self.headers, end_stream=False
+        )
+        self.headers_sent = True
+
+    def _emit_body(self, data):
+        if not data:
+            return
+        self.h2_conn.send_data(self.stream_id, data, end_stream=False)
+
+    def close(self):
+        if not self.headers_sent:
+            self.send_headers()
+        if self._stream_ended:
+            return
+        self._stream_ended = True
+        trailers = getattr(self, "trailers", None)
+        self.h2_conn.end_stream(self.stream_id, trailers=trailers)

--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -14,6 +14,7 @@ from gunicorn import util
 from gunicorn import sock as gunicorn_sock
 from gunicorn.http.errors import InvalidH2CPreface
 from gunicorn.http2 import negotiation
+from gunicorn.http2.response import HTTP2Response
 from gunicorn.workers import base
 
 ALREADY_HANDLED = object()
@@ -173,7 +174,13 @@ class AsyncWorker(base.Worker):
 
         try:
             self.cfg.pre_request(self, req)
-            resp, environ = wsgi.create(req, sock, addr, listener_name, self.cfg)
+            # The response frames itself as HTTP/2, so the body streams out
+            # instead of being collected first, and the no-body and sendfile
+            # rules come from Response unchanged.
+            resp, environ = wsgi.create(req, sock, addr, listener_name,
+                                        self.cfg,
+                                        response_class=HTTP2Response,
+                                        response_args=(h2_conn, stream_id))
             environ["wsgi.multithread"] = True
             environ["HTTP_VERSION"] = "2"
 
@@ -188,24 +195,14 @@ class AsyncWorker(base.Worker):
             if self.is_already_handled(respiter):
                 return
 
-            # Collect response body
-            response_body = b''
+            # Stream each chunk as the application produces it
             try:
-                if hasattr(respiter, '__iter__'):
-                    for item in respiter:
-                        if item:
-                            response_body += item
+                for item in respiter:
+                    resp.write(item)
+                resp.close()
             finally:
                 if hasattr(respiter, "close"):
                     respiter.close()
-
-            # Send response via HTTP/2
-            h2_conn.send_response(
-                stream_id,
-                resp.status_code,
-                resp.headers,
-                response_body
-            )
 
             request_time = datetime.now() - request_start
             self.log.access(resp, req, environ, request_time)

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -29,6 +29,7 @@ from .. import sock
 from ..http import wsgi
 from ..http.errors import InvalidH2CPreface
 from ..http2 import negotiation
+from ..http2.response import HTTP2Response
 
 
 # Sentinel value to indicate connection should be deferred back to poller
@@ -596,9 +597,13 @@ class ThreadWorker(base.Worker):
             self.cfg.pre_request(self, req)
             request_start = datetime.now()
 
-            # Create WSGI environ
+            # Create WSGI environ. The response frames itself as HTTP/2,
+            # so the body streams out instead of being collected first, and
+            # the no-body and sendfile rules come from Response unchanged.
             resp, environ = wsgi.create(req, conn.sock, conn.client,
-                                        conn.server, self.cfg)
+                                        conn.server, self.cfg,
+                                        response_class=HTTP2Response,
+                                        response_args=(h2_conn, stream_id))
             environ["wsgi.multithread"] = True
             environ["HTTP_VERSION"] = "2"  # Indicate HTTP/2
 
@@ -609,12 +614,9 @@ class ThreadWorker(base.Worker):
 
             environ["wsgi.early_hints"] = send_early_hints_h2
 
-            # Add HTTP/2 trailer support
-            pending_trailers = []
-
             def send_trailers_h2(trailers):
-                """Queue trailers to be sent after response body."""
-                pending_trailers.extend(trailers)
+                """Queue trailers to be sent when the stream ends."""
+                resp.trailers = list(trailers)
 
             environ["gunicorn.http2.send_trailers"] = send_trailers_h2
 
@@ -624,50 +626,15 @@ class ThreadWorker(base.Worker):
                     self.log.info("Autorestarting worker after current request.")
                     self.alive = False
 
-            # Run WSGI app
+            # Run WSGI app, streaming each chunk as it is produced
             respiter = self.wsgi(environ, resp.start_response)
-
-            # Collect response body
-            response_body = b''
             try:
-                if hasattr(respiter, '__iter__'):
-                    for item in respiter:
-                        if item:
-                            response_body += item
+                for item in respiter:
+                    resp.write(item)
+                resp.close()
             finally:
                 if hasattr(respiter, "close"):
                     respiter.close()
-
-            # Send response via HTTP/2
-            if pending_trailers:
-                # Send headers, body, then trailers separately
-                # Build response headers with :status pseudo-header
-                response_headers = [(':status', str(resp.status_code))]
-                for name, value in resp.headers:
-                    response_headers.append((name.lower(), str(value)))
-
-                # Send headers without ending stream
-                h2_conn.h2_conn.send_headers(stream_id, response_headers, end_stream=False)
-                stream = h2_conn.streams[stream_id]
-                stream.send_headers(response_headers, end_stream=False)
-                h2_conn._send_pending_data()
-
-                # Send body without ending stream
-                if response_body:
-                    h2_conn.h2_conn.send_data(stream_id, response_body, end_stream=False)
-                    stream.send_data(response_body, end_stream=False)
-                    h2_conn._send_pending_data()
-
-                # Send trailers (ends stream)
-                h2_conn.send_trailers(stream_id, pending_trailers)
-            else:
-                # No trailers, use standard response
-                h2_conn.send_response(
-                    stream_id,
-                    resp.status_code,
-                    resp.headers,
-                    response_body
-                )
 
             request_time = datetime.now() - request_start
             self.log.access(resp, req, environ, request_time)

--- a/tests/test_http2_connection.py
+++ b/tests/test_http2_connection.py
@@ -1200,3 +1200,92 @@ class TestHTTP2NotAvailable:
         # Test that HTTP2NotAvailable can be raised
         with pytest.raises(errors.HTTP2NotAvailable):
             raise errors.HTTP2NotAvailable()
+
+
+class TestDeferredFlowControlEvents:
+    """Events arriving during a flow-control wait must not be lost."""
+
+    def _conn(self):
+        from gunicorn.http2.connection import HTTP2ServerConnection
+        return HTTP2ServerConnection(MockConfig(), MockSocket(),
+                                     ('127.0.0.1', 12345))
+
+    def test_deferred_events_are_drained_by_receive_data(self):
+        conn = self._conn()
+        marker = mock.Mock(name="RequestReceived")
+        conn._deferred_events.append(marker)
+
+        seen = []
+        conn._handle_event = lambda e: seen.append(e) or None
+        conn.h2_conn = mock.Mock()
+        conn.h2_conn.receive_data.return_value = ["later"]
+        conn._send_pending_data = lambda: None
+
+        conn.receive_data(b"some bytes")
+
+        # the deferred event is processed, and before the new one
+        assert seen == [marker, "later"]
+        assert not conn._deferred_events
+
+    def test_queue_starts_empty(self):
+        assert not self._conn()._deferred_events
+
+    def test_events_during_a_window_wait_are_captured(self):
+        """The real bug: events read while blocked must not be discarded."""
+        import socket as _socket
+        from gunicorn.http2.connection import HTTP2ServerConnection
+
+        server, client = _socket.socketpair()
+        try:
+            conn = HTTP2ServerConnection(MockConfig(), server,
+                                         ('127.0.0.1', 12345))
+            # a request arriving alongside the WINDOW_UPDATE we are waiting on
+            arriving = mock.Mock(name="RequestReceived")
+            windows = iter([0, 65535])
+            conn.h2_conn = mock.Mock()
+            conn.h2_conn.local_flow_control_window.side_effect = \
+                lambda sid: next(windows)
+            conn.h2_conn.receive_data.return_value = [arriving]
+            conn._send_pending_data = lambda: None
+
+            client.sendall(b"frame bytes")
+            conn._wait_for_flow_control_window(1)
+
+            assert list(conn._deferred_events) == [arriving], \
+                "event read during the wait was dropped"
+        finally:
+            server.close()
+            client.close()
+
+
+class TestEndStream:
+    """Ending a stream must actually put END_STREAM on the wire."""
+
+    def _conn(self):
+        from gunicorn.http2.connection import HTTP2ServerConnection
+        conn = HTTP2ServerConnection(MockConfig(), MockSocket(),
+                                     ('127.0.0.1', 12345))
+        conn.h2_conn = mock.Mock()
+        conn.streams[1] = mock.Mock()
+        conn._send_pending_data = lambda: None
+        return conn
+
+    def test_end_stream_sets_the_flag(self):
+        # Regression: routing this through send_data() sent nothing, because
+        # send_data loops on the payload and an empty one skips the loop. The
+        # client then waited forever for a response that had already finished.
+        conn = self._conn()
+        conn.end_stream(1)
+        conn.h2_conn.send_data.assert_called_once()
+        assert conn.h2_conn.send_data.call_args.kwargs["end_stream"] is True
+
+    def test_end_stream_with_trailers_sends_trailers(self):
+        conn = self._conn()
+        conn.send_trailers = mock.Mock()
+        conn.end_stream(1, trailers=[("x-sum", "1")])
+        conn.send_trailers.assert_called_once_with(1, [("x-sum", "1")])
+        conn.h2_conn.send_data.assert_not_called()
+
+    def test_end_stream_on_unknown_stream(self):
+        conn = self._conn()
+        assert conn.end_stream(999) is False

--- a/tests/test_http2_response.py
+++ b/tests/test_http2_response.py
@@ -1,0 +1,116 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+"""Tests for the HTTP/2 WSGI response writer."""
+
+from unittest import mock
+
+import pytest
+
+from gunicorn.config import Config
+from gunicorn.http2.response import HTTP2Response
+
+
+def make_response(method="GET", status="200 OK", headers=None, cfg=None):
+    req = mock.Mock()
+    req.method = method
+    req.version = (2, 0)
+    conn = mock.Mock()
+    resp = HTTP2Response(req, None, cfg or Config(), conn, 1)
+    resp.start_response(status, headers or [("Content-Type", "text/plain")])
+    return resp, conn
+
+
+def sent_data(conn):
+    return [c.args[1] for c in conn.send_data.call_args_list]
+
+
+class TestStreaming:
+    """Bodies go out as they are produced, not collected first."""
+
+    def test_each_write_is_its_own_frame(self):
+        resp, conn = make_response()
+        resp.write(b"one")
+        resp.write(b"two")
+        resp.write(b"three")
+        assert sent_data(conn) == [b"one", b"two", b"three"]
+
+    def test_headers_sent_once_before_the_first_frame(self):
+        resp, conn = make_response()
+        resp.write(b"a")
+        resp.write(b"b")
+        assert conn.send_response_headers.call_count == 1
+
+    def test_close_ends_the_stream(self):
+        resp, conn = make_response()
+        resp.write(b"a")
+        resp.close()
+        assert conn.end_stream.call_count == 1
+
+    def test_close_is_idempotent(self):
+        resp, conn = make_response()
+        resp.close()
+        resp.close()
+        assert conn.end_stream.call_count == 1
+
+    def test_empty_writes_send_no_frame(self):
+        resp, conn = make_response()
+        resp.write(b"")
+        assert sent_data(conn) == []
+
+
+class TestNoBodyFraming:
+    """HEAD, 204 and 304 carry no body over HTTP/2 either."""
+
+    @pytest.mark.parametrize("method,status", [
+        ("HEAD", "200 OK"),
+        ("GET", "204 No Content"),
+        ("GET", "304 Not Modified"),
+    ])
+    def test_body_is_dropped(self, method, status):
+        resp, conn = make_response(method=method, status=status)
+        resp.write(b"should not be sent")
+        resp.close()
+        assert sent_data(conn) == []
+
+    def test_ordinary_response_still_sends_its_body(self):
+        resp, conn = make_response()
+        resp.write(b"sent")
+        resp.close()
+        assert sent_data(conn) == [b"sent"]
+
+
+class TestFramingRules:
+    def test_never_chunked(self):
+        # chunked transfer coding is forbidden on HTTP/2 (RFC 9113 8.1)
+        resp, _ = make_response()
+        assert resp.is_chunked() is False
+        assert resp.chunked is False
+
+    def test_never_sendfile(self):
+        # raw file bytes would bypass HTTP/2 framing. The base class guards
+        # this with cfg.is_ssl, which does not hold for cleartext HTTP/2.
+        resp, _ = make_response()
+        assert resp.can_sendfile() is False
+
+    def test_sendfile_declines_even_when_enabled(self):
+        cfg = Config()
+        cfg.set("sendfile", True)
+        resp, _ = make_response(cfg=cfg)
+        assert resp.can_sendfile() is False
+
+
+class TestTrailers:
+    def test_trailers_passed_to_end_stream(self):
+        resp, conn = make_response()
+        resp.trailers = [("x-checksum", "abc")]
+        resp.write(b"body")
+        resp.close()
+        assert conn.end_stream.call_args.kwargs["trailers"] == [
+            ("x-checksum", "abc")]
+
+    def test_no_trailers_by_default(self):
+        resp, conn = make_response()
+        resp.close()
+        assert conn.end_stream.call_args.kwargs["trailers"] is None


### PR DESCRIPTION
Part of #3489.

Both WSGI workers collected the whole response body in memory before sending
anything. They write through an `HTTP2Response` now, a `Response` subclass that
overrides only the wire framing.

Subclassing is the point: HEAD, 204 and 304 stop carrying a body over HTTP/2 and
`sendfile()` is refused, because those rules already live in `Response` and are
inherited rather than written a second time.

Two bugs found on the way. Events read while waiting on a flow-control window
were thrown away, losing a request or its body. And ending a stream went through
`send_data()`, which skips an empty payload, so END_STREAM never reached the
peer: an 8MB response hung until the client gave up. It is 12ms now.

## Breaking changes

Both align HTTP/2 with HTTP/1:

- HEAD, 204 and 304 no longer send a body over HTTP/2. Relying on it was already
  against RFC 9110, and HTTP/1 always dropped it.
- `sendfile()` no longer applies to HTTP/2. It could not work over cleartext, and
  over TLS it was already disabled.
