### PR TITLE
http2: bound the request body held per stream

### DIFF
--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -1,6 +1,19 @@
 <span id="news-2026"></span>
 # Changelog - 2026
 
+## Unreleased
+
+### Bug Fixes
+
+- **HTTP/2 request bodies were buffered without bound**: a stream's DATA
+  frames were kept in two buffers, copied twice more at dispatch, and flow
+  control credit was returned as soon as each frame arrived, so a client that
+  never sent END_STREAM could grow a worker's memory without the application
+  being called. The body is now kept once, handed over without copying, and
+  bounded by the new `http2_max_request_body_size` setting (default 100MB): a
+  stream that grows past it is answered with `413` and reset before dispatch.
+  Only listeners with `h2` in `http_protocols` were affected.
+
 ## 26.2.0 - 2026-08-24
 
 ### New Features

--- a/docs/content/guides/http2.md
+++ b/docs/content/guides/http2.md
@@ -142,6 +142,7 @@ Fine-tune HTTP/2 behavior with these settings:
 | `http2_initial_window_size` | 65535 | Initial flow control window size (bytes) |
 | `http2_max_frame_size` | 16384 | Maximum frame size (bytes) |
 | `http2_max_header_list_size` | 65536 | Maximum header list size (bytes) |
+| `http2_max_request_body_size` | 104857600 | Maximum request body held per stream (bytes), 413 above it |
 
 Example configuration:
 
@@ -775,6 +776,7 @@ protections against known vulnerabilities.
 |--------|------------|---------|
 | Stream Multiplexing Abuse | Limit concurrent streams | `http2_max_concurrent_streams` (default: 100) |
 | HPACK Bomb | Header size limits | `http2_max_header_list_size` (default: 65536) |
+| Unbounded Upload | Request body limit, 413 and RST_STREAM before dispatch | `http2_max_request_body_size` (default: 104857600) |
 | Large Frame Attack | Frame size limits | `http2_max_frame_size` (validated: 16384-16777215) |
 | Resource Exhaustion | Flow control windows | `http2_initial_window_size` (default: 65535) |
 | Slow Read (Slowloris) | Connection timeouts | `timeout` and `keepalive` settings |
@@ -789,6 +791,9 @@ http2_max_concurrent_streams = 100
 
 # Limit header size to prevent HPACK bomb attacks
 http2_max_header_list_size = 65536  # 64KB
+
+# Bound the body buffered per stream before the app sees the request
+http2_max_request_body_size = 104857600  # 100MB
 
 # Standard frame size (RFC minimum)
 http2_max_frame_size = 16384

--- a/docs/content/reference/settings.md
+++ b/docs/content/reference/settings.md
@@ -527,6 +527,25 @@ Default is 65536 (64KB). Set to 0 for unlimited (not recommended).
 
 !!! info "Added in 25.0.0"
 
