### PR TITLE
Skip filesystem checks for abstract namespace unix sockets

### DIFF
--- a/gunicorn/sock.py
+++ b/gunicorn/sock.py
@@ -126,7 +126,9 @@ class UnixSocket(BaseSocket):
     FAMILY = socket.AF_UNIX
 
     def __init__(self, addr, conf, log, fd=None):
-        if fd is None:
+        # Abstract namespace sockets (address starts with a null byte) have
+        # no filesystem presence, so there's nothing to stat or remove.
+        if fd is None and not addr.startswith('\0'):
             try:
                 st = os.stat(addr)
             except OSError as e:
@@ -145,7 +147,8 @@ class UnixSocket(BaseSocket):
     def bind(self, sock):
         old_umask = os.umask(self.conf.umask)
         sock.bind(self.cfg_addr)
-        util.chown(self.cfg_addr, self.conf.uid, self.conf.gid)
+        if not self.cfg_addr.startswith('\0'):
+            util.chown(self.cfg_addr, self.conf.uid, self.conf.gid)
         os.umask(old_umask)
 
 

--- a/tests/test_sock.py
+++ b/tests/test_sock.py
@@ -2,6 +2,7 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
+import errno
 from unittest import mock
 
 from gunicorn import sock
@@ -54,3 +55,33 @@ def test_unix_socket_close_without_unlink(unlink):
     sock.close_sockets([listener], False)
     listener.close.assert_called_with()
     assert not unlink.called, 'unlink should not have been called'
+
+
+@mock.patch('os.stat')
+def test_unix_socket_abstract_namespace_skips_stat(stat):
+    conf = mock.Mock()
+    log = mock.Mock()
+    with mock.patch.object(sock.BaseSocket, '__init__', lambda *a, **kw: None):
+        sock.UnixSocket('\0my-abstract-socket', conf, log)
+    assert not stat.called, 'os.stat should be skipped for an abstract namespace address'
+
+
+@mock.patch('os.stat')
+def test_unix_socket_filesystem_path_still_checks_stat(stat):
+    stat.side_effect = OSError(errno.ENOENT, 'No such file or directory')
+    conf = mock.Mock()
+    log = mock.Mock()
+    with mock.patch.object(sock.BaseSocket, '__init__', lambda *a, **kw: None):
+        sock.UnixSocket('/var/run/test.sock', conf, log)
+    stat.assert_called_once_with('/var/run/test.sock')
+
+
+@mock.patch.object(sock.util, 'chown')
+def test_unix_socket_bind_abstract_namespace_skips_chown(chown):
+    listener = mock.Mock()
+    unix_sock = sock.UnixSocket.__new__(sock.UnixSocket)
+    unix_sock.conf = mock.Mock(umask=0)
+    unix_sock.cfg_addr = '\0my-abstract-socket'
+    unix_sock.bind(listener)
+    listener.bind.assert_called_once_with('\0my-abstract-socket')
+    assert not chown.called, 'chown should be skipped for an abstract namespace address'


### PR DESCRIPTION
Fixes #2699.

Linux supports abstract namespace unix sockets, whose address starts with a null byte and has no presence on the filesystem. Binding gunicorn to one currently crashes before the server starts:

```
bind = "unix:\0my-socket"
```

```
ValueError: embedded null byte
```

`UnixSocket.__init__` always calls `os.stat()` on the address to check for and remove a stale socket file from a previous run. `os.stat()` rejects any path with an embedded null byte outright, so it never has a chance to return `ENOENT` the way a genuinely missing path would, and the `ValueError` propagates straight out of the constructor.

`bind()` has the same problem a step later: it unconditionally chowns the socket path, which would fail the same way once the stat call above stops being in the way.

Since abstract sockets don't exist on the filesystem, there's nothing to stat, remove, or chown for them, so both operations are skipped when the address starts with a null byte.

Added tests covering:
- the abstract-namespace case skips `os.stat()`
- a normal filesystem path still goes through the existing stat/remove logic
- `bind()` skips `chown()` for an abstract-namespace address

Ran the full test suite plus pylint and pycodestyle on the touched files, all clean.