### PR TITLE
Stop writing a 500 on top of a response that already started

### DIFF
--- a/docs/content/news.md
+++ b/docs/content/news.md
@@ -1,6 +1,15 @@
 <span id="news"></span>
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- Worker timeout used to dump a 500 response onto a body that had already
+  started, because `sys.exit()` from the abort handler is a `BaseException`.
+  Once headers are out we just close the connection.
+  ([#3410](https://github.com/benoitc/gunicorn/issues/3410)).
+
 ## 26.2.0 - 2026-08-24
 
 ### New Features

--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -306,7 +306,7 @@ class AsyncWorker(base.Worker):
             # If the original exception was a socket.error we delegate
             # handling it to the caller (where handle() might ignore it)
             util.reraise(*sys.exc_info())
-        except BaseException:
+        except (Exception, SystemExit):
             if resp and resp.headers_sent:
                 # Timeout abort is SystemExit. If we already started the
                 # response, writing a 500 on the same socket corrupts it.

--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -306,10 +306,10 @@ class AsyncWorker(base.Worker):
             # If the original exception was a socket.error we delegate
             # handling it to the caller (where handle() might ignore it)
             util.reraise(*sys.exc_info())
-        except Exception:
+        except BaseException:
             if resp and resp.headers_sent:
-                # If the requests have already been sent, we should close the
-                # connection to indicate the error.
+                # Timeout abort is SystemExit. If we already started the
+                # response, writing a 500 on the same socket corrupts it.
                 self.log.exception("Error handling request")
                 try:
                     sock.shutdown(socket.SHUT_RDWR)

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -730,7 +730,7 @@ class ThreadWorker(base.Worker):
         except OSError:
             # pass to next try-except level
             util.reraise(*sys.exc_info())
-        except BaseException:
+        except (Exception, SystemExit):
             if resp and resp.headers_sent:
                 # Timeout abort is SystemExit. If we already started the
                 # response, writing a 500 on the same socket corrupts it.

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -730,10 +730,10 @@ class ThreadWorker(base.Worker):
         except OSError:
             # pass to next try-except level
             util.reraise(*sys.exc_info())
-        except Exception:
+        except BaseException:
             if resp and resp.headers_sent:
-                # If the requests have already been sent, we should close the
-                # connection to indicate the error.
+                # Timeout abort is SystemExit. If we already started the
+                # response, writing a 500 on the same socket corrupts it.
                 self.log.exception("Error handling request")
                 util.close_graceful(conn.sock)
                 raise StopIteration()

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -197,7 +197,7 @@ class SyncWorker(base.Worker):
         except OSError:
             # pass to next try-except level
             util.reraise(*sys.exc_info())
-        except BaseException:
+        except (Exception, SystemExit):
             if resp and resp.headers_sent:
                 # Timeout abort is SystemExit. If we already started the
                 # response, writing a 500 on the same socket corrupts it.

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -197,10 +197,10 @@ class SyncWorker(base.Worker):
         except OSError:
             # pass to next try-except level
             util.reraise(*sys.exc_info())
-        except Exception:
+        except BaseException:
             if resp and resp.headers_sent:
-                # If the requests have already been sent, we should close the
-                # connection to indicate the error.
+                # Timeout abort is SystemExit. If we already started the
+                # response, writing a 500 on the same socket corrupts it.
                 self.log.exception("Error handling request")
                 util.close_graceful(client)
                 raise StopIteration()


### PR DESCRIPTION
Worker timeout fires SIGABRT → `sys.exit(1)`. That's a BaseException, so the `except Exception` guard that checks `headers_sent` never ran. `handle_error` then wrote a 500 onto the same socket, which is how wget ended up with ISE HTML concatenated onto a partial download.

Once headers are out we just close, same as a regular exception.

Fixes #3410