+### `http2_max_request_body_size`
+
+**Command line:** `--http2-max-request-body-size INT`
+
+**Default:** `104857600`
+
+Maximum HTTP/2 request body size in bytes.
+
+The body of an HTTP/2 request is held in memory until the stream
+ends and the request is handed to the application. A stream whose
+body grows past this limit is answered with `413` and reset
+before the application is called, so the memory held per stream
+is bounded.
+
+Default is 104857600 (100MB). Set to 0 for unlimited (not
+recommended).
+
+!!! info "Added in 26.3.0"
+
 ## Logging
 
 ### `accesslog`

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -2650,6 +2650,30 @@ class HTTP2MaxHeaderListSize(Setting):
         """
 
 
+class HTTP2MaxRequestBodySize(Setting):
+    name = "http2_max_request_body_size"
+    section = "HTTP/2"
+    cli = ["--http2-max-request-body-size"]
+    meta = "INT"
+    validator = validate_pos_int
+    type = int
+    default = 104857600
+    desc = """\
+        Maximum HTTP/2 request body size in bytes.
+
+        The body of an HTTP/2 request is held in memory until the stream
+        ends and the request is handed to the application. A stream whose
+        body grows past this limit is answered with ``413`` and reset
+        before the application is called, so the memory held per stream
+        is bounded.
+
+        Default is 104857600 (100MB). Set to 0 for unlimited (not
+        recommended).
+
+        .. versionadded:: 26.3.0
+        """
+
+
 class PasteGlobalConf(Setting):
     name = "raw_paste_global_conf"
     action = "append"

--- a/gunicorn/http2/async_connection.py
+++ b/gunicorn/http2/async_connection.py
@@ -88,6 +88,7 @@ class AsyncHTTP2Connection:
         # Connection settings from config
         self.initial_window_size = cfg.http2_initial_window_size
         self.max_concurrent_streams = cfg.http2_max_concurrent_streams
+        self.max_request_body_size = cfg.http2_max_request_body_size
         self.max_frame_size = cfg.http2_max_frame_size
         self.max_header_list_size = cfg.http2_max_header_list_size
 
@@ -303,6 +304,15 @@ class AsyncHTTP2Connection:
 
         stream = self.streams.get(stream_id)
         if stream is None:
+            # Stream was reset or doesn't exist
+            return None
+
+        limit = self.max_request_body_size
+        if limit and stream.body_size + len(data) > limit:
+            self._refuse_body_too_large(stream_id)
+            # The frame still consumed connection-level window credit.
+            if len(data) > 0:
+                self.h2_conn.increment_flow_control_window(len(data), stream_id=None)
             return None
 
         stream.receive_data(data, end_stream=False)
@@ -324,6 +334,27 @@ class AsyncHTTP2Connection:
                     pass
 
         return None
+
+    def _refuse_body_too_large(self, stream_id):
+        """Answer 413 and reset a stream whose body outgrew the limit.
+
+        The request never reaches the application. The stream is dropped
+        so its buffered body is released and later frames on it are
+        ignored. RST_STREAM carries NO_ERROR: the response is complete
+        and the client is only asked to stop sending (RFC 9113 8.1).
+        """
+        stream = self.streams.pop(stream_id, None)
+        if stream is not None:
+            stream.reset(HTTP2ErrorCode.NO_ERROR)
+        try:
+            self.h2_conn.send_headers(
+                stream_id,
+                [(':status', '413'), ('content-length', '0')],
+                end_stream=True,
+            )
+            self.h2_conn.reset_stream(stream_id, error_code=HTTP2ErrorCode.NO_ERROR)
+        except _h2_exceptions.ProtocolError:
+            pass
 
     def _handle_stream_ended(self, event):
         """Handle StreamEnded event."""

--- a/gunicorn/http2/connection.py
+++ b/gunicorn/http2/connection.py
@@ -87,6 +87,7 @@ class HTTP2ServerConnection:
         # Connection settings from config
         self.initial_window_size = cfg.http2_initial_window_size
         self.max_concurrent_streams = cfg.http2_max_concurrent_streams
+        self.max_request_body_size = cfg.http2_max_request_body_size
         self.max_frame_size = cfg.http2_max_frame_size
         self.max_header_list_size = cfg.http2_max_header_list_size
 
@@ -317,6 +318,14 @@ class HTTP2ServerConnection:
             # Stream was reset or doesn't exist
             return None
 
+        limit = self.max_request_body_size
+        if limit and stream.body_size + len(data) > limit:
+            self._refuse_body_too_large(stream_id)
+            # The frame still consumed connection-level window credit.
+            if len(data) > 0:
+                self.h2_conn.increment_flow_control_window(len(data), stream_id=None)
+            return None
+
         stream.receive_data(data, end_stream=False)
 
         # Increment flow control windows (only if data received)
@@ -333,6 +342,27 @@ class HTTP2ServerConnection:
                 self.close(error_code=HTTP2ErrorCode.FLOW_CONTROL_ERROR)
 
         return None
+
+    def _refuse_body_too_large(self, stream_id):
+        """Answer 413 and reset a stream whose body outgrew the limit.
+
+        The request never reaches the application. The stream is dropped
+        so its buffered body is released and later frames on it are
+        ignored. RST_STREAM carries NO_ERROR: the response is complete
+        and the client is only asked to stop sending (RFC 9113 8.1).
+        """
+        stream = self.streams.pop(stream_id, None)
+        if stream is not None:
+            stream.reset(HTTP2ErrorCode.NO_ERROR)
+        try:
+            self.h2_conn.send_headers(
+                stream_id,
+                [(':status', '413'), ('content-length', '0')],
+                end_stream=True,
+            )
+            self.h2_conn.reset_stream(stream_id, error_code=HTTP2ErrorCode.NO_ERROR)
+        except _h2_exceptions.ProtocolError:
+            pass
 
     def _handle_stream_ended(self, event):
         """Handle StreamEnded event.

