### PR TITLE
http2: no-body framing and flow control on the ASGI worker

### DIFF
--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -1636,6 +1636,8 @@ class ASGIProtocol(asyncio.Protocol):
         response_started = False
         response_complete = False
         headers_sent = False
+        omits_body = False
+        omits_body_warned = False
         exc_to_raise = None
         response_status = 500
         response_headers = []
@@ -1690,6 +1692,7 @@ class ASGIProtocol(asyncio.Protocol):
         async def send(message):
             nonlocal response_started, response_complete, headers_sent
             nonlocal response_status, response_headers, response_sent, exc_to_raise
+            nonlocal omits_body, omits_body_warned
 
             msg_type = message["type"]
 
@@ -1707,6 +1710,10 @@ class ASGIProtocol(asyncio.Protocol):
                     return
                 response_started = True
                 response_status = message["status"]
+                # RFC 9110: HEAD, 1xx, 204 and 304 carry no body. The HTTP/1
+                # handler has always applied this; HTTP/2 did not.
+                omits_body = self._response_omits_body(
+                    request.method, response_status)
                 response_headers = message.get("headers", [])
                 # Don't send headers yet - wait for first body chunk
 
@@ -1720,6 +1727,16 @@ class ASGIProtocol(asyncio.Protocol):
 
                 body = message.get("body", b"")
                 more_body = message.get("more_body", False)
+
+                if omits_body:
+                    if body and not omits_body_warned:
+                        self.log.warning(
+                            "ASGI app sent body bytes on a no-body response "
+                            "(method=%s status=%s); dropping per RFC 9110.",
+                            request.method, response_status,
+                        )
+                        omits_body_warned = True
+                    body = b""
 
                 # Send headers with first body chunk
                 if not headers_sent:

