### PR TITLE
uwsgi: fix response handling

### DIFF
--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -1121,6 +1121,8 @@ class ASGIProtocol(asyncio.Protocol):
         use_chunked = False
         omits_body = False
         omits_body_warned = False
+        response_requires_close = False
+        uses_uwsgi = getattr(self.cfg, "protocol", "http") == "uwsgi"
 
         # Reset response buffer for write batching
         self._response_buffer = None
@@ -1136,7 +1138,7 @@ class ASGIProtocol(asyncio.Protocol):
         async def send(message):
             nonlocal response_started, response_complete, exc_to_raise
             nonlocal response_status, response_headers, response_sent, use_chunked, omits_body
-            nonlocal omits_body_warned
+            nonlocal omits_body_warned, response_requires_close
 
             # If client disconnected, silently ignore send attempts
             # This allows apps to finish cleanup without errors
@@ -1171,6 +1173,20 @@ class ASGIProtocol(asyncio.Protocol):
                         has_transfer_encoding = True
                         use_chunked = True  # Framework already set chunked encoding
 
+                # Transfer-Encoding is HTTP hop-by-hop framing.  A uWSGI
+                # upstream response carries raw body bytes, so forwarding or
+                # applying it would make nginx expose the chunk markers as
+                # part of the application response.
+                if uses_uwsgi and has_transfer_encoding:
+                    response_headers = [
+                        (name, value) for name, value in response_headers
+                        if name.lower() not in (
+                            b"transfer-encoding", "transfer-encoding"
+                        )
+                    ]
+                    has_transfer_encoding = False
+                    use_chunked = False
+
                 # No-body responses (HEAD/1xx/204/304) must not carry a body.
                 # Always drop Transfer-Encoding (no chunked terminator without
                 # a body); Content-Length is dropped only for statuses that
@@ -1194,10 +1210,17 @@ class ASGIProtocol(asyncio.Protocol):
                     and not has_transfer_encoding
                     and request.version >= (1, 1)
                     and not omits_body
+                    and not uses_uwsgi
                 )
                 if needs_chunked:
                     use_chunked = True
                     response_headers = list(response_headers) + [(b"transfer-encoding", b"chunked")]
+
+                # Without Content-Length, EOF delimits a uWSGI response body.
+                # Do not reuse the upstream connection for another request.
+                response_requires_close = (
+                    uses_uwsgi and not has_content_length and not omits_body
+                )
 
                 self._send_response_start(response_status, response_headers, request)
 
@@ -1302,6 +1325,9 @@ class ASGIProtocol(asyncio.Protocol):
                 self.log.exception("Exception in post_request hook")
 
         # Determine keepalive
+        if response_requires_close:
+            return False
+
         if request.should_close():
             return False
 

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -411,6 +411,12 @@ class Response:
         # Only use chunked responses when the client is
         # speaking HTTP/1.1 or newer and there was
         # no Content-Length header set.
+        #
+        # uWSGI response bodies are not HTTP message bodies: nginx treats
+        # them as opaque bytes and chooses the downstream HTTP framing.  If
+        # we add HTTP chunk markers here they leak into the application body.
+        if getattr(self.cfg, "protocol", "http") == "uwsgi":
+            return False
         if self.response_length is not None:
             return False
         elif self.req.version <= (1, 0):

--- a/tests/docker/uwsgi/test_uwsgi_integration.py
+++ b/tests/docker/uwsgi/test_uwsgi_integration.py
@@ -26,7 +26,7 @@ class TestBasicRequests:
         """Test basic GET request to root endpoint."""
         response = requests.get(f'{nginx_url}/')
         assert response.status_code == 200
-        assert b'Hello from gunicorn uWSGI!' in response.content
+        assert response.content == b'Hello from gunicorn uWSGI!\n'
 
     def test_get_with_query_string(self, nginx_url):
         """Test GET request with query string parameters."""