--- a/gunicorn/http2/stream.py
+++ b/gunicorn/http2/stream.py
@@ -10,7 +10,6 @@ Each HTTP/2 stream represents a single request/response exchange.
 """
 
 from enum import Enum, auto
-from io import BytesIO
 
 from .errors import HTTP2StreamError
 
@@ -49,7 +48,6 @@ class HTTP2Stream:
 
         # Request data
         self.request_headers = []
-        self.request_body = BytesIO()
         self.request_complete = False
 
         # Response data
@@ -71,8 +69,12 @@ class HTTP2Stream:
         self.priority_depends_on = 0
         self.priority_exclusive = False
 
-        # Streaming body support (avoids buffering entire uploads)
+        # Request body: one list of DATA payloads, in arrival order. It
+        # is the only copy kept; get_request_body() joins it once and
+        # read_body_chunk() drains it. body_size counts every byte that
+        # arrived so the connection can bound what a stream may hold.
         self._body_chunks = []
+        self.body_size = 0
         self._body_event = None  # Lazy-init asyncio.Event
         self._body_complete = False
 
@@ -142,14 +144,11 @@ class HTTP2Stream:
                 f"Cannot receive data in state {self.state.name}"
             )
 
-        # Add to chunks queue for streaming reads
         if data:
             self._body_chunks.append(data)
+            self.body_size += len(data)
             if self._body_event:
                 self._body_event.set()
-
-        # Also write to legacy BytesIO for compatibility
-        self.request_body.write(data)
 
         if end_stream:
             self._half_close_remote()
@@ -296,7 +295,9 @@ class HTTP2Stream:
         Returns:
             bytes: The request body data
         """