--- a/gunicorn/http2/async_connection.py
+++ b/gunicorn/http2/async_connection.py
@@ -11,6 +11,7 @@ asyncio for non-blocking I/O.
 """
 
 import asyncio
+import collections
 
 from .errors import (
     HTTP2Error, HTTP2ProtocolError, HTTP2ConnectionError,
@@ -76,6 +77,10 @@ class AsyncHTTP2Connection:
 
         # Active streams indexed by stream ID
         self.streams = {}
+        # Events pulled off the wire while blocked on a flow-control window.
+        # They have left the h2 state machine already, so they are held here
+        # for the main receive loop rather than discarded.
+        self._deferred_events = collections.deque()
 
         # Queue of completed requests for the worker
         self._request_queue = asyncio.Queue()
@@ -179,8 +184,12 @@ class AsyncHTTP2Connection:
             await self.close(error_code=HTTP2ErrorCode.PROTOCOL_ERROR)
             raise HTTP2ProtocolError(str(e))
 
-        # Process events
+        # Process events, oldest first: anything set aside during a
+        # flow-control wait arrived before this batch.
         completed_requests = []
+        if self._deferred_events:
+            events = list(self._deferred_events) + list(events)
+            self._deferred_events.clear()
         for event in events:
             request = self._handle_event(event)
             if request is not None:
@@ -425,6 +434,12 @@ class AsyncHTTP2Connection:
                         elif isinstance(event, _h2_events.ConnectionTerminated):
                             self._closed = True
                             return -1
+                        else:
+                            # Anything else arriving alongside the
+                            # WINDOW_UPDATE belongs to the main loop. It has
+                            # already left the h2 state machine, so dropping
+                            # it here loses a request or its body for good.
+                            self._deferred_events.append(event)
                     await self._send_pending_data()
                 else:
                     # Connection closed

--- a/tests/test_asgi_http2_response.py
+++ b/tests/test_asgi_http2_response.py
@@ -1,0 +1,98 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+"""Tests for the ASGI worker's HTTP/2 response path.
+
+This path had no coverage: a change that made every HTTP/2 request return
+500 still left the whole suite green.
+"""
+
+from unittest import mock
+
+import pytest
+
+from gunicorn.config import Config
+from gunicorn.asgi.protocol import ASGIProtocol
+
+
+def make_protocol(app):
+    worker = mock.Mock()
+    worker.cfg = Config()
+    worker.log = mock.Mock()
+    worker.nr_conns = 0
+    # ASGIProtocol captures worker.asgi at construction, so the app has to be
+    # in place first or it calls a Mock and every request 500s.
+    worker.asgi = app
+    proto = ASGIProtocol(worker)
+    proto.transport = mock.Mock()
+    return proto, worker
+
+
+def make_request():
+    req = mock.Mock()
+    req.method = "GET"
+    req.stream.stream_id = 1
+    req.path = "/"
+    req.query = ""
+    req.headers = []
+    req.version = (2, 0)
+    req.raw_path = b"/"
+    req.scheme = "http"
+    req.body = None
+    return req
+
+
+async def run_app(app, method="GET"):
+    """Drive _handle_http2_request and report what reached the wire."""
+    proto, worker = make_protocol(app)
+    h2 = mock.AsyncMock()
+    h2.streams = {1: mock.Mock()}
+    h2.h2_conn = mock.Mock()
+    req = make_request()
+    req.method = method
+    await proto._handle_http2_request(
+        req, h2, ("127.0.0.1", 8000), ("127.0.0.1", 1))
+    assert not worker.log.exception.called, (
+        "handler raised; a 500 must not be mistaken for a dropped body")
+    payloads = [c.args[1] for c in h2.send_data.call_args_list]
+    return payloads, worker
+
+
+def responder(status):
+    async def app(scope, receive, send):
+        await send({"type": "http.response.start", "status": status,
+                    "headers": [(b"content-type", b"text/plain")]})
+        await send({"type": "http.response.body", "body": b"BODY"})
+    return app
+
+
+class TestASGIHTTP2Response:
+    @pytest.mark.asyncio
+    async def test_ordinary_response_sends_its_body(self):
+        payloads, _ = await run_app(responder(200))
+        assert b"BODY" in payloads
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [204, 304])
+    async def test_no_body_status_drops_the_body(self, status):
+        payloads, _ = await run_app(responder(status))
+        assert b"BODY" not in payloads
+
+    @pytest.mark.asyncio
+    async def test_head_drops_the_body(self):
+        payloads, _ = await run_app(responder(200), method="HEAD")
+        assert b"BODY" not in payloads
+
+    @pytest.mark.asyncio
+    async def test_dropping_the_body_is_logged_once(self):
+        _, worker = await run_app(responder(204))
+        warnings = [c for c in worker.log.warning.call_args_list
+                    if "no-body response" in str(c)]
+        assert len(warnings) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_warning_for_an_ordinary_response(self):
+        _, worker = await run_app(responder(200))
+        assert not [c for c in worker.log.warning.call_args_list
+                    if "no-body response" in str(c)]

--- a/tests/test_http2_async_connection.py
+++ b/tests/test_http2_async_connection.py
@@ -1021,3 +1021,35 @@ class TestAsyncHTTP2ProtocolErrorHandling:
         assert len(sent_data) > 0
         # Connection should be marked as closed
         assert conn.is_closed is True
+
+
+class TestAsyncDeferredFlowControlEvents:
+    """Events read while waiting on a window must reach the main loop."""
+
+    def _conn(self):
+        from gunicorn.http2.async_connection import AsyncHTTP2Connection
+        return AsyncHTTP2Connection(MockConfig(), MockAsyncReader(),
+                                    MockAsyncWriter(), ('127.0.0.1', 12345))
+
+    def test_queue_starts_empty(self):
+        assert not self._conn()._deferred_events
+
+    @pytest.mark.asyncio
+    async def test_events_during_a_window_wait_are_captured(self):
+        conn = self._conn()
+        arriving = mock.Mock(name="RequestReceived")
+        windows = iter([0, 0, 65535])
+        conn.h2_conn = mock.Mock()
+        conn.h2_conn.local_flow_control_window.side_effect = \
+            lambda sid: next(windows)
+        conn.h2_conn.receive_data.return_value = [arriving]
+        conn.reader = MockAsyncReader(b"frame bytes")
+
+        async def noop():
+            return None
+        conn._send_pending_data = noop
+
+        await conn._wait_for_flow_control_window(1)
+
+        assert list(conn._deferred_events) == [arriving], \
+            "event read during the wait was dropped"


### PR DESCRIPTION
The ASGI HTTP/2 handler sent whatever the application produced, so HEAD, 204 and
304 carried a body over HTTP/2 while the HTTP/1 handler next to it had always
dropped it. Same rule now, same warning.

Events read while blocked on a flow-control window were discarded in the async
connection as well, so it gets the same fix as the sync one.

This path was added in earlier commits without any test. A 500 on every HTTP/2
request went through that gap while writing this, and is fixed here. Tests added
so it cannot happen again.

## Breaking changes

HEAD, 204 and 304 no longer send a body over HTTP/2 on the ASGI worker. Relying
on it was already against RFC 9110, and both the HTTP/1 path and the WSGI workers
already dropped it.
