### PR TITLE
http2: Upgrade: h2c on every worker, and docs for the HTTP/2 work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ nohup.out
 setuptools-*
 site/
 docs/site/
+tests/docker/*/results/

--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -9,7 +9,9 @@
   `upgrade`, `both` or `off` (the default). With `prior-knowledge`, a connection
   opening with the HTTP/2 preface is served as HTTP/2 on the gthread, gevent and
   ASGI workers, which is what a TLS-terminating proxy in front of gunicorn needs
-  to avoid dropping to HTTP/1.1 upstream. Only peers in `forwarded_allow_ips` are
+  to avoid dropping to HTTP/1.1 upstream. `upgrade` honours an HTTP/1.1
+  `Upgrade: h2c` request on the gthread and gevent workers; the ASGI worker
+  accepts prior knowledge only. Only peers in `forwarded_allow_ips` are
   considered; anything else from such a peer is refused with 400 rather than
   silently downgraded. Each mechanism is enabled separately, so turning one on
   does not turn the other on

--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -1,6 +1,63 @@
 <span id="news-2026"></span>
 # Changelog - 2026
 
+## Unreleased
+
+### New Features
+
+- **Cleartext HTTP/2 (h2c)**: `http2_cleartext` accepts `prior-knowledge`,
+  `upgrade`, `both` or `off` (the default). With `prior-knowledge`, a connection
+  opening with the HTTP/2 preface is served as HTTP/2 on the gthread, gevent and
+  ASGI workers, which is what a TLS-terminating proxy in front of gunicorn needs
+  to avoid dropping to HTTP/1.1 upstream. Only peers in `forwarded_allow_ips` are
+  considered; anything else from such a peer is refused with 400 rather than
+  silently downgraded. Each mechanism is enabled separately, so turning one on
+  does not turn the other on
+  ([#3489](https://github.com/benoitc/gunicorn/issues/3489),
+  [#3663](https://github.com/benoitc/gunicorn/pull/3663)).
+
+### Security
+
+- **HTTP/2 bypassed the header policy**: `HTTP2Request` built its headers
+  straight from the stream, so nothing the HTTP/1 path enforces applied over
+  HTTP/2: the underscore and `header_map` policy, duplicate `Host` and
+  `Content-Type`, control characters in values, and the `forwarded_allow_ips`
+  trust gate. An untrusted client could set `SCRIPT_NAME` and forge `HTTP_*`
+  entries in the WSGI environ, and decide `wsgi.url_scheme` through `:scheme`.
+  The policy now lives on a mixin both request classes share, and the scheme is
+  derived from the transport
+  ([#3705](https://github.com/benoitc/gunicorn/pull/3705)).
+
+### Bug Fixes
+
+- **WSGI HTTP/2 responses were buffered whole**: both WSGI workers collected the
+  entire body in memory before sending anything. They write through an
+  `HTTP2Response` now, so the body leaves as it is produced
+  ([#3709](https://github.com/benoitc/gunicorn/pull/3709)).
+
+- **No-body responses carried a body over HTTP/2**: HEAD, 204 and 304 sent
+  application body bytes on all three workers, while the HTTP/1 path had always
+  dropped them per RFC 9110. They no longer do
+  ([#3709](https://github.com/benoitc/gunicorn/pull/3709),
+  [#3710](https://github.com/benoitc/gunicorn/pull/3710)).
+
+- **Events lost during flow-control waits**: while blocked waiting for a
+  WINDOW_UPDATE, both HTTP/2 connections read from the socket and discarded
+  every event that was not a stream reset or connection termination, losing
+  requests and body data outright. They are queued for the main loop now
+  ([#3709](https://github.com/benoitc/gunicorn/pull/3709),
+  [#3710](https://github.com/benoitc/gunicorn/pull/3710)).
+
+- **`sendfile()` on HTTP/2**: it was guarded by `cfg.is_ssl`, which covered
+  HTTP/2 only for as long as HTTP/2 implied TLS. It is refused on HTTP/2
+  responses directly, so cleartext cannot bypass HTTP/2 framing
+  ([#3709](https://github.com/benoitc/gunicorn/pull/3709)).
+
+### Changes
+
+- **Fast HTTP Parser**: require `gunicorn_h1c >= 0.6.8`, which adds
+  `remaining()` for recovering bytes pipelined behind a completed message.
+
 ## 26.1.0 - 2026-08-18
 
 ### New Features

--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -56,8 +56,11 @@
 
 ### Changes
 
-- **Fast HTTP Parser**: require `gunicorn_h1c >= 0.6.8`, which adds
-  `remaining()` for recovering bytes pipelined behind a completed message.
+- **Fast HTTP Parser**: require `gunicorn_h1c >= 0.6.9`, which adds
+  `remaining()` for recovering bytes pipelined behind a completed message, and
+  stops an `Upgrade` header from suppressing body parsing. That second one was
+  losing the request body of any upgrade request on the ASGI worker, HTTP/2 or
+  not.
 
 ## 26.1.0 - 2026-08-18
 

--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -7,11 +7,10 @@
 
 - **Cleartext HTTP/2 (h2c)**: `http2_cleartext` accepts `prior-knowledge`,
   `upgrade`, `both` or `off` (the default). With `prior-knowledge`, a connection
-  opening with the HTTP/2 preface is served as HTTP/2 on the gthread, gevent and
-  ASGI workers, which is what a TLS-terminating proxy in front of gunicorn needs
-  to avoid dropping to HTTP/1.1 upstream. `upgrade` honours an HTTP/1.1
-  `Upgrade: h2c` request on the gthread and gevent workers; the ASGI worker
-  accepts prior knowledge only. Only peers in `forwarded_allow_ips` are
+  opening with the HTTP/2 preface is served as HTTP/2, which is what a
+  TLS-terminating proxy in front of gunicorn needs to avoid dropping to HTTP/1.1
+  upstream. `upgrade` honours an HTTP/1.1 `Upgrade: h2c` request. Both work on
+  the gthread, gevent and ASGI workers. Only peers in `forwarded_allow_ips` are
   considered; anything else from such a peer is refused with 400 rather than
   silently downgraded. Each mechanism is enabled separately, so turning one on
   does not turn the other on

--- a/docs/content/guides/http2.md
+++ b/docs/content/guides/http2.md
@@ -106,11 +106,11 @@ preface) is rejected with a 400 rather than silently downgraded, so a
 misconfigured proxy fails loudly instead of quietly losing HTTP/2.
 Untrusted peers are served HTTP/1.1 exactly as if the flag were off.
 
-`Upgrade: h2c` is served by the `gthread` and `gevent` workers; the
-`asgi` worker accepts prior knowledge only. Note that with
-`prior-knowledge` alone a trusted peer sending anything else is refused
-with 400, while with `upgrade` or `both` an ordinary HTTP/1 request is
-served normally, because that is how an upgrade starts.
+Both mechanisms are served by the `gthread`, `gevent` and `asgi`
+workers. Note that with `prior-knowledge` alone a trusted peer sending
+anything else is refused with 400, while with `upgrade` or `both` an
+ordinary HTTP/1 request is served normally, because that is how an
+upgrade starts.
 
 Streams on an HTTP/2 connection are handled one after another, not
 concurrently, so a slow handler holds up the other streams on that

--- a/docs/content/guides/http2.md
+++ b/docs/content/guides/http2.md
@@ -85,7 +85,8 @@ http_protocols = "h2, h1"
 
 When TLS is terminated in front of Gunicorn - Cloud Run, fly.io, a
 service-mesh sidecar - the proxy can speak HTTP/2 to the upstream over
-plain TCP. Enable it with `--http2-cleartext` (gthread worker):
+plain TCP. Enable it with `--http2-cleartext`, on the `gthread`, `gevent`
+or `asgi` worker:
 
 ```bash
 gunicorn myapp:app -k gthread --http-protocols h2,h1 \
@@ -105,9 +106,19 @@ preface) is rejected with a 400 rather than silently downgraded, so a
 misconfigured proxy fails loudly instead of quietly losing HTTP/2.
 Untrusted peers are served HTTP/1.1 exactly as if the flag were off.
 
+Only the RFC 9113 prior-knowledge mechanism is implemented so far.
+Setting `upgrade` or `both` is accepted by the configuration but the
+`Upgrade: h2c` handshake is not honoured yet.
+
 Streams on an HTTP/2 connection are handled one after another, not
 concurrently, so a slow handler holds up the other streams on that
-connection.
+connection. Response bodies are streamed as the application produces
+them rather than collected first, so a large response does not sit in
+worker memory.
+
+As on HTTP/1, responses that cannot carry a body (HEAD, 1xx, 204, 304)
+send none, and `sendfile()` does not apply to HTTP/2 responses: raw file
+bytes would bypass HTTP/2 framing.
 
 Test prior knowledge with:
 

--- a/docs/content/guides/http2.md
+++ b/docs/content/guides/http2.md
@@ -106,9 +106,11 @@ preface) is rejected with a 400 rather than silently downgraded, so a
 misconfigured proxy fails loudly instead of quietly losing HTTP/2.
 Untrusted peers are served HTTP/1.1 exactly as if the flag were off.
 
-Only the RFC 9113 prior-knowledge mechanism is implemented so far.
-Setting `upgrade` or `both` is accepted by the configuration but the
-`Upgrade: h2c` handshake is not honoured yet.
+`Upgrade: h2c` is served by the `gthread` and `gevent` workers; the
+`asgi` worker accepts prior knowledge only. Note that with
+`prior-knowledge` alone a trusted peer sending anything else is refused
+with 400, while with `upgrade` or `both` an ordinary HTTP/1 request is
+served normally, because that is how an upgrade starts.
 
 Streams on an HTTP/2 connection are handled one after another, not
 concurrently, so a slow handler holds up the other streams on that

--- a/docs/content/reference/settings.md
+++ b/docs/content/reference/settings.md
@@ -439,6 +439,10 @@ Valid values are:
 The mechanisms are listed separately on purpose: enabling one does not
 enable the other.
 
+Only ``prior-knowledge`` is implemented so far. ``upgrade`` and
+``both`` are accepted, but the ``Upgrade: h2c`` handshake is not
+honoured yet and those connections stay on HTTP/1.1.
+
 Only peers in [forwarded-allow-ips](#forwarded_allow_ips) are considered. Everyone else
 is served HTTP/1.x exactly as if this were ``off``. Anything else from
 a trusted peer on a prior-knowledge port (an HTTP/1.x request, a

--- a/docs/content/reference/settings.md
+++ b/docs/content/reference/settings.md
@@ -439,10 +439,6 @@ Valid values are:
 The mechanisms are listed separately on purpose: enabling one does not
 enable the other.
 
-``upgrade`` is served by the gthread and gevent workers. The ASGI
-worker accepts prior knowledge only; an upgrade request there stays
-on HTTP/1.1.
-
 With ``prior-knowledge`` alone, a trusted peer that does not send the
 preface is refused with 400, since it is expected to speak HTTP/2.
 With ``upgrade`` or ``both`` an HTTP/1 request is how an upgrade

--- a/docs/content/reference/settings.md
+++ b/docs/content/reference/settings.md
@@ -439,9 +439,14 @@ Valid values are:
 The mechanisms are listed separately on purpose: enabling one does not
 enable the other.
 
-Only ``prior-knowledge`` is implemented so far. ``upgrade`` and
-``both`` are accepted, but the ``Upgrade: h2c`` handshake is not
-honoured yet and those connections stay on HTTP/1.1.
+``upgrade`` is served by the gthread and gevent workers. The ASGI
+worker accepts prior knowledge only; an upgrade request there stays
+on HTTP/1.1.
+
+With ``prior-knowledge`` alone, a trusted peer that does not send the
+preface is refused with 400, since it is expected to speak HTTP/2.
+With ``upgrade`` or ``both`` an HTTP/1 request is how an upgrade
+begins, so it is served normally.
 
 Only peers in [forwarded-allow-ips](#forwarded_allow_ips) are considered. Everyone else
 is served HTTP/1.x exactly as if this were ``off``. Anything else from

--- a/gunicorn/asgi/parser.py
+++ b/gunicorn/asgi/parser.py
@@ -231,6 +231,23 @@ class PythonProtocol:
             else:
                 break
 
+    def remaining(self):
+        """Bytes fed after the completed message (b'' if none or not complete).
+
+        Matches the accessor H1CProtocol gained in 0.6.8, so a caller does not
+        have to know which parser it holds. Nothing extra is buffered here:
+        feed() leaves the state loop once the message completes, and both the
+        content-length and chunked paths delete what they consume.
+        """
+        if not self.is_complete:
+            return b''
+        return bytes(self._buffer)
+
+    @property
+    def remaining_truncated(self):
+        """Always False: this parser keeps the whole tail, uncapped."""
+        return False
+
     @property
     def proxy_protocol_info(self):
         """Return proxy protocol info if parsed."""

--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -456,7 +456,7 @@ class ASGIProtocol(asyncio.Protocol):
         peername = self.transport.get_extra_info('peername')
         # Decided once per connection: upgrade needs a parser that can hand
         # back the bytes pipelined behind the request, which gunicorn_h1c
-        # gained in 0.6.8. The pip floor is not enforced at runtime, so an
+        # gained in 0.6.9. The pip floor is not enforced at runtime, so an
         # older parser means no upgrade rather than silently dropped frames.
         self._h2c_upgrade_ok = (
             negotiation.upgrade_allowed(self.cfg, peername)
@@ -591,11 +591,7 @@ class ASGIProtocol(asyncio.Protocol):
         # Create body receiver for this request
         self._body_receiver = BodyReceiver(self._current_request, self)
 
-        if self._h2c_upgrade_ok and not self._current_request.chunked:
-            # Chunked is excluded: the fast parser hands an upgrade request's
-            # payload back still chunk-encoded, mixed into the bytes that
-            # follow it, with no framing left to tell them apart. Such a
-            # request is served over HTTP/1.1 instead.
+        if self._h2c_upgrade_ok:
             self._h2c_upgrade_settings = negotiation.upgrade_settings(
                 self._current_request)
             if self._h2c_upgrade_settings is not None:
@@ -780,21 +776,6 @@ class ASGIProtocol(asyncio.Protocol):
             self._request_ready.set()
             return False
         pending = parser.remaining()
-
-        # The two parsers disagree about where an upgrade request's payload
-        # goes: the Python one delivers it through _on_body, the fast one
-        # stops at the end of the headers and leaves it at the front of the
-        # tail. Take whatever is missing off that front so both end up here.
-        missing = (self._current_request.content_length or 0) - len(
-            self._h2c_upgrade_body)
-        if missing > 0:
-            if len(pending) < missing:
-                # Still arriving. remaining() accumulates across feeds, so
-                # nothing is consumed until the whole payload is in.
-                return True
-            self._h2c_upgrade_body += pending[:missing]
-            pending = pending[missing:]
-
         self._callback_parser = None
         self.reader = asyncio.StreamReader()
         if pending:

--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -683,10 +683,15 @@ class ASGIProtocol(asyncio.Protocol):
         if state is negotiation.MATCH:
             self._h2c_start(buffered)
             return
-        # A trusted peer on a prior-knowledge port must speak HTTP/2.
-        # Anything else is refused rather than silently downgraded.
-        self._send_error_response(400, "Invalid HTTP/2 connection preface")
-        self._close_transport()
+        if negotiation.mismatch_is_error(self.cfg):
+            # A trusted peer on a prior-knowledge-only port must speak
+            # HTTP/2. Anything else is refused rather than downgraded.
+            self._send_error_response(400, "Invalid HTTP/2 connection preface")
+            self._close_transport()
+            return
+        # Upgrade is enabled too, so this may be the HTTP/1 request that
+        # carries it; carry on with the bytes preserved.
+        self._start_http1(buffered)
 
     def _h2c_start(self, buffered):
         """Commit to HTTP/2 and replay the bytes read while undecided."""
@@ -698,11 +703,20 @@ class ASGIProtocol(asyncio.Protocol):
         self.reader.feed_data(buffered)
 
     def _h2c_undecided_timeout(self):
-        """A client that stalls mid-preface is refused, not downgraded."""
+        """Nothing conclusive arrived in time.
+
+        With prior knowledge alone the peer is expected to speak HTTP/2, so
+        stalling mid-preface is refused rather than downgraded. Where an
+        upgrade is also on offer, a quiet client is just a quiet client and
+        the ordinary HTTP/1 timeouts apply.
+        """
         self._h2c_timer = None
         if self._h2c_buffer is None:
             return
-        self._h2c_buffer = None
+        buffered, self._h2c_buffer = self._h2c_buffer, None
+        if not negotiation.mismatch_is_error(self.cfg):
+            self._start_http1(buffered)
+            return
         self._send_error_response(400, "Invalid HTTP/2 connection preface")
         self._close_transport()
 

--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -364,6 +364,11 @@ class ASGIProtocol(asyncio.Protocol):
         # connection preface, before either protocol has been committed to.
         self._h2c_buffer = None
         self._h2c_timer = None
+        # Upgrade: h2c. ``_h2c_upgrade_ok`` is the per-connection decision;
+        # the other two are per-request and only set once one is under way.
+        self._h2c_upgrade_ok = False
+        self._h2c_upgrade_settings = None
+        self._h2c_upgrade_body = None
         self.writer = None
         self._task = None
         self.req_count = 0
@@ -438,11 +443,28 @@ class ASGIProtocol(asyncio.Protocol):
         # Setup flow control for HTTP/1.x
         self._flow_control = FlowControl(transport)
         transport.set_write_buffer_limits(high=HIGH_WATER_LIMIT)
+        self._start_http1()
 
-        # Setup callback parser with request ready event
+    def _start_http1(self, buffered=b""):
+        """Commit to HTTP/1.x and replay anything already read.
+
+        Called straight from connection_made(), and again when h2c sniffing
+        gives up on a connection that turned out to speak HTTP/1 after all.
+        """
         self._request_ready = asyncio.Event()
         self._setup_callback_parser()
+        peername = self.transport.get_extra_info('peername')
+        # Decided once per connection: upgrade needs a parser that can hand
+        # back the bytes pipelined behind the request, which gunicorn_h1c
+        # gained in 0.6.8. The pip floor is not enforced at runtime, so an
+        # older parser means no upgrade rather than silently dropped frames.
+        self._h2c_upgrade_ok = (
+            negotiation.upgrade_allowed(self.cfg, peername)
+            and hasattr(self._callback_parser, 'remaining')
+        )
         self._task = self.worker.loop.create_task(self._handle_connection())
+        if buffered:
+            self._feed_callback_parser(buffered)
 
     @classmethod
     def _check_h1c_protocol_available(cls):
@@ -569,6 +591,20 @@ class ASGIProtocol(asyncio.Protocol):
         # Create body receiver for this request
         self._body_receiver = BodyReceiver(self._current_request, self)
 
+        if self._h2c_upgrade_ok and not self._current_request.chunked:
+            # Chunked is excluded: the fast parser hands an upgrade request's
+            # payload back still chunk-encoded, mixed into the bytes that
+            # follow it, with no framing left to tell them apart. Such a
+            # request is served over HTTP/1.1 instead.
+            self._h2c_upgrade_settings = negotiation.upgrade_settings(
+                self._current_request)
+            if self._h2c_upgrade_settings is not None:
+                # Hold the request back until the message is complete and the
+                # bytes behind it have been recovered. Waking the connection
+                # loop now would let it answer over HTTP/1 mid-upgrade.
+                self._h2c_upgrade_body = bytearray()
+                return False
+
         # Signal that request is ready for processing
         if self._request_ready:
             self._request_ready.set()
@@ -578,6 +614,12 @@ class ASGIProtocol(asyncio.Protocol):
 
     def _on_body(self, chunk):
         """Callback: received body data chunk."""
+        if self._h2c_upgrade_body is not None:
+            # RFC 7540 section 3.2 allows a payload on the upgrade request.
+            # It becomes the body of stream 1, so it is kept here instead of
+            # going to a receiver no ASGI app will ever read from.
+            self._h2c_upgrade_body += chunk
+            return
         if self._body_receiver:
             self._body_receiver.feed(chunk)
 
@@ -676,6 +718,8 @@ class ASGIProtocol(asyncio.Protocol):
         """
         try:
             self._callback_parser.feed(data)
+            if self._h2c_upgrade_settings is not None:
+                return self._h2c_arm_upgrade()
             return True
         except LimitRequestLine as e:
             self._send_error_response(414, str(e))  # URI Too Long
@@ -694,6 +738,55 @@ class ASGIProtocol(asyncio.Protocol):
             if self._handle_h1c_exception(e):
                 return False
             raise
+
+    def _h2c_arm_upgrade(self):
+        """Hand the connection over to HTTP/2 once the request is complete.
+
+        Runs synchronously, inside data_received(), because that is what stops
+        the connection preface and the frames behind it from reaching the
+        HTTP/1 parser. Installing the reader here also gives later
+        data_received() calls somewhere to land while the connection loop is
+        still waking up.
+
+        Returns True to keep feeding HTTP/1, as _feed_callback_parser does.
+        """
+        parser = self._callback_parser
+        if not parser.is_complete:
+            return True
+        if parser.remaining_truncated:
+            # The tail is capped, so frames the client already sent are gone
+            # and the HTTP/2 stream would start corrupt. Nobody legitimately
+            # pipelines that much behind an upgrade request.
+            self._h2c_upgrade_settings = None
+            self._h2c_upgrade_body = None
+            self._send_error_response(400, "Upgrade request tail too large")
+            self._close_transport()
+            # Let the connection loop out of its wait instead of leaving it
+            # for the disconnect grace period to cancel.
+            self._request_ready.set()
+            return False
+        pending = parser.remaining()
+
+        # The two parsers disagree about where an upgrade request's payload
+        # goes: the Python one delivers it through _on_body, the fast one
+        # stops at the end of the headers and leaves it at the front of the
+        # tail. Take whatever is missing off that front so both end up here.
+        missing = (self._current_request.content_length or 0) - len(
+            self._h2c_upgrade_body)
+        if missing > 0:
+            if len(pending) < missing:
+                # Still arriving. remaining() accumulates across feeds, so
+                # nothing is consumed until the whole payload is in.
+                return True
+            self._h2c_upgrade_body += pending[:missing]
+            pending = pending[missing:]
+
+        self._callback_parser = None
+        self.reader = asyncio.StreamReader()
+        if pending:
+            self.reader.feed_data(pending)
+        self._request_ready.set()
+        return False
 
     def _is_buffer_full(self):
         """Check if internal buffer is full (HTTP/2 only)."""
@@ -861,6 +954,11 @@ class ASGIProtocol(asyncio.Protocol):
                 # If PROXY protocol provided a real client address, use it.
                 effective_peer = self._effective_peername(peername)
 
+                # Check for cleartext HTTP/2 upgrade
+                if self._h2c_upgrade_settings is not None:
+                    await self._handle_h2c_upgrade(request)
+                    break  # HTTP/2 takes over the connection
+
                 # Check for WebSocket upgrade
                 if self._is_websocket_upgrade(request):
                     await self._handle_websocket(request, sockname, effective_peer)
@@ -965,6 +1063,21 @@ class ASGIProtocol(asyncio.Protocol):
                 break
 
             await request.drain_body()
+
+    async def _handle_h2c_upgrade(self, request):
+        """Serve an Upgrade: h2c request over HTTP/2.
+
+        The 101 goes out here rather than in _h2c_arm_upgrade so that nothing
+        can write between it and the SETTINGS frame the HTTP/2 handler sends.
+        """
+        settings = self._h2c_upgrade_settings
+        body = bytes(self._h2c_upgrade_body or b"")
+        self._h2c_upgrade_settings = None
+        self._h2c_upgrade_body = None
+        self.transport.write(negotiation.UPGRADE_101)
+        await self._handle_http2_connection(
+            self.transport, None, upgrade=(settings, request, body)
+        )
 
     def _is_websocket_upgrade(self, request):
         """Check if request is a WebSocket upgrade.
@@ -1540,8 +1653,14 @@ class ASGIProtocol(asyncio.Protocol):
                 pass
             self._closed = True
 
-    async def _handle_http2_connection(self, transport, ssl_object):
-        """Handle an HTTP/2 connection."""
+    async def _handle_http2_connection(self, transport, ssl_object, upgrade=None):
+        """Handle an HTTP/2 connection.
+
+        ``upgrade`` is set when the connection arrives over Upgrade: h2c and
+        carries ``(settings, http1_req, body)``. The request that asked for
+        the upgrade becomes stream 1 and is served before the receive loop
+        starts, per RFC 7540 section 3.2.
+        """
         try:
             from gunicorn.http2.async_connection import AsyncHTTP2Connection
 
@@ -1560,9 +1679,17 @@ class ASGIProtocol(asyncio.Protocol):
             h2_conn = AsyncHTTP2Connection(
                 self.cfg, reader, writer, peername
             )
-            await h2_conn.initiate_connection()
-
-            self._h2_conn = h2_conn
+            if upgrade is None:
+                await h2_conn.initiate_connection()
+                self._h2_conn = h2_conn
+            else:
+                settings, http1_req, body = upgrade
+                upgraded = await h2_conn.initiate_upgrade(
+                    settings, http1_req, body)
+                self._h2_conn = h2_conn
+                await self._serve_http2_request(
+                    upgraded, h2_conn, sockname, peername)
+                self.worker.nr += 1
 
             # Main loop - receive and handle requests
             while not h2_conn.is_closed and self.worker.alive:
@@ -1575,20 +1702,8 @@ class ASGIProtocol(asyncio.Protocol):
                     break
 
                 for req in requests:
-                    try:
-                        await self._handle_http2_request(
-                            req, h2_conn, sockname, peername
-                        )
-                    except Exception as e:
-                        self.log.exception("Error handling HTTP/2 request")
-                        try:
-                            await h2_conn.send_error(
-                                req.stream.stream_id, 500, str(e)
-                            )
-                        except Exception:
-                            pass
-                    finally:
-                        h2_conn.cleanup_stream(req.stream.stream_id)
+                    await self._serve_http2_request(
+                        req, h2_conn, sockname, peername)
 
                 # Increment worker request count
                 self.worker.nr += len(requests)
@@ -1610,6 +1725,19 @@ class ASGIProtocol(asyncio.Protocol):
                 except Exception:
                     pass
             self._close_transport()
+
+    async def _serve_http2_request(self, req, h2_conn, sockname, peername):
+        """Run one HTTP/2 request, answering 500 rather than dropping it."""
+        try:
+            await self._handle_http2_request(req, h2_conn, sockname, peername)
+        except Exception as e:
+            self.log.exception("Error handling HTTP/2 request")
+            try:
+                await h2_conn.send_error(req.stream.stream_id, 500, str(e))
+            except Exception:
+                pass
+        finally:
+            h2_conn.cleanup_stream(req.stream.stream_id)
 
     def _convert_h2_headers(self, headers):
         """Convert ASGI headers to HTTP/2 format (lowercase string names)."""

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -2539,10 +2539,6 @@ class HTTP2Cleartext(Setting):
         The mechanisms are listed separately on purpose: enabling one does not
         enable the other.
 
-        ``upgrade`` is served by the gthread and gevent workers. The ASGI
-        worker accepts prior knowledge only; an upgrade request there stays
-        on HTTP/1.1.
-
         With ``prior-knowledge`` alone, a trusted peer that does not send the
         preface is refused with 400, since it is expected to speak HTTP/2.
         With ``upgrade`` or ``both`` an HTTP/1 request is how an upgrade

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -2539,9 +2539,14 @@ class HTTP2Cleartext(Setting):
         The mechanisms are listed separately on purpose: enabling one does not
         enable the other.
 
-        Only ``prior-knowledge`` is implemented so far. ``upgrade`` and
-        ``both`` are accepted, but the ``Upgrade: h2c`` handshake is not
-        honoured yet and those connections stay on HTTP/1.1.
+        ``upgrade`` is served by the gthread and gevent workers. The ASGI
+        worker accepts prior knowledge only; an upgrade request there stays
+        on HTTP/1.1.
+
+        With ``prior-knowledge`` alone, a trusted peer that does not send the
+        preface is refused with 400, since it is expected to speak HTTP/2.
+        With ``upgrade`` or ``both`` an HTTP/1 request is how an upgrade
+        begins, so it is served normally.
 
         Only peers in :ref:`forwarded-allow-ips` are considered. Everyone else
         is served HTTP/1.x exactly as if this were ``off``. Anything else from

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -2539,6 +2539,10 @@ class HTTP2Cleartext(Setting):
         The mechanisms are listed separately on purpose: enabling one does not
         enable the other.
 
+        Only ``prior-knowledge`` is implemented so far. ``upgrade`` and
+        ``both`` are accepted, but the ``Upgrade: h2c`` handshake is not
+        honoured yet and those connections stay on HTTP/1.1.
+
         Only peers in :ref:`forwarded-allow-ips` are considered. Everyone else
         is served HTTP/1.x exactly as if this were ``off``. Anything else from
         a trusted peer on a prior-knowledge port (an HTTP/1.x request, a

--- a/gunicorn/http/unreader.py
+++ b/gunicorn/http/unreader.py
@@ -16,6 +16,18 @@ class Unreader:
     def chunk(self):
         raise NotImplementedError()
 
+    def take_buffered(self):
+        """Return read-ahead already held, without touching the source.
+
+        read() blocks on the source when the buffer is empty, which is wrong
+        for a caller that only wants the bytes it has: an Upgrade: h2c
+        handshake needs whatever the client pipelined behind the request,
+        and must not wait for more.
+        """
+        data = self.buf.getvalue()
+        self.buf = io.BytesIO()
+        return data
+
     def read(self, size=None):
         if size is not None and not isinstance(size, int):
             raise TypeError("size parameter must be an int or long.")

--- a/gunicorn/http2/async_connection.py
+++ b/gunicorn/http2/async_connection.py
@@ -124,6 +124,52 @@ class AsyncHTTP2Connection:
         await self._send_pending_data()
         self._initialized = True
 
+    async def initiate_upgrade(self, settings_header, http1_req, body=b""):
+        """Switch a connection to HTTP/2 after an Upgrade: h2c request.
+
+        The async twin of HTTP2Connection.initiate_upgrade. The upgraded
+        request becomes stream 1 (RFC 7540 section 3.2): h2 opens it in the
+        state machine, and the matching gunicorn stream is built here from the
+        HTTP/1 request that carried the upgrade, so the worker sees an
+        ordinary HTTP/2 request.
+
+        The body is passed in rather than read off the request: the callback
+        parser hands body chunks to the protocol, not to the request object.
+
+        Returns the HTTP2Request for stream 1.
+        """
+        self.h2_conn.update_settings({
+            _h2_settings.SettingCodes.MAX_CONCURRENT_STREAMS: self.max_concurrent_streams,
+            _h2_settings.SettingCodes.INITIAL_WINDOW_SIZE: self.initial_window_size,
+            _h2_settings.SettingCodes.MAX_FRAME_SIZE: self.max_frame_size,
+            _h2_settings.SettingCodes.MAX_HEADER_LIST_SIZE: self.max_header_list_size,
+        })
+        self.h2_conn.initiate_upgrade_connection(settings_header=settings_header)
+        await self._send_pending_data()
+        self._initialized = True
+
+        stream = HTTP2Stream(stream_id=1, connection=self)
+        authority = ""
+        for name, value in http1_req.headers:
+            if name == "HOST":
+                authority = value
+                break
+        pseudo = [
+            (':method', http1_req.method),
+            (':path', http1_req.uri),
+            (':scheme', http1_req.scheme),
+        ]
+        if authority:
+            pseudo.append((':authority', authority))
+        regular = [(name.lower(), value) for name, value in http1_req.headers
+                   if name not in ("CONNECTION", "UPGRADE", "HTTP2-SETTINGS")]
+
+        stream.receive_headers(pseudo + regular, end_stream=not body)
+        if body:
+            stream.receive_data(body, end_stream=True)
+        self.streams[1] = stream
+        return HTTP2Request(stream, self.cfg, self.client_addr)
+
     async def receive_data(self, timeout=None):
         """Receive data and return completed requests.
 

--- a/gunicorn/http2/connection.py
+++ b/gunicorn/http2/connection.py
@@ -125,13 +125,17 @@ class HTTP2ServerConnection:
         self._send_pending_data()
         self._initialized = True
 
-    def initiate_upgrade(self, settings_header, http1_req):
+    def initiate_upgrade(self, settings_header, http1_req, body=None):
         """Switch a connection to HTTP/2 after an Upgrade: h2c request.
 
         The upgraded request becomes stream 1 (RFC 7540 section 3.2). h2
         opens it in the state machine; the matching gunicorn stream is built
         here from the HTTP/1 request that carried the upgrade, so the worker
         sees an ordinary HTTP/2 request.
+
+        ``body`` is the request payload. A caller that has to drain it before
+        collecting the bytes pipelined behind the request passes it here;
+        leaving it None reads it off the request.
 
         Returns the HTTP2Request for stream 1.
         """
@@ -161,9 +165,10 @@ class HTTP2ServerConnection:
         regular = [(name.lower(), value) for name, value in http1_req.headers
                    if name not in ("CONNECTION", "UPGRADE", "HTTP2-SETTINGS")]
 
-        body = b""
-        if http1_req.body is not None:
-            body = http1_req.body.read() or b""
+        if body is None:
+            body = b""
+            if http1_req.body is not None:
+                body = http1_req.body.read() or b""
         stream.receive_headers(pseudo + regular, end_stream=not body)
         if body:
             stream.receive_data(body, end_stream=True)

--- a/gunicorn/http2/connection.py
+++ b/gunicorn/http2/connection.py
@@ -125,6 +125,51 @@ class HTTP2ServerConnection:
         self._send_pending_data()
         self._initialized = True
 
+    def initiate_upgrade(self, settings_header, http1_req):
+        """Switch a connection to HTTP/2 after an Upgrade: h2c request.
+
+        The upgraded request becomes stream 1 (RFC 7540 section 3.2). h2
+        opens it in the state machine; the matching gunicorn stream is built
+        here from the HTTP/1 request that carried the upgrade, so the worker
+        sees an ordinary HTTP/2 request.
+
+        Returns the HTTP2Request for stream 1.
+        """
+        self.h2_conn.update_settings({
+            _h2_settings.SettingCodes.MAX_CONCURRENT_STREAMS: self.max_concurrent_streams,
+            _h2_settings.SettingCodes.INITIAL_WINDOW_SIZE: self.initial_window_size,
+            _h2_settings.SettingCodes.MAX_FRAME_SIZE: self.max_frame_size,
+            _h2_settings.SettingCodes.MAX_HEADER_LIST_SIZE: self.max_header_list_size,
+        })
+        self.h2_conn.initiate_upgrade_connection(settings_header=settings_header)
+        self._send_pending_data()
+        self._initialized = True
+
+        stream = HTTP2Stream(stream_id=1, connection=self)
+        authority = ""
+        for name, value in http1_req.headers:
+            if name == "HOST":
+                authority = value
+                break
+        pseudo = [
+            (':method', http1_req.method),
+            (':path', http1_req.uri),
+            (':scheme', http1_req.scheme),
+        ]
+        if authority:
+            pseudo.append((':authority', authority))
+        regular = [(name.lower(), value) for name, value in http1_req.headers
+                   if name not in ("CONNECTION", "UPGRADE", "HTTP2-SETTINGS")]
+
+        body = b""
+        if http1_req.body is not None:
+            body = http1_req.body.read() or b""
+        stream.receive_headers(pseudo + regular, end_stream=not body)
+        if body:
+            stream.receive_data(body, end_stream=True)
+        self.streams[1] = stream
+        return HTTP2Request(stream, self.cfg, self.client_addr)
+
     def receive_data(self, data=None):
         """Process received data and return completed requests.
 

--- a/gunicorn/http2/negotiation.py
+++ b/gunicorn/http2/negotiation.py
@@ -73,6 +73,17 @@ def prior_knowledge_allowed(cfg, peer_addr):
     return _h2c_available(cfg) and peer_trusted_for_h2c(cfg, peer_addr)
 
 
+def mismatch_is_error(cfg):
+    """Whether a trusted peer failing to send the preface is a 400.
+
+    Only when prior knowledge is the sole mechanism: such a peer is expected
+    to speak HTTP/2 and a silent downgrade would hide a misconfiguration.
+    When upgrade is also enabled, an HTTP/1 request is not a mistake, it is
+    how an upgrade begins, so it has to be allowed through.
+    """
+    return cfg.http2_cleartext == "prior-knowledge"
+
+
 def upgrade_allowed(cfg, peer_addr):
     """Whether to honour an ``Upgrade: h2c`` request from this peer."""
     if cfg.http2_cleartext not in ("upgrade", "both"):
@@ -119,3 +130,41 @@ def read_preface_blocking(sock, timeout=None):
                 return False, buf
     finally:
         sock.settimeout(original)
+
+
+#: Sent before switching an HTTP/1.1 connection over to HTTP/2.
+UPGRADE_101 = (
+    b"HTTP/1.1 101 Switching Protocols\r\n"
+    b"Connection: Upgrade\r\n"
+    b"Upgrade: h2c\r\n"
+    b"\r\n"
+)
+
+
+def upgrade_settings(req):
+    """Return the HTTP2-Settings payload if this request asks for h2c.
+
+    RFC 7540 section 3.2: the request must name ``h2c`` in Upgrade and carry
+    exactly one HTTP2-Settings header, itself named in Connection. Returns
+    None when the request is not a well-formed upgrade attempt, so the caller
+    simply carries on with HTTP/1.
+    """
+    upgrade = None
+    settings = []
+    connection = ""
+    for name, value in req.headers:
+        if name == "UPGRADE":
+            upgrade = value.strip().lower()
+        elif name == "HTTP2-SETTINGS":
+            settings.append(value.strip())
+        elif name == "CONNECTION":
+            connection = value.lower()
+
+    if upgrade != "h2c":
+        return None
+    # Exactly one, per RFC 7540 3.2.1: a second one is ambiguous.
+    if len(settings) != 1:
+        return None
+    if "http2-settings" not in connection or "upgrade" not in connection:
+        return None
+    return settings[0].encode("latin-1")

--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -134,6 +134,10 @@ class AsyncWorker(base.Worker):
         Returns True when the connection has been taken over. Any HTTP/2
         bytes the client pipelined behind the upgrade request are still in
         the parser's unreader, so they are handed on rather than dropped.
+
+        The request body has to come out first: it shares that buffer, and
+        taking the buffer before draining it would feed the payload to the
+        HTTP/2 state machine as if it were frames.
         """
         if not negotiation.upgrade_allowed(self.cfg, addr):
             return False
@@ -141,10 +145,13 @@ class AsyncWorker(base.Worker):
         if settings is None:
             return False
 
+        body = b""
+        if req.body is not None:
+            body = req.body.read() or b""
         pending = parser.unreader.take_buffered()
         util.write(client, negotiation.UPGRADE_101)
         self.handle_http2(listener, client, addr, preface=pending,
-                          upgrade=(settings, req))
+                          upgrade=(settings, req, body))
         return True
 
     def handle_http2(self, listener, client, addr, preface=b"",
@@ -162,8 +169,8 @@ class AsyncWorker(base.Worker):
         try:
             h2_conn = http.get_parser(self.cfg, client, addr, http2_connection=True)
             if upgrade is not None:
-                settings, http1_req = upgrade
-                upgraded = h2_conn.initiate_upgrade(settings, http1_req)
+                settings, http1_req, body = upgrade
+                upgraded = h2_conn.initiate_upgrade(settings, http1_req, body)
             else:
                 upgraded = None
                 h2_conn.initiate_connection()

--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -35,6 +35,7 @@ class AsyncWorker(base.Worker):
 
     def handle(self, listener, client, addr):
         req = None
+        unread_preface = b""
         try:
             # Complete the handshake to ensure ALPN negotiation is done
             # (needed if do_handshake_on_connect is False)
@@ -57,16 +58,24 @@ class AsyncWorker(base.Worker):
                 if matched:
                     self.handle_http2(listener, client, addr, preface=buf)
                     return
-                # A trusted peer on a prior-knowledge port must speak
-                # HTTP/2. Anything else is rejected rather than silently
-                # downgraded, so a misconfigured proxy fails loudly.
-                raise InvalidH2CPreface(buf)
+                if negotiation.mismatch_is_error(self.cfg):
+                    # A trusted peer on a prior-knowledge-only port must
+                    # speak HTTP/2; anything else is a misconfiguration.
+                    raise InvalidH2CPreface(buf)
+                # Upgrade is enabled too, so this may be the HTTP/1 request
+                # that carries it; fall through with the bytes preserved.
+                unread_preface = buf
 
             parser = http.get_parser(self.cfg, client, addr)
+            if unread_preface:
+                parser.unreader.unread(unread_preface)
             try:
                 listener_name = listener.getsockname()
                 if not self.cfg.keepalive:
                     req = next(parser)
+                    if self._try_h2c_upgrade(listener, req, parser, client,
+                                             addr):
+                        return
                     self.handle_request(listener_name, req, client, addr)
                 else:
                     # keepalive loop
@@ -77,6 +86,9 @@ class AsyncWorker(base.Worker):
                             req = next(parser)
                         if not req:
                             break
+                        if self._try_h2c_upgrade(listener, req, parser, client,
+                                                 addr):
+                            return
                         if req.proxy_protocol_info:
                             proxy_protocol_info = req.proxy_protocol_info
                         else:
@@ -116,7 +128,27 @@ class AsyncWorker(base.Worker):
         finally:
             util.close(client)
 
-    def handle_http2(self, listener, client, addr, preface=b""):
+    def _try_h2c_upgrade(self, listener, req, parser, client, addr):
+        """Switch to HTTP/2 if this request asks to upgrade.
+
+        Returns True when the connection has been taken over. Any HTTP/2
+        bytes the client pipelined behind the upgrade request are still in
+        the parser's unreader, so they are handed on rather than dropped.
+        """
+        if not negotiation.upgrade_allowed(self.cfg, addr):
+            return False
+        settings = negotiation.upgrade_settings(req)
+        if settings is None:
+            return False
+
+        pending = parser.unreader.take_buffered()
+        util.write(client, negotiation.UPGRADE_101)
+        self.handle_http2(listener, client, addr, preface=pending,
+                          upgrade=(settings, req))
+        return True
+
+    def handle_http2(self, listener, client, addr, preface=b"",
+                     upgrade=None):
         """Handle an HTTP/2 connection.
 
         Processes multiplexed HTTP/2 streams until the connection closes.
@@ -129,11 +161,21 @@ class AsyncWorker(base.Worker):
 
         try:
             h2_conn = http.get_parser(self.cfg, client, addr, http2_connection=True)
-            h2_conn.initiate_connection()
+            if upgrade is not None:
+                settings, http1_req = upgrade
+                upgraded = h2_conn.initiate_upgrade(settings, http1_req)
+            else:
+                upgraded = None
+                h2_conn.initiate_connection()
             if preface:
                 # The preface alone cannot complete a request, so replaying
                 # it yields no requests and nothing is dropped.
                 h2_conn.receive_data(preface)
+
+            if upgraded is not None:
+                # The upgraded request is stream 1; serve it before the loop.
+                self.handle_http2_request(listener.getsockname(), upgraded,
+                                          client, addr, h2_conn)
 
             while not h2_conn.is_closed and self.alive:
                 try:

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -103,9 +103,15 @@ class TConn:
                     # a request, so nothing is dropped here.
                     self.parser.receive_data(buf)
                     return
-                # A trusted peer on a prior-knowledge port must speak HTTP/2.
-                # Anything else is rejected rather than silently downgraded.
-                raise InvalidH2CPreface(buf)
+                if negotiation.mismatch_is_error(self.cfg):
+                    # A trusted peer on a prior-knowledge-only port must
+                    # speak HTTP/2; anything else is a misconfiguration.
+                    raise InvalidH2CPreface(buf)
+                # Upgrade is enabled too, so this may be the HTTP/1 request
+                # that carries it. Give the bytes back and carry on.
+                self.parser = http.get_parser(self.cfg, self.sock, self.client)
+                self.parser.unreader.unread(buf)
+                return
 
             # initialize the HTTP/1.x parser
             self.parser = http.get_parser(self.cfg, self.sock, self.client)
@@ -500,18 +506,14 @@ class ThreadWorker(base.Worker):
             if not req:
                 return False
 
+            settings = None
+            if negotiation.upgrade_allowed(self.cfg, conn.client):
+                settings = negotiation.upgrade_settings(req)
+            if settings is not None:
+                return self.handle_h2c_upgrade(conn, req, settings)
+
             # Handle the request
-            keepalive = self.handle_request(req, conn)
-            if keepalive:
-                # Discard any unread request body before keepalive to prevent
-                # the socket from appearing readable due to leftover bytes.
-                # Bound the drain by the worker data timeout: a stalled client
-                # must not keep this thread blocked.
-                drain_deadline = time.monotonic() + DEFAULT_WORKER_DATA_TIMEOUT
-                if not conn.parser.finish_body(deadline=drain_deadline):
-                    # Abandon keepalive when the body could not be fully drained.
-                    return False
-                return True
+            return self._keepalive_after(conn, self.handle_request(req, conn))
         except http.errors.NoMoreData as e:
             self.log.debug("Ignored premature client disconnection. %s", e)
         except StopIteration as e:
@@ -537,6 +539,40 @@ class ThreadWorker(base.Worker):
             self.handle_error(req, conn.sock, conn.client, e)
 
         return False
+
+    def _keepalive_after(self, conn, keepalive):
+        """Whether the connection can be reused for another request.
+
+        A body the application did not read leaves bytes on the socket, which
+        would make it look readable again, so it is drained first. The drain
+        is bounded by the worker data timeout: a stalled client must not keep
+        this thread blocked.
+        """
+        if not keepalive:
+            return False
+        drain_deadline = time.monotonic() + DEFAULT_WORKER_DATA_TIMEOUT
+        return bool(conn.parser.finish_body(deadline=drain_deadline))
+
+    def handle_h2c_upgrade(self, conn, req, settings):
+        """Switch this connection to HTTP/2 and serve the upgraded request.
+
+        The client may already have sent HTTP/2 frames behind the upgrade
+        request. Those bytes are sitting in the parser's unreader, so they
+        are handed to the HTTP/2 connection rather than dropped.
+        """
+        pending = conn.parser.unreader.take_buffered()
+        util.write(conn.sock, negotiation.UPGRADE_101)
+
+        h2_conn = http.get_parser(self.cfg, conn.sock, conn.client,
+                                  http2_connection=True)
+        upgraded = h2_conn.initiate_upgrade(settings, req)
+        conn.parser = h2_conn
+        conn.is_http2 = True
+        if pending:
+            h2_conn.receive_data(pending)
+
+        self.handle_http2_request(upgraded, conn, h2_conn)
+        return self.handle_http2(conn)
 
     def handle_http2(self, conn):
         """Handle an HTTP/2 connection. Runs in a worker thread.

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -559,13 +559,20 @@ class ThreadWorker(base.Worker):
         The client may already have sent HTTP/2 frames behind the upgrade
         request. Those bytes are sitting in the parser's unreader, so they
         are handed to the HTTP/2 connection rather than dropped.
+
+        The request body has to come out first: it shares that buffer, and
+        taking the buffer before draining it would feed the payload to the
+        HTTP/2 state machine as if it were frames.
         """
+        body = b""
+        if req.body is not None:
+            body = req.body.read() or b""
         pending = conn.parser.unreader.take_buffered()
         util.write(conn.sock, negotiation.UPGRADE_101)
 
         h2_conn = http.get_parser(self.cfg, conn.sock, conn.client,
                                   http2_connection=True)
-        upgraded = h2_conn.initiate_upgrade(settings, req)
+        upgraded = h2_conn.initiate_upgrade(settings, req, body)
         conn.parser = h2_conn
         conn.is_http2 = True
         if pending:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ tornado = ["tornado>=6.5.7"]
 gthread = []
 setproctitle = ["setproctitle"]
 http2 = ["h2>=4.4.1"]
-fast = ["gunicorn_h1c>=0.6.8"]
+fast = ["gunicorn_h1c>=0.6.9"]
 testing = [
     "gevent>=24.10.1",
     "h2>=4.4.1",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,7 @@ packaging
 pytest>=9.0.3
 pytest-cov
 pytest-asyncio
-gunicorn_h1c>=0.6.8
+gunicorn_h1c>=0.6.9
 h2>=4.4.1
 uvloop>=0.19.0
 inotify>=0.2.10; sys_platform == 'linux'

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -612,3 +612,104 @@ class TestH2CASGI:
         finally:
             loop.close()
             asyncio.set_event_loop(None)
+
+
+class TestUpgradeDetection:
+    """RFC 7540 3.2: what counts as an upgrade request."""
+
+    def _req(self, headers):
+        r = mock.Mock()
+        r.headers = headers
+        return r
+
+    VALID = [("UPGRADE", "h2c"), ("HTTP2-SETTINGS", "AAMAAABk"),
+             ("CONNECTION", "Upgrade, HTTP2-Settings")]
+
+    def test_valid_upgrade(self):
+        assert negotiation.upgrade_settings(self._req(self.VALID)) == b"AAMAAABk"
+
+    def test_case_insensitive(self):
+        headers = [("UPGRADE", "H2C"), ("HTTP2-SETTINGS", "AAMAAABk"),
+                   ("CONNECTION", "upgrade, http2-settings")]
+        assert negotiation.upgrade_settings(self._req(headers)) == b"AAMAAABk"
+
+    def test_no_upgrade_header(self):
+        assert negotiation.upgrade_settings(
+            self._req([("CONNECTION", "keep-alive")])) is None
+
+    def test_wrong_protocol(self):
+        headers = [("UPGRADE", "websocket")] + self.VALID[1:]
+        assert negotiation.upgrade_settings(self._req(headers)) is None
+
+    def test_two_settings_headers_are_ambiguous(self):
+        headers = [("UPGRADE", "h2c"), ("HTTP2-SETTINGS", "a"),
+                   ("HTTP2-SETTINGS", "b"),
+                   ("CONNECTION", "Upgrade, HTTP2-Settings")]
+        assert negotiation.upgrade_settings(self._req(headers)) is None
+
+    def test_settings_not_named_in_connection(self):
+        headers = [("UPGRADE", "h2c"), ("HTTP2-SETTINGS", "a"),
+                   ("CONNECTION", "Upgrade")]
+        assert negotiation.upgrade_settings(self._req(headers)) is None
+
+
+class TestMismatchPolicy:
+    """A non-preface is only an error when prior knowledge stands alone."""
+
+    def _cfg(self, mode):
+        cfg = h2c_config()
+        cfg.set("http2_cleartext", mode)
+        return cfg
+
+    def test_prior_knowledge_only_refuses(self):
+        assert negotiation.mismatch_is_error(self._cfg("prior-knowledge"))
+
+    def test_both_allows_http1_through(self):
+        # otherwise the HTTP/1 request carrying an upgrade would be refused
+        assert not negotiation.mismatch_is_error(self._cfg("both"))
+
+    def test_upgrade_allows_http1_through(self):
+        assert not negotiation.mismatch_is_error(self._cfg("upgrade"))
+
+
+@pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")
+class TestUpgradeSynthesis:
+    """The upgraded request becomes stream 1."""
+
+    def _connection(self):
+        from gunicorn.http2.connection import HTTP2ServerConnection
+        server, client = socket.socketpair()
+        cfg = h2c_config()
+        conn = HTTP2ServerConnection(cfg, server, TRUSTED_ADDR)
+        return conn, server, client
+
+    def test_request_is_carried_over(self):
+        import base64
+        conn, server, client = self._connection()
+        try:
+            req = mock.Mock()
+            req.method = "POST"
+            req.uri = "/upgraded?x=1"
+            req.scheme = "http"
+            req.body = None
+            req.headers = [("HOST", "example.com"), ("UPGRADE", "h2c"),
+                           ("HTTP2-SETTINGS", "AAMAAABk"),
+                           ("CONNECTION", "Upgrade, HTTP2-Settings"),
+                           ("X-KEPT", "yes")]
+            settings = base64.urlsafe_b64encode(
+                b"\x00\x03\x00\x00\x00\x64").rstrip(b"=")
+            h2req = conn.initiate_upgrade(settings, req)
+
+            assert h2req.method == "POST"
+            assert h2req.path == "/upgraded"
+            assert h2req.query == "x=1"
+            assert 1 in conn.streams
+            names = [n for n, _ in h2req.headers]
+            # hop-by-hop upgrade headers do not travel to HTTP/2
+            assert "UPGRADE" not in names
+            assert "HTTP2-SETTINGS" not in names
+            assert "CONNECTION" not in names
+            assert "X-KEPT" in names
+        finally:
+            server.close()
+            client.close()

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -851,13 +851,12 @@ class TestH2CASGIUpgrade:
             assert bytes(proto._h2c_upgrade_body) == b"hello=world"
             assert bytes(proto.reader._buffer) == negotiation.H2C_PREFACE
 
-    def test_chunked_stays_on_http1(self, parser):
-        # the fast parser hands a chunked payload back still encoded and
-        # mixed into the tail, so there is no safe boundary to upgrade at
+    def test_chunked_payload_is_decoded(self, parser):
         with self._protocol(asgi_upgrade_config(parser)) as (proto, transport):
-            proto.data_received(upgrade_request(b"hello", chunked=True))
-            assert proto._h2c_upgrade_settings is None
-            assert proto._callback_parser is not None
+            proto.data_received(upgrade_request(b"hello", chunked=True)
+                                + negotiation.H2C_PREFACE)
+            assert bytes(proto._h2c_upgrade_body) == b"hello"
+            assert bytes(proto.reader._buffer) == negotiation.H2C_PREFACE
 
     def test_ordinary_request_is_untouched(self, parser):
         with self._protocol(asgi_upgrade_config(parser)) as (proto, transport):
@@ -956,7 +955,7 @@ class TestH2CASGIUpgradeEndToEnd:
     will happily report success while the server answers 500.
     """
 
-    def _run(self, parser, body=b""):
+    def _run(self, parser, body=b"", chunked=False):
         import h2.config
         import h2.connection
         import h2.events
@@ -999,7 +998,8 @@ class TestH2CASGIUpgradeEndToEnd:
                     client_side=True, header_encoding="utf-8"))
             client.initiate_upgrade_connection()
 
-            proto.data_received(upgrade_request(body) + client.data_to_send())
+            proto.data_received(upgrade_request(body, chunked)
+                                + client.data_to_send())
 
             async def until_answered():
                 while b"BODY" not in transport.written:
@@ -1032,6 +1032,10 @@ class TestH2CASGIUpgradeEndToEnd:
 
     def test_payload_reaches_the_application(self, parser):
         echoed, _events = self._run(parser, body=b"hello=world")
+        assert echoed == [("http", "2", "POST", "/p", b"hello=world")]
+
+    def test_chunked_payload_reaches_the_application(self, parser):
+        echoed, _events = self._run(parser, body=b"hello=world", chunked=True)
         assert echoed == [("http", "2", "POST", "/p", b"hello=world")]
 
 

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -751,6 +751,212 @@ class TestUpgradeWithBody:
         assert not worker.errors
 
 
+UPGRADE_HEADERS = (
+    b"Host: x\r\nUpgrade: h2c\r\n"
+    b"Connection: Upgrade, HTTP2-Settings\r\n"
+    b"HTTP2-Settings: AAMAAABkAAQAoAAAAAIAAAAA\r\n"
+)
+
+
+def upgrade_request(body=b"", chunked=False):
+    """An Upgrade: h2c request, optionally carrying a payload."""
+    if chunked:
+        framing = b"Transfer-Encoding: chunked\r\n"
+        payload = b"%x\r\n%s\r\n0\r\n\r\n" % (len(body), body) if body else b"0\r\n\r\n"
+    elif body:
+        framing = b"Content-Length: %d\r\n" % len(body)
+        payload = body
+    else:
+        framing = b""
+        payload = b""
+    method = b"POST" if body else b"GET"
+    return (method + b" /p HTTP/1.1\r\n" + UPGRADE_HEADERS + framing
+            + b"\r\n" + payload)
+
+
+def asgi_upgrade_config(parser="fast", mode="upgrade"):
+    cfg = h2c_config()
+    cfg.set("http2_cleartext", mode)
+    cfg.set("http_parser", parser)
+    return cfg
+
+
+@pytest.mark.parametrize("parser", ["fast", "python"])
+class TestH2CASGIUpgrade:
+    """Upgrade: h2c on the ASGI worker, over either callback parser.
+
+    The two parsers split an upgrade request differently: the Python one
+    delivers the payload through on_body, the fast one stops at the end of
+    the headers and leaves it in front of the bytes that follow. The worker
+    has to end up in the same place either way.
+    """
+
+    def _connect(self, cfg, peername=TRUSTED_ADDR):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        proto = make_asgi_protocol(cfg, loop)
+        transport = _FakeTransport(peername)
+        proto.connection_made(transport)
+        return proto, transport, loop
+
+    @contextlib.contextmanager
+    def _protocol(self, cfg, peername=TRUSTED_ADDR):
+        proto, transport, loop = self._connect(cfg, peername)
+        try:
+            yield proto, transport
+        finally:
+            proto._h2c_cancel_timer()
+            if proto._task is not None:
+                proto._task.cancel()
+            loop.close()
+            asyncio.set_event_loop(None)
+
+    def test_handover_takes_the_frames_and_leaves_nothing_behind(self, parser):
+        with self._protocol(asgi_upgrade_config(parser)) as (proto, transport):
+            proto.data_received(upgrade_request() + negotiation.H2C_PREFACE)
+            assert proto._h2c_upgrade_settings == b"AAMAAABkAAQAoAAAAAIAAAAA"
+            # the HTTP/1 parser is out of the way before the frames arrive
+            assert proto._callback_parser is None
+            assert bytes(proto.reader._buffer) == negotiation.H2C_PREFACE
+            assert not transport.closed
+
+    def test_payload_is_body_not_frames(self, parser):
+        with self._protocol(asgi_upgrade_config(parser)) as (proto, transport):
+            proto.data_received(
+                upgrade_request(b"hello=world") + negotiation.H2C_PREFACE)
+            assert bytes(proto._h2c_upgrade_body) == b"hello=world"
+            assert bytes(proto.reader._buffer) == negotiation.H2C_PREFACE
+
+    def test_waits_for_the_whole_payload(self, parser):
+        with self._protocol(asgi_upgrade_config(parser)) as (proto, transport):
+            whole = upgrade_request(b"hello=world") + negotiation.H2C_PREFACE
+            proto.data_received(whole[:-30])
+            # payload still incomplete: nothing may be handed over yet
+            assert proto._callback_parser is not None
+            assert proto.reader is None
+            proto.data_received(whole[-30:])
+            assert bytes(proto._h2c_upgrade_body) == b"hello=world"
+            assert bytes(proto.reader._buffer) == negotiation.H2C_PREFACE
+
+    def test_chunked_stays_on_http1(self, parser):
+        # the fast parser hands a chunked payload back still encoded and
+        # mixed into the tail, so there is no safe boundary to upgrade at
+        with self._protocol(asgi_upgrade_config(parser)) as (proto, transport):
+            proto.data_received(upgrade_request(b"hello", chunked=True))
+            assert proto._h2c_upgrade_settings is None
+            assert proto._callback_parser is not None
+
+    def test_ordinary_request_is_untouched(self, parser):
+        with self._protocol(asgi_upgrade_config(parser)) as (proto, transport):
+            proto.data_received(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+            assert proto._h2c_upgrade_settings is None
+            assert proto._callback_parser is not None
+            assert proto.reader is None
+
+    def test_untrusted_peer_is_not_upgraded(self, parser):
+        with self._protocol(asgi_upgrade_config(parser),
+                            peername=UNTRUSTED_ADDR) as (proto, transport):
+            assert proto._h2c_upgrade_ok is False
+            proto.data_received(upgrade_request() + negotiation.H2C_PREFACE)
+            assert proto._h2c_upgrade_settings is None
+            assert proto._callback_parser is not None
+
+    def test_disabled_does_not_upgrade(self, parser):
+        cfg = asgi_upgrade_config(parser, mode="prior-knowledge")
+        # prior-knowledge alone: sniffing is on, upgrade is not
+        with self._protocol(cfg) as (proto, transport):
+            assert proto._h2c_upgrade_ok is False
+
+
+@pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")
+@pytest.mark.parametrize("parser", ["fast", "python"])
+class TestH2CASGIUpgradeEndToEnd:
+    """Drive the whole handover and read the answer back as an h2 client.
+
+    The unit tests above stop at the handover. This one runs the event loop
+    and decodes what actually goes on the wire, because a mocked application
+    will happily report success while the server answers 500.
+    """
+
+    def _run(self, parser, body=b""):
+        import h2.config
+        import h2.connection
+        import h2.events
+
+        echoed = []
+
+        async def app(scope, receive, send):
+            payload = b""
+            while True:
+                message = await receive()
+                payload += message.get("body", b"")
+                if not message.get("more_body"):
+                    break
+            echoed.append((scope["type"], scope["http_version"],
+                           scope["method"], scope["path"], payload))
+            await send({"type": "http.response.start", "status": 200,
+                        "headers": [(b"content-type", b"text/plain")]})
+            await send({"type": "http.response.body", "body": b"BODY"})
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            cfg = asgi_upgrade_config(parser)
+            worker = mock.Mock()
+            worker.cfg = cfg
+            worker.log = mock.Mock()
+            # assigned before construction: ASGIProtocol captures worker.asgi
+            worker.asgi = app
+            worker.loop = loop
+            worker.nr_conns = 0
+            worker.nr = 0
+            worker.max_requests = 1000
+            from gunicorn.asgi.protocol import ASGIProtocol
+            proto = ASGIProtocol(worker)
+            transport = _FakeTransport()
+            proto.connection_made(transport)
+
+            client = h2.connection.H2Connection(
+                config=h2.config.H2Configuration(
+                    client_side=True, header_encoding="utf-8"))
+            client.initiate_upgrade_connection()
+
+            proto.data_received(upgrade_request(body) + client.data_to_send())
+
+            async def until_answered():
+                while b"BODY" not in transport.written:
+                    await asyncio.sleep(0.005)
+            loop.run_until_complete(
+                asyncio.wait_for(until_answered(), timeout=5))
+
+            assert not worker.log.exception.called
+            assert transport.written.startswith(negotiation.UPGRADE_101)
+            events = client.receive_data(
+                transport.written[len(negotiation.UPGRADE_101):])
+            return echoed, events
+        finally:
+            if proto._task is not None:
+                proto._task.cancel()
+            loop.close()
+            asyncio.set_event_loop(None)
+
+    def test_upgraded_request_is_served_over_http2(self, parser):
+        import h2.events
+        echoed, events = self._run(parser)
+
+        assert echoed == [("http", "2", "GET", "/p", b"")]
+        statuses = [dict(e.headers)[":status"] for e in events
+                    if isinstance(e, h2.events.ResponseReceived)]
+        assert statuses == ["200"]
+        data = b"".join(e.data for e in events
+                        if isinstance(e, h2.events.DataReceived))
+        assert data == b"BODY"
+
+    def test_payload_reaches_the_application(self, parser):
+        echoed, _events = self._run(parser, body=b"hello=world")
+        assert echoed == [("http", "2", "POST", "/p", b"hello=world")]
+
+
 @pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")
 class TestUpgradeSynthesis:
     """The upgraded request becomes stream 1."""

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -21,6 +21,19 @@ try:
 except ImportError:
     H2_AVAILABLE = False
 
+# The fast parser is an optional extra; FreeBSD CI has no wheel for it.
+try:
+    import gunicorn_h1c  # pylint: disable=unused-import
+    H1C_AVAILABLE = True
+except ImportError:
+    H1C_AVAILABLE = False
+
+PARSERS = [
+    pytest.param("fast", marks=pytest.mark.skipif(
+        not H1C_AVAILABLE, reason="gunicorn_h1c not available")),
+    "python",
+]
+
 from gunicorn.config import Config
 from gunicorn.http.errors import InvalidH2CPreface
 from gunicorn.http.parser import RequestParser
@@ -781,7 +794,7 @@ def asgi_upgrade_config(parser="fast", mode="upgrade"):
     return cfg
 
 
-@pytest.mark.parametrize("parser", ["fast", "python"])
+@pytest.mark.parametrize("parser", PARSERS)
 class TestH2CASGIUpgrade:
     """Upgrade: h2c on the ASGI worker, over either callback parser.
 
@@ -934,7 +947,7 @@ class TestH2CASGIBothModes:
 
 
 @pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")
-@pytest.mark.parametrize("parser", ["fast", "python"])
+@pytest.mark.parametrize("parser", PARSERS)
 class TestH2CASGIUpgradeEndToEnd:
     """Drive the whole handover and read the answer back as an h2 client.
 

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -342,10 +342,12 @@ class _StubAsyncWorker(base_async.AsyncWorker):
         self.nr = 0
         self.log = mock.Mock()
         self.http2_calls = []
+        self.upgrades = []
         self.errors = []
 
-    def handle_http2(self, listener, client, addr, preface=b""):
+    def handle_http2(self, listener, client, addr, preface=b"", upgrade=None):
         self.http2_calls.append(preface)
+        self.upgrades.append(upgrade)
 
     def handle_request(self, listener_name, req, sock, addr):
         pass
@@ -357,8 +359,13 @@ class _StubAsyncWorker(base_async.AsyncWorker):
         return contextlib.nullcontext()
 
 
-def run_async_handle(cfg, client_data, addr=TRUSTED_ADDR):
-    """Drive AsyncWorker.handle() over a socketpair. Returns the worker."""
+def run_async_handle(cfg, client_data, addr=TRUSTED_ADDR, close_client=True):
+    """Drive AsyncWorker.handle() over a socketpair. Returns the worker.
+
+    ``close_client`` gives the HTTP/1 path an EOF to stop on. An upgrade
+    needs the peer left open: the 101 is written before the handover, and a
+    closed peer turns that write into an EPIPE.
+    """
     server_sock, client_sock = socket.socketpair()
     listener = mock.Mock()
     listener.getsockname.return_value = ("127.0.0.1", 8000)
@@ -366,7 +373,8 @@ def run_async_handle(cfg, client_data, addr=TRUSTED_ADDR):
     try:
         if client_data:
             client_sock.sendall(client_data)
-        client_sock.close()          # EOF, so the HTTP/1 path terminates
+        if close_client:
+            client_sock.close()
         worker.handle(listener, server_sock, addr)
     finally:
         server_sock.close()
@@ -670,6 +678,77 @@ class TestMismatchPolicy:
 
     def test_upgrade_allows_http1_through(self):
         assert not negotiation.mismatch_is_error(self._cfg("upgrade"))
+
+
+class _StubThreadWorker(gthread.ThreadWorker):
+    """Enough of a gthread worker to drive handle_h2c_upgrade()."""
+
+    def __init__(self, cfg):  # pylint: disable=super-init-not-called
+        self.cfg = cfg
+        self.log = mock.Mock()
+        self.alive = True
+        self.nr = 0
+        self.max_requests = 1000
+        self.served = []
+
+    def handle_http2_request(self, req, conn, h2_conn):
+        self.served.append(req)
+
+    def handle_http2(self, conn):
+        return False
+
+
+@pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")
+class TestUpgradeWithBody:
+    """A payload on the upgrade request is body, not HTTP/2 frames.
+
+    The payload and the frames behind it share one buffer. Collecting the
+    frames before draining the payload hands it to the HTTP/2 state machine,
+    which rejects it as a bad preamble.
+    """
+
+    REQUEST = (
+        b"POST /p HTTP/1.1\r\nHost: x\r\nUpgrade: h2c\r\n"
+        b"Connection: Upgrade, HTTP2-Settings\r\n"
+        b"HTTP2-Settings: AAMAAABkAAQAoAAAAAIAAAAA\r\n"
+        b"Content-Length: 11\r\n\r\nhello=world" + negotiation.H2C_PREFACE
+    )
+
+    def test_gthread(self):
+        cfg = h2c_config()
+        cfg.set("http2_cleartext", "upgrade")
+        conn, client = make_conn(cfg, self.REQUEST)
+        try:
+            conn.init()
+            # Without the fix the payload is collected as frames and the body
+            # read blocks on a socket that will never carry it again. Fail
+            # instead of hanging CI.
+            conn.sock.settimeout(5)
+            req = next(conn.parser)
+            settings = negotiation.upgrade_settings(req)
+            assert settings is not None
+
+            worker = _StubThreadWorker(cfg)
+            worker.handle_h2c_upgrade(conn, req, settings)
+
+            assert len(worker.served) == 1
+            assert worker.served[0].body.read() == b"hello=world"
+            assert not worker.log.exception.called
+        finally:
+            client.close()
+            conn.sock.close()
+
+    def test_gevent(self):
+        cfg = h2c_config()
+        cfg.set("http2_cleartext", "upgrade")
+        worker = run_async_handle(cfg, self.REQUEST, close_client=False)
+
+        assert len(worker.upgrades) == 1
+        _settings, _req, body = worker.upgrades[0]
+        assert body == b"hello=world"
+        # only the frames are replayed into HTTP/2, never the payload
+        assert worker.http2_calls == [negotiation.H2C_PREFACE]
+        assert not worker.errors
 
 
 @pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -868,6 +868,71 @@ class TestH2CASGIUpgrade:
             assert proto._h2c_upgrade_ok is False
 
 
+class TestH2CASGIBothModes:
+    """With both mechanisms on, a non-preface is not an error.
+
+    The sniffer sees the HTTP/1 request that carries the upgrade before
+    anything else does, so refusing every non-preface would reject exactly
+    what ``both`` exists to accept.
+    """
+
+    def _connect(self, mode, peername=TRUSTED_ADDR):
+        cfg = h2c_config()
+        cfg.set("http2_cleartext", mode)
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        proto = make_asgi_protocol(cfg, loop)
+        transport = _FakeTransport(peername)
+        proto.connection_made(transport)
+        return proto, transport, loop
+
+    @contextlib.contextmanager
+    def _protocol(self, mode):
+        proto, transport, loop = self._connect(mode)
+        try:
+            yield proto, transport
+        finally:
+            proto._h2c_cancel_timer()
+            if proto._task is not None:
+                proto._task.cancel()
+            loop.close()
+            asyncio.set_event_loop(None)
+
+    def test_upgrade_request_survives_the_sniffer(self):
+        with self._protocol("both") as (proto, transport):
+            proto.data_received(
+                upgrade_request() + negotiation.H2C_PREFACE)
+            assert b"400" not in transport.written
+            assert proto._h2c_upgrade_settings is not None
+            assert bytes(proto.reader._buffer) == negotiation.H2C_PREFACE
+
+    def test_plain_http1_is_served(self):
+        with self._protocol("both") as (proto, transport):
+            proto.data_received(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+            assert b"400" not in transport.written
+            assert not transport.closed
+            assert proto._current_request is not None
+
+    def test_prior_knowledge_alone_still_refuses(self):
+        with self._protocol("prior-knowledge") as (proto, transport):
+            proto.data_received(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+            assert b"400" in transport.written
+            assert transport.closed
+
+    def test_quiet_client_is_not_refused(self):
+        with self._protocol("both") as (proto, transport):
+            proto._h2c_undecided_timeout()
+            assert b"400" not in transport.written
+            assert not transport.closed
+            assert proto._callback_parser is not None
+
+    def test_quiet_client_is_refused_under_prior_knowledge(self):
+        with self._protocol("prior-knowledge") as (proto, transport):
+            proto._h2c_undecided_timeout()
+            assert b"400" in transport.written
+            assert transport.closed
+
+
 @pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")
 @pytest.mark.parametrize("parser", ["fast", "python"])
 class TestH2CASGIUpgradeEndToEnd:


### PR DESCRIPTION
Finishes the HTTP/2 work.

`Upgrade: h2c` is served on the gthread, gevent and asgi workers: a client
asking to upgrade over HTTP/1.1 gets a 101 and the connection carries on as
HTTP/2, with the upgraded request served as stream 1, behind the same
`forwarded_allow_ips` gate as prior knowledge. `http2_cleartext` now means the
same thing on the three workers.

The delicate part is the bytes a client sends straight after the upgrade
request. On the sync workers they are already in the parser's unreader. On ASGI
there was no way to get them back until gunicorn_h1c 0.6.8 added `remaining()`;
`PythonProtocol` gains the same accessor so the parser choice does not decide
which protocols are available. The ASGI handover runs synchronously in
`data_received()`, which is what keeps the preface and the frames behind it away
from the HTTP/1 parser.

Two bugs came out of testing this against real clients rather than mocks.

A payload on the upgrade request shares that same buffer, and the sync workers
collected the frames before draining it, so the payload was replayed into the
HTTP/2 state machine as a connection preface. A POST upgraded by curl was enough
to kill the connection.

Enabling upgrade also forced narrowing the refusal policy. A trusted peer that
does not send the preface is only refused with 400 when prior knowledge is the
only mechanism. With upgrade enabled an HTTP/1 request is how an upgrade begins,
so `both` was rejecting the very request it exists to accept, and plain HTTP/1
with it.

Chunked upgrade requests stay on HTTP/1.1 on the ASGI worker. The fast parser
hands their payload back still encoded and mixed into the following bytes, so
there is no boundary to split on. The sync workers are unaffected.

Also carries the changelog and guide for everything merged since 26.1.0 that had
no entry: h2c on the three workers, the header policy fix, response streaming,
and the no-body and flow-control fixes.

## Breaking changes

None. `http2_cleartext` stays `off` by default. The 400 on a non-preface still
applies to `prior-knowledge`, which is the only value that did anything before.