-        return self.request_body.getvalue()
+        if len(self._body_chunks) == 1:
+            return self._body_chunks[0]
+        return b"".join(self._body_chunks)
 
     async def read_body_chunk(self):
         """Read next body chunk asynchronously for streaming.

--- a/tests/test_early_hints.py
+++ b/tests/test_early_hints.py
@@ -45,6 +45,7 @@ class MockConfig:
         self.http2_initial_window_size = 65535
         self.http2_max_frame_size = 16384
         self.http2_max_header_list_size = 65536
+        self.http2_max_request_body_size = 104857600
 
     def forwarded_allow_networks(self):
         return []

--- a/tests/test_http2_async_connection.py
+++ b/tests/test_http2_async_connection.py
@@ -17,6 +17,7 @@ try:
     import h2.connection
     import h2.config
     import h2.events
+    import h2.errors
     H2_AVAILABLE = True
 except ImportError:
     H2_AVAILABLE = False
@@ -228,6 +229,86 @@ class TestAsyncHTTP2ConnectionReceiveData:
         assert len(requests) == 1
         assert requests[0].method == 'GET'
         assert requests[0].path == '/async-test'
+
+    async def _post_over_limit(self, cfg_limit=1000):
+        from gunicorn.http2.async_connection import AsyncHTTP2Connection
+
+        cfg = MockConfig()
+        cfg.set("http2_max_request_body_size", cfg_limit)
+        reader = MockAsyncReader()
+        writer = MockAsyncWriter()
+        conn = AsyncHTTP2Connection(cfg, reader, writer, ('127.0.0.1', 12345))
+        await conn.initiate_connection()
+
+        client = create_client_connection()
+        reader.set_data(client.data_to_send())
+        await conn.receive_data()
+        client.receive_data(writer.get_written_data())
+        writer.clear()
+
+        client.send_headers(
+            stream_id=1,
+            headers=[
+                (':method', 'POST'),
+                (':path', '/upload'),
+                (':scheme', 'https'),
+                (':authority', 'localhost'),
+            ],
+            end_stream=False
+        )
+        client.send_data(stream_id=1, data=b"a" * 600, end_stream=False)
+        client.send_data(stream_id=1, data=b"b" * 600, end_stream=False)
+        reader.set_data(client.data_to_send())
+        requests = await conn.receive_data()
+        return conn, client, reader, writer, requests
+
+    @pytest.mark.asyncio
+    async def test_body_over_limit_gets_413_and_reset_before_dispatch(self):
+        conn, client, reader, writer, requests = await self._post_over_limit()
+
+        assert requests == []
+        assert 1 not in conn.streams
+        assert conn.is_closed is False
+
+        events = client.receive_data(writer.get_written_data())
+        statuses = [
+            dict(e.headers)[b':status'] for e in events
+            if isinstance(e, h2.events.ResponseReceived)
+        ]
+        assert statuses == [b'413']
+        resets = [e for e in events if isinstance(e, h2.events.StreamReset)]
+        assert len(resets) == 1
+        assert resets[0].stream_id == 1
+        assert resets[0].error_code == h2.errors.ErrorCodes.NO_ERROR
+
+    @pytest.mark.asyncio
+    async def test_body_over_limit_later_frames_are_ignored(self):
+        conn, client, reader, writer, requests = await self._post_over_limit()
+
+        # The client has not seen the reset yet and finishes the upload.
+        client.send_data(stream_id=1, data=b"c" * 600, end_stream=True)
+        reader.set_data(client.data_to_send())
+        requests = await conn.receive_data()
+        assert requests == []
+        assert 1 not in conn.streams
+        assert conn.is_closed is False
+
+        # The next stream on the connection is served normally.
+        client.receive_data(writer.get_written_data())
+        client.send_headers(
+            stream_id=3,
+            headers=[
+                (':method', 'GET'),
+                (':path', '/'),
+                (':scheme', 'https'),
+                (':authority', 'localhost'),
+            ],
+            end_stream=True
+        )
+        reader.set_data(client.data_to_send())
+        requests = await conn.receive_data()
+        assert len(requests) == 1
+        assert requests[0].stream.stream_id == 3
 
     @pytest.mark.asyncio
     async def test_receive_with_timeout(self):

--- a/tests/test_http2_config.py
+++ b/tests/test_http2_config.py
@@ -341,3 +341,26 @@ class TestValidateHttp2FrameSize:
         """Negative values should raise ValueError."""
         with pytest.raises(ValueError):
             config.validate_http2_frame_size(-1)
+
+
+class TestHttp2MaxRequestBodySizeConfig:
+    """Test http2_max_request_body_size configuration setting."""
+
+    def test_default(self):
+        c = Config()
+        assert c.http2_max_request_body_size == 104857600
+
+    def test_set_value(self):
+        c = Config()
+        c.set("http2_max_request_body_size", "1048576")
+        assert c.http2_max_request_body_size == 1048576
+
+    def test_zero_is_allowed(self):
+        c = Config()
+        c.set("http2_max_request_body_size", 0)
+        assert c.http2_max_request_body_size == 0
+
+    def test_negative_rejected(self):
+        c = Config()
+        with pytest.raises(ValueError):
+            c.set("http2_max_request_body_size", -1)

--- a/tests/test_http2_connection.py
+++ b/tests/test_http2_connection.py
@@ -17,6 +17,7 @@ try:
     import h2.config
     import h2.events
     import h2.exceptions
+    import h2.errors
     H2_AVAILABLE = True
 except ImportError:
     H2_AVAILABLE = False
@@ -258,6 +259,107 @@ class TestHTTP2ServerConnectionReceiveData:
         req = requests[0]
         assert req.method == 'POST'
         assert req.body.read() == b'{"key":"val"}'
+
+    def _post_without_end_stream(self, body_limit, chunks):
+        """Send DATA frames on stream 1 and never END_STREAM.
+
+        Returns (conn, client, sock, all requests produced).
+        """
+        from gunicorn.http2.connection import HTTP2ServerConnection
+
+        cfg = MockConfig()
+        cfg.set("http2_max_request_body_size", body_limit)
+        sock = MockSocket()
+        conn = HTTP2ServerConnection(cfg, sock, ('127.0.0.1', 12345))
+        conn.initiate_connection()
+
+        client = create_client_connection()
+        conn.receive_data(client.data_to_send())
+        client.receive_data(sock.get_sent_data())
+
+        client.send_headers(
+            stream_id=1,
+            headers=[
+                (':method', 'POST'),
+                (':path', '/upload'),
+                (':scheme', 'https'),
+                (':authority', 'localhost'),
+            ],
+            end_stream=False
+        )
+        requests = list(conn.receive_data(client.data_to_send()))
+        sent_before = len(sock.get_sent_data())
+        for chunk in chunks:
+            client.send_data(stream_id=1, data=chunk, end_stream=False)
+            requests += conn.receive_data(client.data_to_send())
+        return conn, client, sock, requests, sent_before
+
+    def test_body_over_limit_gets_413_and_reset_before_dispatch(self):
+        conn, client, sock, requests, sent_before = self._post_without_end_stream(
+            body_limit=1000, chunks=[b"a" * 600, b"b" * 600])
+
+        assert requests == []
+        assert 1 not in conn.streams
+
+        events = client.receive_data(sock.get_sent_data()[sent_before:])
+        statuses = [
+            dict(e.headers)[b':status'].decode() for e in events
+            if isinstance(e, h2.events.ResponseReceived)
+        ]
+        assert statuses == ['413']
+        resets = [e for e in events if isinstance(e, h2.events.StreamReset)]
+        assert len(resets) == 1
+        assert resets[0].stream_id == 1
+        assert resets[0].error_code == h2.errors.ErrorCodes.NO_ERROR
+        assert resets[0].remote_reset is True
+
+    def test_body_over_limit_later_frames_are_ignored(self):
+        conn, client, sock, requests, _ = self._post_without_end_stream(
+            body_limit=1000, chunks=[b"a" * 600, b"b" * 600])
+
+        # Client keeps sending before it sees the reset. Nothing is kept,
+        # no request is produced, the connection stays open.
+        client.send_data(stream_id=1, data=b"c" * 600, end_stream=False)
+        client.send_data(stream_id=1, data=b"d" * 600, end_stream=True)
+        requests = conn.receive_data(client.data_to_send())
+
+        assert requests == []
+        assert 1 not in conn.streams
+        assert conn.is_closed is False
+
+        # A new stream on the same connection still works.
+        client.receive_data(sock.get_sent_data())
+        client.send_headers(
+            stream_id=3,
+            headers=[
+                (':method', 'GET'),
+                (':path', '/'),
+                (':scheme', 'https'),
+                (':authority', 'localhost'),
+            ],
+            end_stream=True
+        )
+        requests = conn.receive_data(client.data_to_send())
+        assert len(requests) == 1
+        assert requests[0].stream.stream_id == 3
+
+    def test_body_at_limit_is_accepted(self):
+        conn, client, sock, requests, _ = self._post_without_end_stream(
+            body_limit=1200, chunks=[b"a" * 600, b"b" * 600])
+
+        assert requests == []
+        assert 1 in conn.streams
+        client.send_data(stream_id=1, data=b"", end_stream=True)
+        requests = conn.receive_data(client.data_to_send())
+        assert len(requests) == 1
+        assert requests[0].body.read() == b"a" * 600 + b"b" * 600
+
+    def test_body_limit_zero_is_unlimited(self):
+        conn, client, sock, requests, _ = self._post_without_end_stream(
+            body_limit=0, chunks=[b"a" * 16000, b"b" * 16000, b"c" * 16000])
+
+        assert 1 in conn.streams
+        assert conn.streams[1].body_size == 48000
 
     def test_socket_error_raises_connection_error(self):
         from gunicorn.http2.connection import HTTP2ServerConnection

--- a/tests/test_http2_request.py
+++ b/tests/test_http2_request.py
@@ -10,7 +10,7 @@ import pytest
 from gunicorn.config import Config
 from gunicorn.http.errors import InvalidHeader
 from gunicorn.http2.request import HTTP2Request, HTTP2Body
-from gunicorn.http2.stream import HTTP2Stream
+from gunicorn.http2.stream import HTTP2Stream, StreamState
 
 
 class MockConnection:
@@ -163,8 +163,8 @@ class TestHTTP2Request:
         stream = HTTP2Stream(stream_id=1, connection=conn)
         stream.receive_headers(headers, end_stream=(len(body) == 0))
         if body:
-            stream.request_body.write(body)
-            stream.request_complete = True
+            stream.state = StreamState.OPEN
+            stream.receive_data(body, end_stream=True)
         return stream
 
     def test_basic_get_request(self):

--- a/tests/test_http2_stream.py
+++ b/tests/test_http2_stream.py
@@ -222,7 +222,7 @@ class TestReceiveData:
 
         stream.receive_data(b"Hello, World!", end_stream=False)
 
-        assert stream.request_body.getvalue() == b"Hello, World!"
+        assert stream.get_request_body() == b"Hello, World!"
         assert stream.request_complete is False
 
     def test_receive_data_with_end_stream(self):
@@ -244,7 +244,8 @@ class TestReceiveData:
         stream.receive_data(b"Part2")
         stream.receive_data(b"Part3", end_stream=True)
 
-        assert stream.request_body.getvalue() == b"Part1Part2Part3"
+        assert stream.get_request_body() == b"Part1Part2Part3"
+        assert stream.body_size == 15
 
     def test_receive_data_in_half_closed_local(self):
         conn = MockConnection()
@@ -252,7 +253,7 @@ class TestReceiveData:
         stream.state = StreamState.HALF_CLOSED_LOCAL
 
         stream.receive_data(b"data", end_stream=False)
-        assert stream.request_body.getvalue() == b"data"
+        assert stream.get_request_body() == b"data"
 
     def test_receive_data_in_invalid_state(self):
         conn = MockConnection()
@@ -475,6 +476,19 @@ class TestGetRequestBody:
         stream.receive_data(b"Test body content")
 
         assert stream.get_request_body() == b"Test body content"
+
+
+    def test_single_copy_is_kept(self):
+        """One DATA frame is handed back as-is: no join, no second buffer."""
+        conn = MockConnection()
+        stream = HTTP2Stream(stream_id=1, connection=conn)
+        stream.state = StreamState.OPEN
+        payload = b"x" * 1024
+        stream.receive_data(payload, end_stream=True)
+
+        assert stream.get_request_body() is payload
+        assert stream.body_size == 1024
+        assert not hasattr(stream, "request_body")
 
 
 class TestReadBodyChunk:


### PR DESCRIPTION
HTTP/2 DATA frames were kept in two buffers (`_body_chunks` and a `request_body` BytesIO), copied twice more at dispatch, and flow-control credit was returned as each frame arrived. A client that never sent END_STREAM could grow a worker's memory without the application ever being called. Only listeners with `h2` in `http_protocols` were affected.

Changes:
- `HTTP2Stream` keeps the body once (`_body_chunks`, `body_size`) and hands it over without copying.
- New `http2_max_request_body_size` / `--http2-max-request-body-size`, default 100MB, 0 for unlimited.
- Both connection classes check the limit before buffering. Over it, the stream is dropped, answered with `413` + `END_STREAM`, then `RST_STREAM(NO_ERROR)` (RFC 9113 8.1). Later frames on that stream are ignored and the connection stays open.
- Docs and changelog updated.