--- a/tests/test_asgi_uwsgi.py
+++ b/tests/test_asgi_uwsgi.py
@@ -6,10 +6,14 @@
 Tests for ASGI uWSGI protocol parser.
 """
 
+from unittest import mock
+
 import pytest
 
+from gunicorn.asgi.protocol import ASGIProtocol, BodyReceiver
 from gunicorn.asgi.unreader import AsyncUnreader
 from gunicorn.asgi.uwsgi import AsyncUWSGIRequest
+from gunicorn.config import Config
 from gunicorn.uwsgi.errors import (
     InvalidUWSGIHeader,
     UnsupportedModifier,
@@ -70,6 +74,67 @@ def build_uwsgi_packet(vars_dict, modifier1=0, modifier2=0):
     header += bytes([modifier2])
 
     return header + vars_data
+
+
+@pytest.mark.asyncio
+async def test_response_without_content_length_is_not_http_chunked():
+    """uWSGI sends raw body bytes and closes to delimit an unknown length."""
+    async def app(scope, receive, send):
+        await send({
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"text/plain")],
+        })
+        await send({
+            "type": "http.response.body",
+            "body": b"Hello, world!\n",
+            "more_body": False,
+        })
+
+    cfg = Config()
+    cfg.set("protocol", "uwsgi")
+    worker = mock.Mock()
+    worker.cfg = cfg
+    worker.log = mock.Mock()
+    worker.log.access_log_enabled = False
+    worker.asgi = app
+    worker.nr = 0
+    worker.max_requests = 1000
+    worker.alive = True
+    worker.state = {}
+
+    protocol = ASGIProtocol(worker)
+    protocol.transport = mock.Mock()
+
+    request = mock.Mock()
+    request.method = "GET"
+    request.path = "/"
+    request.raw_path = b"/"
+    request.query = ""
+    request.version = (1, 1)
+    request.scheme = "http"
+    request.headers = []
+    request.headers_bytes = []
+    request.uri = "/"
+    request.should_close.return_value = False
+    request.content_length = 0
+    request.chunked = False
+
+    protocol._body_receiver = BodyReceiver(request, protocol)
+    protocol._body_receiver.set_complete()
+
+    keepalive = await protocol._handle_http_request(
+        request, ("127.0.0.1", 8000), ("127.0.0.1", 50000)
+    )
+
+    wire = b"".join(
+        call.args[0] for call in protocol.transport.write.call_args_list
+    )
+    headers, body = wire.split(b"\r\n\r\n", 1)
+
+    assert b"transfer-encoding" not in headers.lower()
+    assert body == b"Hello, world!\n"
+    assert keepalive is False
 
 
 # Basic parsing tests

--- a/tests/test_uwsgi.py
+++ b/tests/test_uwsgi.py
@@ -6,6 +6,8 @@ import io
 import pytest
 from unittest import mock
 
+from gunicorn.config import Config
+from gunicorn.http.wsgi import Response
 from gunicorn.uwsgi import (
     UWSGIRequest,
     UWSGIParser,
@@ -360,6 +362,35 @@ class TestUWSGIParser:
     def test_parser_mesg_class(self):
         """Test that parser uses UWSGIRequest."""
         assert UWSGIParser.mesg_class is UWSGIRequest
+
+
+class TestUWSGIResponse:
+    """Test response framing on a uWSGI upstream connection."""
+
+    def test_response_without_content_length_is_not_http_chunked(self):
+        cfg = Config()
+        cfg.set("protocol", "uwsgi")
+
+        req = mock.Mock()
+        req.method = "GET"
+        req.version = (1, 1)
+        req.should_close.return_value = False
+        sock = mock.Mock()
+
+        resp = Response(req, sock, cfg)
+        resp.start_response("200 OK", [("Content-Type", "text/plain")])
+        resp.write(b"Hello, world!\n")
+        resp.close()
+
+        wire = b"".join(
+            call.args[0] for call in sock.sendall.call_args_list
+        )
+        headers, body = wire.split(b"\r\n\r\n", 1)
+
+        assert b"Transfer-Encoding" not in headers
+        assert b"Connection: close" in headers
+        assert body == b"Hello, world!\n"
+        assert resp.should_close() is True
 
 
 class TestExceptionStrings:


### PR DESCRIPTION
Strip Transfer-Encoding headers when an app is served through the uWSGI protocol, so chunk markers are not forwarded as part of the application payload. This keeps the body framing consistent with the raw-byte uWSGI response semantics and avoids leaking chunk encoding to clients behind nginx.

Also update the close-response logic and add regression coverage for the uWSGI integration and behavior.

fix: https://github.com/benoitc/gunicorn/discussions/3697