### PR TITLE
http2: follow-up fixes from the HTTP/2 review

### DIFF
--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -5,6 +5,27 @@
 
 ### Bug Fixes
 
+- **HTTP/2 follow-up to the review**: a bad request now resets its own
+  stream instead of the connection; the request line and field limits and
+  the method token rule apply to HTTP/2 requests; forbidden trailers are
+  dropped; `Expect: 100-continue` is answered; `RST_STREAM` floods close the
+  connection with `ENHANCE_YOUR_CALM`; outbound frames respect the peer's
+  `SETTINGS_MAX_FRAME_SIZE`; a malformed `HTTP2-Settings` header refuses the
+  h2c upgrade before any `101` goes out and an oversized upgrade body is not
+  upgraded; `http2_initial_window_size` and `http2_max_concurrent_streams` are
+  bounded at startup, `http2_max_header_list_size = 0` means unlimited as
+  documented, `h3` is no longer accepted in `http_protocols`, and `h2` without
+  the h2 package is a configuration error. On `gthread` and `gevent` the
+  h2c-upgraded stream is cleaned up like any other, requests queued behind a
+  body read are served before the `max_requests` `GOAWAY`, which names the
+  last stream served, peer protocol errors are logged at debug, and responses
+  carry `Server` and `Date`. On the ASGI worker `send()` raises an `OSError`
+  once the peer is gone (ASGI 2.4), trailers announced on
+  `http.response.start` are sent after the body, no-body statuses drop their
+  framing headers, the body wait is bounded by `timeout`, write backpressure
+  reaches `writer.drain()`, and an idle connection closes after `keepalive`.
+  h2spec runs against every HTTP/2 worker in the docker suites.
+
 - **HTTP/2 request bodies were buffered in full before dispatch**: DATA
   frames were kept in two buffers, copied twice more when the request was
   built, and flow control credit went back to the peer as each frame arrived,

--- a/docs/content/guides/http2.md
+++ b/docs/content/guides/http2.md
@@ -112,11 +112,13 @@ anything else is refused with 400, while with `upgrade` or `both` an
 ordinary HTTP/1 request is served normally, because that is how an
 upgrade starts.
 
-Streams on an HTTP/2 connection are handled one after another, not
-concurrently, so a slow handler holds up the other streams on that
-connection. Response bodies are streamed as the application produces
-them rather than collected first, so a large response does not sit in
-worker memory.
+On the `gthread` and `gevent` workers, streams on an HTTP/2 connection are
+handled one after another, so a slow handler holds up the other streams on
+that connection; the `asgi` worker serves them concurrently. Request bodies
+are pulled from the connection as the application reads them and response
+bodies are streamed as the application produces them, so neither sits in
+worker memory. A stream that makes no progress for `timeout` seconds is
+cancelled, and a connection with nothing open is closed after `keepalive`.
 
 As on HTTP/1, responses that cannot carry a body (HEAD, 1xx, 204, 304)
 send none, and `sendfile()` does not apply to HTTP/2 responses: raw file
@@ -460,7 +462,8 @@ keepalive = 120  # HTTP/2 connections are long-lived
 # SSL/TLS
 certfile = "/path/to/server.crt"
 keyfile = "/path/to/server.key"
-ssl_version = "TLSv1_2"  # Minimum TLS 1.2 for HTTP/2
+# TLS 1.2 is already the floor of the default context; ssl_version is
+# ignored. Use the ssl_context hook to tighten ciphers if you need to.
 
 # HTTP/2
 http_protocols = "h2, h1"
@@ -699,8 +702,8 @@ Reference benchmarks using h2load with 4 Gunicorn workers in Docker (Apple M4 Pr
 # Check HTTP/2 support
 curl -v --http2 https://localhost:443/
 
-# Force HTTP/2
-curl --http2-prior-knowledge https://localhost:443/
+# Over TLS, HTTP/2 is negotiated with ALPN; --http2-prior-knowledge is
+# for cleartext connections (see the h2c section).
 ```
 
 ### Using Python
@@ -768,6 +771,13 @@ and complies with the following specifications:
 
 HTTP/2 introduces new attack vectors compared to HTTP/1.1. Gunicorn includes several
 protections against known vulnerabilities.
+
+### TLS ciphers
+
+RFC 9113 lists cipher suites that must not be used with HTTP/2 (Appendix A).
+The default TLS 1.2 list still contains CBC suites that browsers never pick
+for HTTP/2; gunicorn does not send `INADEQUATE_SECURITY` itself. Set
+`ciphers` to a modern list if your clients are not browsers.
 
 ### Built-in Protections
 

--- a/docs/content/reference/settings.md
+++ b/docs/content/reference/settings.md
@@ -393,8 +393,7 @@ HTTP protocol versions to support (comma-separated, order = preference).
 Valid protocols:
 
 * ``h1`` - HTTP/1.1 (default)
-* ``h2`` - HTTP/2 (requires TLS with ALPN)
-* ``h3`` - HTTP/3 (future, not yet implemented)
+* ``h2`` - HTTP/2 (TLS with ALPN, or cleartext via ``http2_cleartext``)
 
 Examples::
 
@@ -404,7 +403,8 @@ Examples::
     # Prefer HTTP/2, fallback to HTTP/1.1
     --http-protocols=h2,h1
 
-    # HTTP/2 only (reject HTTP/1.1 clients)
+    # Offer HTTP/2 only. A client that does not select it over ALPN
+    # is still served HTTP/1.1; there is no rejection.
     --http-protocols=h2
 
 HTTP/2 requires:

--- a/gunicorn/app/base.py
+++ b/gunicorn/app/base.py
@@ -33,6 +33,7 @@ class BaseApplication:
         try:
             self.load_default_config()
             self.load_config()
+            self.cfg.validate()
         except Exception as e:
             print("\nError: %s" % str(e), file=sys.stderr)
             sys.stderr.flush()

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -147,9 +147,6 @@ class Arbiter:
         self.num_workers = self.cfg.workers
         self.timeout = self.cfg.timeout
         self.proc_name = self.cfg.proc_name
-
-        from gunicorn.http2 import check_config as check_http2_config
-        check_http2_config(self.cfg, self.log)
         self.log.debug('Current configuration:\n{0}'.format(
             '\n'.join(
                 '  {0}: {1}'.format(config, value.value)

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -148,6 +148,8 @@ class Arbiter:
         self.timeout = self.cfg.timeout
         self.proc_name = self.cfg.proc_name
 
+        from gunicorn.http2 import check_config as check_http2_config
+        check_http2_config(self.cfg, self.log)
         self.log.debug('Current configuration:\n{0}'.format(
             '\n'.join(
                 '  {0}: {1}'.format(config, value.value)

--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -370,6 +370,8 @@ class ASGIProtocol(asyncio.Protocol):
         self._h2_tasks = set()
         # Stand-in protocol behind the HTTP/2 StreamWriter; drain() waits on it
         self._h2_writer_protocol = None
+        # Transport asked us to stop writing: we stop reading as well
+        self._write_paused = False
 
         self.transport = None
         self.reader = None  # Only used for HTTP/2
@@ -917,6 +919,12 @@ class ASGIProtocol(asyncio.Protocol):
             self._flow_control.pause_writing()
         elif self._h2_writer_protocol is not None:
             self._h2_writer_protocol.pause_writing()
+            # The peer is not reading. Stop reading from it too: its PING
+            # and SETTINGS frames are answered without waiting for the
+            # transport, so parsing more of them would grow a write buffer
+            # that is already over its limit.
+            self._write_paused = True
+            self._pause_reading()
 
     def resume_writing(self):
         """Called by transport when write buffer drains below low water mark."""
@@ -924,6 +932,8 @@ class ASGIProtocol(asyncio.Protocol):
             self._flow_control.resume_writing()
         elif self._h2_writer_protocol is not None:
             self._h2_writer_protocol.resume_writing()
+            self._write_paused = False
+            self._maybe_resume_reading()
 
     def _safe_write(self, data):
         """Write data to transport, handling connection errors gracefully.
@@ -1806,6 +1816,10 @@ class ASGIProtocol(asyncio.Protocol):
         Only the HTTP/1 loop used to resume; an HTTP/2 connection that
         once paused never read again. Half the limit gives hysteresis.
         """
+        if self._write_paused:
+            # The transport is still over its write limit; reading more
+            # would only make us answer frames we cannot send.
+            return
         if (self._reading_paused and self.reader is not None
                 and len(self.reader._buffer) <= self._max_buffer_size // 2):
             self._resume_reading()

--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -22,7 +22,7 @@ from gunicorn.asgi.parser import (
 from gunicorn.asgi.uwsgi import AsyncUWSGIRequest
 from gunicorn.http.errors import NoMoreData
 from gunicorn.http2 import negotiation
-from gunicorn.http2.errors import HTTP2ErrorCode, HTTP2StreamError
+from gunicorn.http2.errors import HTTP2ConnectionError, HTTP2ErrorCode, HTTP2StreamError
 from gunicorn.http2.stream import StreamState
 from gunicorn.uwsgi.errors import UWSGIParseException
 
@@ -83,6 +83,13 @@ _CHUNK_PREFIXES = {i: f"{i:x}\r\n".encode("latin-1") for i in range(16384)}
 
 # High water mark for write buffer backpressure (64KB)
 HIGH_WATER_LIMIT = 65536
+
+
+class ClientDisconnected(OSError):
+    """Raised from an HTTP/2 send() once the peer reset the stream or left.
+
+    ASGI 2.4 asks for an OSError subclass on a closed connection.
+    """
 
 
 class FlowControl:
@@ -361,6 +368,8 @@ class ASGIProtocol(asyncio.Protocol):
         self.app = worker.asgi
         # Tasks serving HTTP/2 streams on this connection
         self._h2_tasks = set()
+        # Stand-in protocol behind the HTTP/2 StreamWriter; drain() waits on it
+        self._h2_writer_protocol = None
 
         self.transport = None
         self.reader = None  # Only used for HTTP/2
@@ -619,6 +628,11 @@ class ASGIProtocol(asyncio.Protocol):
             # It becomes the body of stream 1, so it is kept here instead of
             # going to a receiver no ASGI app will ever read from.
             self._h2c_upgrade_body += chunk
+            if len(self._h2c_upgrade_body) > negotiation.H2C_UPGRADE_BODY_LIMIT:
+                # Held in memory until stream 1 exists; nothing needs more.
+                self.log.debug("h2c upgrade body over %d bytes, closing",
+                               negotiation.H2C_UPGRADE_BODY_LIMIT)
+                self._close_transport()
             return
         if self._body_receiver:
             self._body_receiver.feed(chunk)
@@ -869,10 +883,16 @@ class ASGIProtocol(asyncio.Protocol):
         if self._body_receiver is not None:
             self._body_receiver.signal_disconnect()
 
-        # HTTP/2: every stream task learns the peer is gone
+        # HTTP/2: every stream task learns the peer is gone, and a task
+        # blocked in writer.drain() is released with an error.
         h2_conn = getattr(self, '_h2_conn', None)
         if h2_conn is not None:
             h2_conn.abort_streams_nowait()
+        if self._h2_writer_protocol is not None:
+            try:
+                self._h2_writer_protocol.connection_lost(exc)
+            except Exception:
+                pass
 
         # Schedule task cancellation after grace period if task doesn't complete
         if self._task and not self._task.done():
@@ -895,11 +915,15 @@ class ASGIProtocol(asyncio.Protocol):
         """Called by transport when write buffer exceeds high water mark."""
         if self._flow_control:
             self._flow_control.pause_writing()
+        elif self._h2_writer_protocol is not None:
+            self._h2_writer_protocol.pause_writing()
 
     def resume_writing(self):
         """Called by transport when write buffer drains below low water mark."""
         if self._flow_control:
             self._flow_control.resume_writing()
+        elif self._h2_writer_protocol is not None:
+            self._h2_writer_protocol.resume_writing()
 
     def _safe_write(self, data):
         """Write data to transport, handling connection errors gracefully.
@@ -1678,6 +1702,14 @@ class ASGIProtocol(asyncio.Protocol):
             writer = asyncio.StreamWriter(
                 transport, protocol, reader, self.worker.loop
             )
+            # The transport reports pause/resume to this ASGIProtocol; they
+            # are forwarded to the stand-in so writer.drain() really waits.
+            self._h2_writer_protocol = protocol
+            self._flow_control = None
+            try:
+                transport.set_write_buffer_limits(high=HIGH_WATER_LIMIT)
+            except (AttributeError, RuntimeError):
+                pass
 
             # Create HTTP/2 connection handler
             h2_conn = AsyncHTTP2Connection(
@@ -1701,8 +1733,20 @@ class ASGIProtocol(asyncio.Protocol):
             # GOAWAY, the loop keeps reading until the streams already in
             # flight have finished, so their bodies still arrive; streams
             # opened meanwhile are refused.
+            loop = self.worker.loop
+            idle_since = None
+            keepalive = self.cfg.keepalive or None
             while not h2_conn.is_closed:
                 if (not self.worker.alive or h2_conn.draining) and not self._h2_tasks:
+                    break
+                if self._h2_tasks or h2_conn.streams:
+                    idle_since = None
+                elif idle_since is None:
+                    idle_since = loop.time()
+                elif keepalive and loop.time() - idle_since >= keepalive:
+                    # Nothing open for cfg.keepalive: same as an idle
+                    # HTTP/1 keep-alive connection, closed with GOAWAY.
+                    await h2_conn.close()
                     break
                 self._maybe_resume_reading()
                 try:
@@ -1727,7 +1771,7 @@ class ASGIProtocol(asyncio.Protocol):
                         self.worker.alive = False
 
         except asyncio.CancelledError:
-            pass
+            raise
         except Exception as e:
             self.log.exception("HTTP/2 connection error: %s", e)
         finally:
@@ -1860,11 +1904,16 @@ class ASGIProtocol(asyncio.Protocol):
                     "more_body": False,
                 }
 
-            # Streaming: read next chunk
+            if stream.expect_continue and not stream.response_headers_sent:
+                # The client is waiting for a 100 before sending the body.
+                stream.expect_continue = False
+                await h2_conn.send_informational(stream_id, 100, [])
+
+            # Streaming: read next chunk, for at most cfg.timeout
             try:
                 chunk = await asyncio.wait_for(
                     stream.read_body_chunk(),
-                    timeout=30.0
+                    timeout=self.cfg.timeout or None
                 )
             except (asyncio.TimeoutError, HTTP2StreamError):
                 return {"type": "http.disconnect"}
@@ -1889,16 +1938,25 @@ class ASGIProtocol(asyncio.Protocol):
             }
 
         # Set once a send loses to the peer's RST_STREAM: the response is
-        # over, later sends are inert, and none of it is an app failure.
+        # over and every later send raises ClientDisconnected (ASGI 2.4);
+        # none of it is an application failure.
         peer_gone = False
+        expect_trailers = False
+        trailers_sent = False
+        pending_trailers = []
 
-        async def send(message):  # pylint: disable=too-many-return-statements
+        def gone():
+            nonlocal peer_gone, response_complete
+            peer_gone = response_complete = True
+            raise ClientDisconnected("HTTP/2 stream %d closed by the peer" % stream_id)
+
+        async def send(message):  # pylint: disable=too-many-return-statements,too-many-branches
             nonlocal response_started, response_complete, headers_sent
             nonlocal response_status, response_headers, response_sent, exc_to_raise
-            nonlocal omits_body, omits_body_warned, peer_gone
+            nonlocal omits_body, omits_body_warned, expect_trailers, trailers_sent
 
-            if peer_gone:
-                return
+            if peer_gone or stream.disconnected:
+                gone()
 
             msg_type = message["type"]
 
@@ -1921,6 +1979,10 @@ class ASGIProtocol(asyncio.Protocol):
                 omits_body = self._response_omits_body(
                     request.method, response_status)
                 response_headers = message.get("headers", [])
+                if omits_body:
+                    response_headers = self._strip_body_framing_headers(
+                        response_headers, response_status)
+                expect_trailers = bool(message.get("trailers", False))
                 # Don't send headers yet - wait for first body chunk
 
             elif msg_type == "http.response.body":
@@ -1953,32 +2015,43 @@ class ASGIProtocol(asyncio.Protocol):
                     # Send headers without end_stream since we have body
                     if not await h2_conn.send_response_headers(
                             stream_id, response_hdrs, end_stream=False):
-                        peer_gone = response_complete = True
-                        return
+                        gone()
                     headers_sent = True
+
+                # The stream ends with the body unless trailers follow
+                final = not more_body and not expect_trailers
 
                 # Stream body immediately
                 if body:
-                    if not await h2_conn.send_data(stream_id, body, end_stream=not more_body):
-                        peer_gone = response_complete = True
-                        return
+                    if not await h2_conn.send_data(stream_id, body, end_stream=final):
+                        gone()
                     response_sent += len(body)
 
                 if not more_body:
-                    if not body:
+                    if not body and final:
                         # Empty final chunk - send end_stream
                         if not await h2_conn.send_data(stream_id, b"", end_stream=True):
-                            peer_gone = True
+                            gone()
                     response_complete = True
 
             elif msg_type == "http.response.trailers":
                 if not response_complete:
                     exc_to_raise = RuntimeError("Cannot send trailers before body complete")
                     return
-                trailer_headers = message.get("headers", [])
-                trailers = self._convert_h2_headers(trailer_headers)
+                if not expect_trailers:
+                    exc_to_raise = RuntimeError(
+                        "Trailers were not announced in http.response.start")
+                    return
+                if trailers_sent:
+                    exc_to_raise = RuntimeError("Trailers already sent")
+                    return
+                pending_trailers.extend(message.get("headers", []))
+                if message.get("more_trailers", False):
+                    return
+                trailers = self._convert_h2_headers(pending_trailers)
+                trailers_sent = True
                 if not await h2_conn.send_trailers(stream_id, trailers):
-                    peer_gone = True
+                    gone()
 
         # Only build environ for logging if access logging is enabled
         access_log_enabled = self.log.access_log_enabled
@@ -1992,9 +2065,15 @@ class ASGIProtocol(asyncio.Protocol):
                 raise exc_to_raise
 
             # Handle case where app didn't send any response
-            if not response_started:
+            if peer_gone or stream.disconnected:
+                pass  # nobody to answer
+            elif not response_started:
                 await h2_conn.send_error(stream_id, 500, "Internal Server Error")
                 response_status = 500
+
+            # Trailers were announced but never sent: end the stream anyway
+            elif headers_sent and expect_trailers and not trailers_sent and not peer_gone:
+                await h2_conn.send_data(stream_id, b"", end_stream=True)
 
             # Handle case where headers were started but no body was sent
             elif not headers_sent:
@@ -2005,9 +2084,12 @@ class ASGIProtocol(asyncio.Protocol):
                 await h2_conn.send_response_headers(
                     stream_id, response_hdrs, end_stream=True)
 
+        except (ClientDisconnected, HTTP2ConnectionError) as e:
+            # A peer that reset the stream or left is not an app failure
+            self.log.debug("HTTP/2 stream %s: %s", stream_id, e)
         except Exception:
             self.log.exception("Error in ASGI application")
-            if not headers_sent:
+            if not headers_sent and not peer_gone:
                 await h2_conn.send_error(stream_id, 500, "Internal Server Error")
                 response_status = 500
         finally:

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -83,6 +83,29 @@ class Config:
             raise AttributeError("No configuration setting for: %s" % name)
         self.settings[name].set(value)
 
+    def validate(self):
+        """Check settings against each other once everything is loaded.
+
+        Individual values are checked by their own validator as they are
+        set; this is for combinations that only make sense as a whole.
+
+        Raises:
+            gunicorn.errors.ConfigError: the configuration cannot be served
+        """
+        if "h2" in self.http_protocols:
+            from gunicorn.http2 import is_http2_available
+
+            if not is_http2_available():
+                raise ConfigError(
+                    "http_protocols includes h2 but the h2 package is not "
+                    "installed. Install gunicorn[http2], or drop h2 from "
+                    "http_protocols.")
+            if not self.is_ssl and self.http2_cleartext == "off":
+                sys.stderr.write(
+                    "Warning: http_protocols includes h2 but there is no TLS "
+                    "and http2_cleartext is off, so HTTP/2 will never be "
+                    "negotiated.\n")
+
     def get_cmd_args_from_env(self):
         if 'GUNICORN_CMD_ARGS' in self.env_orig:
             return shlex.split(self.env_orig['GUNICORN_CMD_ARGS'])

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -406,6 +406,21 @@ def validate_pos_int(val):
     return val
 
 
+def validate_http2_window_size(val):
+    """Flow control windows are at most 2^31-1 (RFC 9113 section 6.9.1)."""
+    val = validate_pos_int(val)
+    if val > 2 ** 31 - 1:
+        raise ValueError("HTTP/2 window size must be at most 2147483647: %s" % val)
+    return val
+
+
+def validate_http2_stream_limit(val):
+    val = validate_pos_int(val)
+    if val < 1:
+        raise ValueError("HTTP/2 max concurrent streams must be at least 1: %s" % val)
+    return val
+
+
 def validate_http2_frame_size(val):
     """Validate HTTP/2 max frame size per RFC 7540."""
     if not isinstance(val, int):
@@ -2447,12 +2462,11 @@ class Ciphers(Setting):
 # HTTP/2 Protocol Settings
 
 # Valid protocol identifiers
-VALID_HTTP_PROTOCOLS = frozenset(["h1", "h2", "h3"])
+VALID_HTTP_PROTOCOLS = frozenset(["h1", "h2"])
 # Map protocol identifiers to ALPN protocol names
 ALPN_PROTOCOL_MAP = {
     "h1": "http/1.1",
     "h2": "h2",
-    "h3": "h3",  # Future: HTTP/3 over QUIC
 }
 
 
@@ -2460,7 +2474,7 @@ def validate_http_protocols(val):
     """Validate http_protocols setting.
 
     Accepts comma-separated list of protocol identifiers.
-    Valid values: h1 (HTTP/1.1), h2 (HTTP/2), h3 (HTTP/3 - future)
+    Valid values: h1 (HTTP/1.1), h2 (HTTP/2)
     Order indicates preference (first = most preferred).
     """
     if val is None:
@@ -2504,8 +2518,7 @@ class HTTPProtocols(Setting):
         Valid protocols:
 
         * ``h1`` - HTTP/1.1 (default)
-        * ``h2`` - HTTP/2 (requires TLS with ALPN)
-        * ``h3`` - HTTP/3 (future, not yet implemented)
+        * ``h2`` - HTTP/2 (TLS with ALPN, or cleartext via ``http2_cleartext``)
 
         Examples::
 
@@ -2515,7 +2528,8 @@ class HTTPProtocols(Setting):
             # Prefer HTTP/2, fallback to HTTP/1.1
             --http-protocols=h2,h1
 
-            # HTTP/2 only (reject HTTP/1.1 clients)
+            # Offer HTTP/2 only. A client that does not select it over ALPN
+            # is still served HTTP/1.1; there is no rejection.
             --http-protocols=h2
 
         HTTP/2 requires:
@@ -2583,7 +2597,7 @@ class HTTP2MaxConcurrentStreams(Setting):
     section = "HTTP/2"
     cli = ["--http2-max-concurrent-streams"]
     meta = "INT"
-    validator = validate_pos_int
+    validator = validate_http2_stream_limit
     type = int
     default = 100
     desc = """\
@@ -2605,7 +2619,7 @@ class HTTP2InitialWindowSize(Setting):
     section = "HTTP/2"
     cli = ["--http2-initial-window-size"]
     meta = "INT"
-    validator = validate_pos_int
+    validator = validate_http2_window_size
     type = int
     default = 65535
     desc = """\

--- a/gunicorn/http2/__init__.py
+++ b/gunicorn/http2/__init__.py
@@ -84,3 +84,22 @@ __all__ = [
     'get_async_http2_connection_class',
     'H2_MIN_VERSION',
 ]
+
+
+def check_config(cfg, log):
+    """Refuse or warn at startup when ``h2`` in http_protocols cannot work.
+
+    Raises:
+        gunicorn.errors.ConfigError: h2 requested without the h2 package
+    """
+    from gunicorn.errors import ConfigError
+
+    if "h2" not in cfg.http_protocols:
+        return
+    if not is_http2_available():
+        raise ConfigError(
+            "http_protocols includes h2 but the h2 package is not installed; "
+            "install gunicorn[http2] or drop h2 from http_protocols")
+    if not cfg.is_ssl and cfg.http2_cleartext == "off":
+        log.warning("http_protocols includes h2 but there is no TLS and "
+                    "http2_cleartext is off, so HTTP/2 cannot be negotiated")

--- a/gunicorn/http2/__init__.py
+++ b/gunicorn/http2/__init__.py
@@ -84,22 +84,3 @@ __all__ = [
     'get_async_http2_connection_class',
     'H2_MIN_VERSION',
 ]
-
-
-def check_config(cfg, log):
-    """Refuse or warn at startup when ``h2`` in http_protocols cannot work.
-
-    Raises:
-        gunicorn.errors.ConfigError: h2 requested without the h2 package
-    """
-    from gunicorn.errors import ConfigError
-
-    if "h2" not in cfg.http_protocols:
-        return
-    if not is_http2_available():
-        raise ConfigError(
-            "http_protocols includes h2 but the h2 package is not installed; "
-            "install gunicorn[http2] or drop h2 from http_protocols")
-    if not cfg.is_ssl and cfg.http2_cleartext == "off":
-        log.warning("http_protocols includes h2 but there is no TLS and "
-                    "http2_cleartext is off, so HTTP/2 cannot be negotiated")

--- a/gunicorn/http2/async_connection.py
+++ b/gunicorn/http2/async_connection.py
@@ -282,8 +282,9 @@ class AsyncHTTP2Connection:
                 live.append(request)
         completed_requests = live
 
-        # Send any pending data (WINDOW_UPDATE, etc.)
-        await self._send_pending_data()
+        # Send any pending data (WINDOW_UPDATE, etc.). Not waited on: a
+        # peer that stopped reading must not stop us from reading.
+        await self._write_pending()
 
         return completed_requests
 
@@ -682,8 +683,9 @@ class AsyncHTTP2Connection:
                 async with self._lock():
                     self.h2_conn.send_data(stream_id, b"", end_stream=True)
                     stream.send_data(b"", end_stream=True)
-                    self._write_locked()
-                await self._drain()
+                    wrote = self._write_locked()
+                if wrote:
+                    await self._drain()
                 return True
             while data_to_send:
                 # The window is read and the frame queued under the lock,
@@ -700,11 +702,12 @@ class AsyncHTTP2Connection:
                         # drain: a reset processed meanwhile closes the
                         # stream and must not turn into a send error.
                         stream.send_data(chunk, end_stream=is_final)
-                        self._write_locked()
+                        wrote = self._write_locked()
                 if chunk_size > 0:
                     # Outside the lock: a peer that stops reading must not
                     # hold up the receive loop or the other streams.
-                    await self._drain()
+                    if wrote:
+                        await self._drain()
                 else:
                     # Wait for WINDOW_UPDATE per RFC 7540 Section 6.9.2
                     available = await self._wait_for_flow_control_window(stream_id)
@@ -846,24 +849,44 @@ class AsyncHTTP2Connection:
         """
         async with self._lock():
             queue_frames()
-            self._write_locked()
-        await self._drain()
+            wrote = self._write_locked()
+        if wrote:
+            await self._drain()
 
     async def _send_pending_data(self):
-        """Send whatever h2 already has queued."""
+        """Send whatever h2 already has queued and wait for the transport."""
+        async with self._lock():
+            wrote = self._write_locked()
+        if wrote:
+            await self._drain()
+
+    async def _write_pending(self):
+        """Send whatever h2 already has queued, without waiting.
+
+        Used by the receive loop: what it has to send are control frames
+        (SETTINGS and PING acknowledgements, WINDOW_UPDATE, RST_STREAM,
+        GOAWAY), and waiting for the transport there would stop the
+        connection from reading. Backpressure belongs on the response
+        path, where the volume is.
+        """
         async with self._lock():
             self._write_locked()
-        await self._drain()
 
     def _write_locked(self):
-        """Hand h2's pending bytes to the transport. Never waits."""
+        """Hand h2's pending bytes to the transport. Never waits.
+
+        Returns:
+            bool: True if there was anything to write
+        """
         data = self.h2_conn.data_to_send()
-        if data:
-            try:
-                self.writer.write(data)
-            except (OSError, IOError) as e:
-                self._closed = True
-                raise HTTP2ConnectionError(f"Socket write error: {e}")
+        if not data:
+            return False
+        try:
+            self.writer.write(data)
+        except (OSError, IOError) as e:
+            self._closed = True
+            raise HTTP2ConnectionError(f"Socket write error: {e}")
+        return True
 
     async def _drain(self):
         """Wait for the transport to catch up, for at most cfg.timeout.

--- a/gunicorn/http2/async_connection.py
+++ b/gunicorn/http2/async_connection.py
@@ -682,7 +682,8 @@ class AsyncHTTP2Connection:
                 async with self._lock():
                     self.h2_conn.send_data(stream_id, b"", end_stream=True)
                     stream.send_data(b"", end_stream=True)
-                    await self._flush_locked()
+                    self._write_locked()
+                await self._drain()
                 return True
             while data_to_send:
                 # The window is read and the frame queued under the lock,
@@ -699,8 +700,12 @@ class AsyncHTTP2Connection:
                         # drain: a reset processed meanwhile closes the
                         # stream and must not turn into a send error.
                         stream.send_data(chunk, end_stream=is_final)
-                        await self._flush_locked()
-                if chunk_size <= 0:
+                        self._write_locked()
+                if chunk_size > 0:
+                    # Outside the lock: a peer that stops reading must not
+                    # hold up the receive loop or the other streams.
+                    await self._drain()
+                else:
                     # Wait for WINDOW_UPDATE per RFC 7540 Section 6.9.2
                     available = await self._wait_for_flow_control_window(stream_id)
                     if available == 0:
@@ -833,29 +838,52 @@ class AsyncHTTP2Connection:
     async def _send(self, queue_frames):
         """Queue frames on h2 and put them on the wire.
 
-        Streams are served by concurrent tasks, so both steps happen
-        under one lock with no await between them: the receive loop
-        cannot parse a GOAWAY (which clears h2's outbound buffer) in
-        between, and HEADERS leave in the order they were encoded.
+        Streams are served by concurrent tasks, so encoding and writing
+        happen under one lock with no await between them: the receive
+        loop cannot parse a GOAWAY (which clears h2's outbound buffer)
+        in between, and HEADERS leave in the order they were encoded.
+        Waiting for the transport happens after the lock is released.
         """
         async with self._lock():
             queue_frames()
-            await self._flush_locked()
+            self._write_locked()
+        await self._drain()
 
     async def _send_pending_data(self):
         """Send whatever h2 already has queued."""
         async with self._lock():
-            await self._flush_locked()
+            self._write_locked()
+        await self._drain()
 
-    async def _flush_locked(self):
+    def _write_locked(self):
+        """Hand h2's pending bytes to the transport. Never waits."""
         data = self.h2_conn.data_to_send()
         if data:
             try:
                 self.writer.write(data)
-                await self.writer.drain()
             except (OSError, IOError) as e:
                 self._closed = True
                 raise HTTP2ConnectionError(f"Socket write error: {e}")
+
+    async def _drain(self):
+        """Wait for the transport to catch up, for at most cfg.timeout.
+
+        Holding the write lock here would let one peer that stops
+        reading freeze the receive loop and every other stream on the
+        connection, so this runs outside it. A peer that never catches
+        up is treated as gone: nothing else bounds the wait, since it
+        can keep its flow-control window wide open.
+        """
+        try:
+            await asyncio.wait_for(self.writer.drain(), self.cfg.timeout or None)
+        except asyncio.TimeoutError:
+            self._closed = True
+            self._abort_all_streams()
+            self._signal_window()
+            raise HTTP2ConnectionError("Write timed out: the peer stopped reading")
+        except (OSError, IOError) as e:
+            self._closed = True
+            raise HTTP2ConnectionError(f"Socket write error: {e}")
 
     @property
     def is_closed(self):

--- a/gunicorn/http2/async_connection.py
+++ b/gunicorn/http2/async_connection.py
@@ -394,7 +394,8 @@ class AsyncHTTP2Connection:
             return
         try:
             self.h2_conn.increment_flow_control_window(size, stream_id=stream_id)
-        except (ValueError, _h2_exceptions.ProtocolError):
+        except (ValueError, KeyError, _h2_exceptions.ProtocolError):
+            # h2 raises KeyError for a stream it already dropped
             return
         self._write_pending_nowait()
 
@@ -564,7 +565,7 @@ class AsyncHTTP2Connection:
 
         try:
             await self._send(queue)
-        except _h2_exceptions.StreamClosedError:
+        except (_h2_exceptions.StreamClosedError, _h2_exceptions.StreamIDTooLowError):
             stream.close()
             self.cleanup_stream(stream_id)
             return False
@@ -606,7 +607,7 @@ class AsyncHTTP2Connection:
             if body and len(body) > 0:
                 await self.send_data(stream_id, body, end_stream=True)
             return True
-        except _h2_exceptions.StreamClosedError:
+        except (_h2_exceptions.StreamClosedError, _h2_exceptions.StreamIDTooLowError):
             # Stream was reset by client - clean up gracefully
             stream.close()
             self.cleanup_stream(stream_id)
@@ -755,7 +756,7 @@ class AsyncHTTP2Connection:
 
             await self._send(queue)
             return True
-        except _h2_exceptions.StreamClosedError:
+        except (_h2_exceptions.StreamClosedError, _h2_exceptions.StreamIDTooLowError):
             # Stream was reset by client - clean up gracefully
             stream.close()
             self.cleanup_stream(stream_id)

--- a/gunicorn/http2/async_connection.py
+++ b/gunicorn/http2/async_connection.py
@@ -12,6 +12,7 @@ asyncio for non-blocking I/O.
 
 import asyncio
 import collections
+import time
 
 from .errors import (
     HTTP2Error, HTTP2ProtocolError, HTTP2ConnectionError,
@@ -20,6 +21,7 @@ from .errors import (
 from .stream import HTTP2Stream, StreamState
 from .h2conn import server_connection_class
 from .request import HTTP2Request
+from gunicorn.http.errors import ParseException
 
 
 # Import h2 lazily to allow graceful fallback
@@ -45,6 +47,13 @@ def _import_h2():
         import h2.settings as _h2_settings
     except ImportError:
         raise HTTP2NotAvailable()
+
+
+# RST_STREAM frames a peer may send per window before the connection is
+# closed with ENHANCE_YOUR_CALM (CVE-2023-44487 style floods). A client
+# cancelling requests never comes close.
+RST_STREAM_RATE_LIMIT = 200
+RST_STREAM_RATE_WINDOW = 10.0
 
 
 class AsyncHTTP2Connection:
@@ -82,6 +91,7 @@ class AsyncHTTP2Connection:
         # They have left the h2 state machine already, so they are held here
         # for the main receive loop rather than discarded.
         self._deferred_events = collections.deque()
+        self._reset_times = collections.deque()
         # Set by the receive loop whenever the peer widens a window, so
         # a response task can wait for credit without touching the
         # reader the loop owns.
@@ -126,7 +136,8 @@ class AsyncHTTP2Connection:
             _h2_settings.SettingCodes.MAX_CONCURRENT_STREAMS: self.max_concurrent_streams,
             _h2_settings.SettingCodes.INITIAL_WINDOW_SIZE: self.initial_window_size,
             _h2_settings.SettingCodes.MAX_FRAME_SIZE: self.max_frame_size,
-            _h2_settings.SettingCodes.MAX_HEADER_LIST_SIZE: self.max_header_list_size,
+            **({_h2_settings.SettingCodes.MAX_HEADER_LIST_SIZE: self.max_header_list_size}
+               if self.max_header_list_size else {}),
         })
 
         self.h2_conn.initiate_connection()
@@ -151,7 +162,8 @@ class AsyncHTTP2Connection:
             _h2_settings.SettingCodes.MAX_CONCURRENT_STREAMS: self.max_concurrent_streams,
             _h2_settings.SettingCodes.INITIAL_WINDOW_SIZE: self.initial_window_size,
             _h2_settings.SettingCodes.MAX_FRAME_SIZE: self.max_frame_size,
-            _h2_settings.SettingCodes.MAX_HEADER_LIST_SIZE: self.max_header_list_size,
+            **({_h2_settings.SettingCodes.MAX_HEADER_LIST_SIZE: self.max_header_list_size}
+               if self.max_header_list_size else {}),
         })
         self.h2_conn.initiate_upgrade_connection(settings_header=settings_header)
         await self._send_pending_data()
@@ -242,6 +254,10 @@ class AsyncHTTP2Connection:
             # Send GOAWAY with REFUSED_STREAM
             await self.close(error_code=HTTP2ErrorCode.REFUSED_STREAM)
             raise HTTP2ProtocolError(str(e))
+        except UnicodeDecodeError as e:
+            # Header bytes h2 could not decode
+            await self.close(error_code=HTTP2ErrorCode.PROTOCOL_ERROR)
+            raise HTTP2ProtocolError(f"Undecodable header: {e}")
         except _h2_exceptions.ProtocolError as e:
             # Send GOAWAY with PROTOCOL_ERROR before raising
             await self.close(error_code=HTTP2ErrorCode.PROTOCOL_ERROR)
@@ -331,7 +347,14 @@ class AsyncHTTP2Connection:
         stream.receive_headers(headers, end_stream=False)
 
         # Dispatch on headers: the body streams in behind the request.
-        return HTTP2Request(stream, self.cfg, self.client_addr)
+        try:
+            return HTTP2Request(stream, self.cfg, self.client_addr)
+        except (ParseException, ValueError):
+            # A bad request is a stream error, not a connection error
+            # (RFC 9113 section 8.1.1).
+            self.streams.pop(stream_id, None)
+            self._reset_quietly(stream_id, HTTP2ErrorCode.PROTOCOL_ERROR)
+            return None
 
     def _handle_data_received(self, event):
         """Handle DataReceived event.
@@ -400,6 +423,7 @@ class AsyncHTTP2Connection:
 
     def _handle_stream_reset(self, event):
         """Handle StreamReset event."""
+        self._count_reset()
         stream_id = event.stream_id
         stream = self.streams.get(stream_id)
 
@@ -424,6 +448,22 @@ class AsyncHTTP2Connection:
             return
         self._closed = True
         self._abort_all_streams()
+
+    def _count_reset(self):
+        """Close the connection when the peer resets streams at flood rate."""
+        now = time.monotonic()
+        self._reset_times.append(now)
+        while self._reset_times and now - self._reset_times[0] > RST_STREAM_RATE_WINDOW:
+            self._reset_times.popleft()
+        if len(self._reset_times) > RST_STREAM_RATE_LIMIT:
+            self._closed = True
+            try:
+                self.h2_conn.close_connection(error_code=HTTP2ErrorCode.ENHANCE_YOUR_CALM)
+                self._write_pending_nowait()
+            except Exception:
+                pass
+            self._abort_all_streams()
+            raise HTTP2ProtocolError("RST_STREAM rate exceeded")
 
     def _abort_all_streams(self):
         """The connection is gone: wake every stream still waiting on it."""
@@ -648,7 +688,7 @@ class AsyncHTTP2Connection:
                 # so another stream cannot spend the credit in between.
                 async with self._lock():
                     available = self.h2_conn.local_flow_control_window(stream_id)
-                    chunk_size = min(available, self.max_frame_size, len(data_to_send))
+                    chunk_size = min(available, self.h2_conn.max_outbound_frame_size, len(data_to_send))
                     if chunk_size > 0:
                         chunk = data_to_send[:chunk_size]
                         data_to_send = data_to_send[chunk_size:]

--- a/gunicorn/http2/connection.py
+++ b/gunicorn/http2/connection.py
@@ -442,7 +442,8 @@ class HTTP2ServerConnection:
             return
         try:
             self.h2_conn.increment_flow_control_window(size, stream_id=stream_id)
-        except (ValueError, _h2_exceptions.ProtocolError):
+        except (ValueError, KeyError, _h2_exceptions.ProtocolError):
+            # h2 raises KeyError for a stream it already dropped
             return
         self._send_pending_data()
 
@@ -631,7 +632,7 @@ class HTTP2ServerConnection:
         try:
             self.h2_conn.send_headers(stream_id, response_headers,
                                       end_stream=end_stream)
-        except _h2_exceptions.StreamClosedError:
+        except (_h2_exceptions.StreamClosedError, _h2_exceptions.StreamIDTooLowError):
             stream.close()
             self.cleanup_stream(stream_id)
             return False
@@ -672,7 +673,7 @@ class HTTP2ServerConnection:
             if body and len(body) > 0:
                 self.send_data(stream_id, body, end_stream=True)
             return True
-        except _h2_exceptions.StreamClosedError:
+        except (_h2_exceptions.StreamClosedError, _h2_exceptions.StreamIDTooLowError):
             # Stream was reset by client - clean up gracefully
             stream = self.streams.get(stream_id)
             if stream is not None:
@@ -850,7 +851,7 @@ class HTTP2ServerConnection:
             stream.send_trailers(trailer_headers)
             self._send_pending_data()
             return True
-        except _h2_exceptions.StreamClosedError:
+        except (_h2_exceptions.StreamClosedError, _h2_exceptions.StreamIDTooLowError):
             # Stream was reset by client - clean up gracefully
             stream.close()
             self.cleanup_stream(stream_id)

--- a/gunicorn/http2/connection.py
+++ b/gunicorn/http2/connection.py
@@ -21,6 +21,7 @@ from .errors import (
 from .stream import HTTP2Stream, StreamState
 from .h2conn import server_connection_class
 from .request import HTTP2Request
+from gunicorn.http.errors import ParseException
 
 
 # Import h2 lazily to allow graceful fallback
@@ -46,6 +47,13 @@ def _import_h2():
         import h2.settings as _h2_settings
     except ImportError:
         raise HTTP2NotAvailable()
+
+
+# RST_STREAM frames a peer may send per window before the connection is
+# closed with ENHANCE_YOUR_CALM (CVE-2023-44487 style floods). A client
+# cancelling requests never comes close.
+RST_STREAM_RATE_LIMIT = 200
+RST_STREAM_RATE_WINDOW = 10.0
 
 
 class HTTP2ServerConnection:
@@ -82,6 +90,7 @@ class HTTP2ServerConnection:
         # They have left the h2 state machine already, so they are held here
         # for the main receive loop rather than discarded.
         self._deferred_events = collections.deque()
+        self._reset_times = collections.deque()
 
         # Requests that arrived while a request body was being pulled
         # off the socket; handed to the worker on its next call.
@@ -128,7 +137,8 @@ class HTTP2ServerConnection:
             _h2_settings.SettingCodes.MAX_CONCURRENT_STREAMS: self.max_concurrent_streams,
             _h2_settings.SettingCodes.INITIAL_WINDOW_SIZE: self.initial_window_size,
             _h2_settings.SettingCodes.MAX_FRAME_SIZE: self.max_frame_size,
-            _h2_settings.SettingCodes.MAX_HEADER_LIST_SIZE: self.max_header_list_size,
+            **({_h2_settings.SettingCodes.MAX_HEADER_LIST_SIZE: self.max_header_list_size}
+               if self.max_header_list_size else {}),
         })
 
         self.h2_conn.initiate_connection()
@@ -153,7 +163,8 @@ class HTTP2ServerConnection:
             _h2_settings.SettingCodes.MAX_CONCURRENT_STREAMS: self.max_concurrent_streams,
             _h2_settings.SettingCodes.INITIAL_WINDOW_SIZE: self.initial_window_size,
             _h2_settings.SettingCodes.MAX_FRAME_SIZE: self.max_frame_size,
-            _h2_settings.SettingCodes.MAX_HEADER_LIST_SIZE: self.max_header_list_size,
+            **({_h2_settings.SettingCodes.MAX_HEADER_LIST_SIZE: self.max_header_list_size}
+               if self.max_header_list_size else {}),
         })
         self.h2_conn.initiate_upgrade_connection(settings_header=settings_header)
         self._send_pending_data()
@@ -290,6 +301,10 @@ class HTTP2ServerConnection:
             # Send GOAWAY with REFUSED_STREAM
             self.close(error_code=HTTP2ErrorCode.REFUSED_STREAM)
             raise HTTP2ProtocolError(str(e))
+        except UnicodeDecodeError as e:
+            # Header bytes h2 could not decode
+            self.close(error_code=HTTP2ErrorCode.PROTOCOL_ERROR)
+            raise HTTP2ProtocolError(f"Undecodable header: {e}")
         except _h2_exceptions.ProtocolError as e:
             # Send GOAWAY with PROTOCOL_ERROR before raising
             self.close(error_code=HTTP2ErrorCode.PROTOCOL_ERROR)
@@ -378,7 +393,14 @@ class HTTP2ServerConnection:
         stream.receive_headers(headers, end_stream=False)
 
         # Dispatch on headers: the body streams in behind the request.
-        return HTTP2Request(stream, self.cfg, self.client_addr)
+        try:
+            return HTTP2Request(stream, self.cfg, self.client_addr)
+        except (ParseException, ValueError):
+            # A bad request is a stream error, not a connection error
+            # (RFC 9113 section 8.1.1).
+            self.streams.pop(stream_id, None)
+            self._reset_quietly(stream_id, HTTP2ErrorCode.PROTOCOL_ERROR)
+            return None
 
     def _handle_data_received(self, event):
         """Handle DataReceived event.
@@ -452,6 +474,7 @@ class HTTP2ServerConnection:
         Args:
             event: StreamReset event
         """
+        self._count_reset()
         stream_id = event.stream_id
         stream = self.streams.get(stream_id)
 
@@ -485,6 +508,22 @@ class HTTP2ServerConnection:
             return
         self._closed = True
         self._abort_all_streams()
+
+    def _count_reset(self):
+        """Close the connection when the peer resets streams at flood rate."""
+        now = time.monotonic()
+        self._reset_times.append(now)
+        while self._reset_times and now - self._reset_times[0] > RST_STREAM_RATE_WINDOW:
+            self._reset_times.popleft()
+        if len(self._reset_times) > RST_STREAM_RATE_LIMIT:
+            self._closed = True
+            try:
+                self.h2_conn.close_connection(error_code=HTTP2ErrorCode.ENHANCE_YOUR_CALM)
+                self._send_pending_data()
+            except Exception:
+                pass
+            self._abort_all_streams()
+            raise HTTP2ProtocolError("RST_STREAM rate exceeded")
 
     def _abort_all_streams(self):
         """The connection is gone: wake every stream still waiting on it."""
@@ -739,7 +778,7 @@ class HTTP2ServerConnection:
                 return True
             while data_to_send:
                 available = self.h2_conn.local_flow_control_window(stream_id)
-                chunk_size = min(available, self.max_frame_size, len(data_to_send))
+                chunk_size = min(available, self.h2_conn.max_outbound_frame_size, len(data_to_send))
 
                 if chunk_size <= 0:
                     # Wait for WINDOW_UPDATE per RFC 7540 Section 6.9.2,
@@ -755,7 +794,7 @@ class HTTP2ServerConnection:
                     if available < 0:
                         self.cleanup_stream(stream_id)
                         return False
-                    chunk_size = min(available, self.max_frame_size, len(data_to_send))
+                    chunk_size = min(available, self.h2_conn.max_outbound_frame_size, len(data_to_send))
 
                 chunk = data_to_send[:chunk_size]
                 data_to_send = data_to_send[chunk_size:]

--- a/gunicorn/http2/negotiation.py
+++ b/gunicorn/http2/negotiation.py
@@ -56,8 +56,8 @@ def peer_trusted_for_h2c(cfg, peer_addr):
 def _h2c_available(cfg):
     """Whether cleartext HTTP/2 could apply to this server at all.
 
-    Whether the h2 package is installed is checked once at startup
-    (gunicorn.http2.check_config), not per connection.
+    Whether the h2 package is installed is checked once when the
+    configuration is loaded (Config.validate), not per connection.
     """
     return (
         "h2" in cfg.http_protocols

--- a/gunicorn/http2/negotiation.py
+++ b/gunicorn/http2/negotiation.py
@@ -55,10 +55,13 @@ def peer_trusted_for_h2c(cfg, peer_addr):
 
 def _h2c_available(cfg):
     """Whether cleartext HTTP/2 could apply to this server at all."""
+    from . import is_http2_available
+
     return (
         "h2" in cfg.http_protocols
         and getattr(cfg, "protocol", "http") == "http"
         and not cfg.is_ssl
+        and is_http2_available()
     )
 
 
@@ -141,7 +144,7 @@ UPGRADE_101 = (
 )
 
 
-def upgrade_settings(req):
+def upgrade_settings(req):  # pylint: disable=too-many-return-statements
     """Return the HTTP2-Settings payload if this request asks for h2c.
 
     RFC 7540 section 3.2: the request must name ``h2c`` in Upgrade and carry
@@ -165,6 +168,57 @@ def upgrade_settings(req):
     # Exactly one, per RFC 7540 3.2.1: a second one is ambiguous.
     if len(settings) != 1:
         return None
-    if "http2-settings" not in connection or "upgrade" not in connection:
+    tokens = {t.strip() for t in connection.split(",")}
+    if "http2-settings" not in tokens or "upgrade" not in tokens:
         return None
-    return settings[0].encode("latin-1")
+    version = getattr(req, "version", None)
+    if isinstance(version, tuple) and version < (1, 1):
+        # RFC 7540 3.2 describes the upgrade for HTTP/1.1 requests.
+        return None
+    if _upgrade_body_too_large(req):
+        return None
+    payload = settings[0].encode("latin-1")
+    if not _settings_payload_valid(payload):
+        # RFC 7540 3.2.1: a server that cannot use the settings does not
+        # upgrade; refusing here keeps the 101 from going out first.
+        return None
+    return payload
+
+
+#: Largest HTTP/1 body accepted on an upgrade request. It is held in
+#: memory until the HTTP/2 stream is built; nothing needs a large one.
+H2C_UPGRADE_BODY_LIMIT = 65536
+
+
+def _upgrade_body_too_large(req):
+    for name, value in req.headers:
+        if name == "CONTENT-LENGTH":
+            try:
+                return int(value) > H2C_UPGRADE_BODY_LIMIT
+            except ValueError:
+                return True
+    return False
+
+
+def _settings_payload_valid(payload):
+    """Decode the base64url HTTP2-Settings payload and check its values."""
+    import base64
+    import binascii
+
+    try:
+        raw = base64.b64decode(payload + b"=" * (-len(payload) % 4),
+                               altchars=b"-_", validate=True)
+    except (binascii.Error, ValueError):
+        return False
+    if len(raw) % 6:
+        return False
+    for i in range(0, len(raw), 6):
+        code = int.from_bytes(raw[i:i + 2], "big")
+        value = int.from_bytes(raw[i + 2:i + 6], "big")
+        if code == 2 and value not in (0, 1):
+            return False
+        if code == 4 and value > 2 ** 31 - 1:
+            return False
+        if code == 5 and not 16384 <= value <= 16777215:
+            return False
+    return True

--- a/gunicorn/http2/negotiation.py
+++ b/gunicorn/http2/negotiation.py
@@ -54,14 +54,15 @@ def peer_trusted_for_h2c(cfg, peer_addr):
 
 
 def _h2c_available(cfg):
-    """Whether cleartext HTTP/2 could apply to this server at all."""
-    from . import is_http2_available
+    """Whether cleartext HTTP/2 could apply to this server at all.
 
+    Whether the h2 package is installed is checked once at startup
+    (gunicorn.http2.check_config), not per connection.
+    """
     return (
         "h2" in cfg.http_protocols
         and getattr(cfg, "protocol", "http") == "http"
         and not cfg.is_ssl
-        and is_http2_available()
     )
 
 

--- a/gunicorn/http2/request.py
+++ b/gunicorn/http2/request.py
@@ -10,10 +10,13 @@ Provides a Request-compatible interface for HTTP/2 streams.
 """
 
 from gunicorn.http.message import (
+    RFC9110_6_5_1_FORBIDDEN_TRAILER, TOKEN_RE,
     HeaderPolicy,
     RFC9110_5_5_INVALID_AND_DANGEROUS,
 )
-from gunicorn.http.errors import InvalidHeader
+from gunicorn.http.errors import (
+    InvalidHeader, InvalidRequestMethod, LimitRequestHeaders, LimitRequestLine,
+)
 from gunicorn.http2.errors import HTTP2StreamError
 from gunicorn.http2.stream import StreamState
 from gunicorn.util import split_request_uri
@@ -60,6 +63,10 @@ class HTTP2Body:
                     stream.stream_id,
                     "stream closed before its request body was complete")
             pump = getattr(connection, "pump", None)
+            if stream.expect_continue and not stream.response_headers_sent:
+                # The client is waiting for a 100 before sending the body.
+                stream.expect_continue = False
+                connection.send_informational(stream.stream_id, 100, [])
             if pump is None:
                 # Nothing here can wait for frames; the caller reads via
                 # read_body_chunk() instead.
@@ -201,6 +208,8 @@ class HTTP2Request(HeaderPolicy):
         # Parse pseudo-headers
         pseudo = stream.get_pseudo_headers()
         self.method = pseudo.get(':method', 'GET')
+        if not TOKEN_RE.fullmatch(self.method):
+            raise InvalidRequestMethod(self.method)
         # Derive the scheme from the transport, as HTTP/1 does. A client
         # supplied :scheme is honoured only from a peer allowed to speak for
         # the connection; otherwise it is ignored rather than rejected, which
@@ -211,6 +220,16 @@ class HTTP2Request(HeaderPolicy):
             self.scheme = claimed_scheme
         authority = pseudo.get(':authority', '')
         path = pseudo.get(':path', '/')
+        # The same limits HTTP/1 applies to the request line and fields.
+        if cfg.limit_request_line and len(path) > cfg.limit_request_line:
+            raise LimitRequestLine(len(path), cfg.limit_request_line)
+        regular = stream.get_regular_headers()
+        if cfg.limit_request_fields and len(regular) > cfg.limit_request_fields:
+            raise LimitRequestHeaders("limit request headers fields")
+        if cfg.limit_request_field_size:
+            for name, value in regular:
+                if len(name) + len(value) + 2 > cfg.limit_request_field_size:
+                    raise LimitRequestHeaders("limit request headers fields size")
 
         # Parse the path into components
         self.uri = path
@@ -257,6 +276,8 @@ class HTTP2Request(HeaderPolicy):
 
         # Body: read from the stream as it arrives.
         self.body = HTTP2Body(stream)
+        expect = self.get_header('EXPECT')
+        stream.expect_continue = bool(expect) and expect.strip().lower() == '100-continue'
 
         # Connection state
         self.must_close = False
@@ -282,6 +303,8 @@ class HTTP2Request(HeaderPolicy):
         return [
             (name.upper(), value)
             for name, value in self.stream.trailers
+            if name.upper() not in RFC9110_6_5_1_FORBIDDEN_TRAILER
+            and not name.startswith(':')
         ]
 
     def force_close(self):

--- a/gunicorn/http2/response.py
+++ b/gunicorn/http2/response.py
@@ -4,6 +4,7 @@
 
 """WSGI response writer for HTTP/2 streams."""
 
+from gunicorn import util
 from gunicorn.http.wsgi import Response
 from gunicorn.http2.errors import HTTP2StreamError
 
@@ -47,8 +48,15 @@ class HTTP2Response(Response):
     def send_headers(self):
         if self.headers_sent:
             return
+        # The same server headers HTTP/1 adds
+        names = {name.lower() for name, _ in self.headers}
+        headers = list(self.headers)
+        if "server" not in names:
+            headers.append(("server", self.version))
+        if "date" not in names:
+            headers.append(("date", util.http_date()))
         if not self.h2_conn.send_response_headers(
-                self.stream_id, self.status_code, self.headers, end_stream=False):
+                self.stream_id, self.status_code, headers, end_stream=False):
             self._aborted("stream closed before headers were sent")
         self.headers_sent = True
 

--- a/gunicorn/http2/stream.py
+++ b/gunicorn/http2/stream.py
@@ -84,6 +84,8 @@ class HTTP2Stream:
         # wait_disconnect() lets an ASGI receive() block on it.
         self.disconnected = False
         self._disconnect_waiter = None
+        # Request carried Expect: 100-continue and no 100 went out yet
+        self.expect_continue = False
 
     @property
     def is_client_stream(self):
@@ -356,7 +358,8 @@ class HTTP2Stream:
 
     def _acknowledge(self, size):
         """Return flow-control credit for ``size`` consumed bytes."""
-        if size <= 0:
+        if size <= 0 or self.acked_size >= self.body_size:
+            # Nothing owed: an h2c upgrade body came over HTTP/1
             return
         self.acked_size += size
         ack = getattr(self.connection, "acknowledge_data", None)

--- a/gunicorn/workers/base_async.py
+++ b/gunicorn/workers/base_async.py
@@ -15,7 +15,7 @@ from gunicorn import sock as gunicorn_sock
 from gunicorn.http.errors import InvalidH2CPreface
 from gunicorn.http2 import negotiation
 from gunicorn.http2.response import HTTP2Response
-from gunicorn.http2.errors import HTTP2ConnectionError, HTTP2StreamError
+from gunicorn.http2.errors import HTTP2ConnectionError, HTTP2ProtocolError, HTTP2StreamError
 from gunicorn.http2.stream import StreamState
 from gunicorn.workers import base
 
@@ -181,10 +181,11 @@ class AsyncWorker(base.Worker):
                 # it yields no requests and nothing is dropped.
                 h2_conn.receive_data(preface)
 
+            last_served = 0
             if upgraded is not None:
                 # The upgraded request is stream 1; serve it before the loop.
-                self.handle_http2_request(listener.getsockname(), upgraded,
-                                          client, addr, h2_conn)
+                self._serve_http2_stream(listener_name, upgraded, client, addr, h2_conn)
+                last_served = 1
 
             while not h2_conn.is_closed and self.alive:
                 try:
@@ -194,27 +195,21 @@ class AsyncWorker(base.Worker):
                     break
 
                 for req in requests:
-                    if req.stream.state is StreamState.CLOSED:
-                        # Reset by the peer before it could be served
-                        h2_conn.cleanup_stream(req.stream.stream_id)
-                        continue
-                    try:
-                        self.handle_http2_request(listener_name, req, client, addr, h2_conn)
-                    except (HTTP2StreamError, HTTP2ConnectionError) as e:
-                        # The peer reset the stream, stalled past the
-                        # timeout, or the socket is gone; nothing to answer.
-                        self.log.debug("HTTP/2 stream closed: %s", e)
-                    except Exception as e:
-                        self.log.exception("Error handling HTTP/2 request")
-                        try:
-                            h2_conn.send_error(req.stream.stream_id, 500, str(e))
-                        except Exception as err:
-                            self.log.debug("HTTP/2 error response failed: %s", err)
-                    finally:
-                        h2_conn.cleanup_stream(req.stream.stream_id)
+                    self._serve_http2_stream(listener_name, req, client, addr, h2_conn)
+                    last_served = req.stream.stream_id
+
+            if not self.alive and not h2_conn.is_closed:
+                # Queued requests are served, then GOAWAY names the last
+                # one so the peer can retry anything after it.
+                for req in h2_conn.receive_data(b""):
+                    self._serve_http2_stream(listener_name, req, client, addr, h2_conn)
+                    last_served = req.stream.stream_id
+                h2_conn.close(last_stream_id=last_served)
 
         except HTTP2ConnectionError as e:
             self.log.debug("HTTP/2 connection closed: %s", e)
+        except HTTP2ProtocolError as e:
+            self.log.debug("HTTP/2 protocol error from peer: %s", e)
         except ssl.SSLError as e:
             if e.args[0] == ssl.SSL_ERROR_EOF:
                 self.log.debug("HTTP/2 SSL connection closed")
@@ -225,6 +220,27 @@ class AsyncWorker(base.Worker):
                 self.log.exception("HTTP/2 socket error")
         except Exception as e:
             self.log.exception("HTTP/2 connection error: %s", e)
+
+    def _serve_http2_stream(self, listener_name, req, sock, addr, h2_conn):
+        """Serve one stream, answering or resetting it whatever happens."""
+        if req.stream.state is StreamState.CLOSED:
+            # Reset by the peer before it could be served
+            h2_conn.cleanup_stream(req.stream.stream_id)
+            return
+        try:
+            self.handle_http2_request(listener_name, req, sock, addr, h2_conn)
+        except (HTTP2StreamError, HTTP2ConnectionError) as e:
+            # The peer reset the stream, stalled past the timeout, or
+            # the socket is gone; nothing to answer.
+            self.log.debug("HTTP/2 stream closed: %s", e)
+        except Exception as e:
+            self.log.exception("Error handling HTTP/2 request")
+            try:
+                h2_conn.send_error(req.stream.stream_id, 500, str(e))
+            except Exception as err:
+                self.log.debug("HTTP/2 error response failed: %s", err)
+        finally:
+            h2_conn.cleanup_stream(req.stream.stream_id)
 
     def handle_http2_request(self, listener_name, req, sock, addr, h2_conn):
         """Handle a single HTTP/2 request."""
@@ -244,6 +260,18 @@ class AsyncWorker(base.Worker):
                                         response_args=(h2_conn, stream_id))
             environ["wsgi.multithread"] = True
             environ["HTTP_VERSION"] = "2"
+
+            def send_early_hints_h2(headers):
+                """Send 103 Early Hints over HTTP/2."""
+                h2_conn.send_informational(stream_id, 103, headers)
+
+            environ["wsgi.early_hints"] = send_early_hints_h2
+
+            def send_trailers_h2(trailers):
+                """Queue trailers to be sent when the stream ends."""
+                resp.trailers = list(trailers)
+
+            environ["gunicorn.http2.send_trailers"] = send_trailers_h2
 
             self.nr += 1
             if self.nr >= self.max_requests:

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -30,7 +30,7 @@ from ..http import wsgi
 from ..http.errors import InvalidH2CPreface
 from ..http2 import negotiation
 from ..http2.response import HTTP2Response
-from ..http2.errors import HTTP2ConnectionError, HTTP2StreamError
+from ..http2.errors import HTTP2ConnectionError, HTTP2ProtocolError, HTTP2StreamError
 from ..http2.stream import StreamState
 
 
@@ -580,8 +580,29 @@ class ThreadWorker(base.Worker):
         if pending:
             h2_conn.receive_data(pending)
 
-        self.handle_http2_request(upgraded, conn, h2_conn)
+        self._serve_http2_stream(upgraded, conn, h2_conn)
         return self.handle_http2(conn)
+
+    def _serve_http2_stream(self, req, conn, h2_conn):
+        """Serve one stream, answering or resetting it whatever happens."""
+        if req.stream.state is StreamState.CLOSED:
+            # Reset by the peer before it could be served
+            h2_conn.cleanup_stream(req.stream.stream_id)
+            return
+        try:
+            self.handle_http2_request(req, conn, h2_conn)
+        except (HTTP2StreamError, HTTP2ConnectionError) as e:
+            # The peer reset the stream, stalled past the timeout, or
+            # the socket is gone; nothing to answer.
+            self.log.debug("HTTP/2 stream closed: %s", e)
+        except Exception as e:
+            self.log.exception("Error handling HTTP/2 request")
+            try:
+                h2_conn.send_error(req.stream.stream_id, 500, str(e))
+            except Exception as err:
+                self.log.debug("HTTP/2 error response failed: %s", err)
+        finally:
+            h2_conn.cleanup_stream(req.stream.stream_id)
 
     def handle_http2(self, conn):
         """Handle an HTTP/2 connection. Runs in a worker thread.
@@ -593,6 +614,7 @@ class ThreadWorker(base.Worker):
             False (HTTP/2 connections don't use keepalive polling)
         """
         h2_conn = conn.parser  # HTTP2ServerConnection
+        last_served = 0
 
         try:
             while not h2_conn.is_closed and self.alive:
@@ -600,35 +622,25 @@ class ThreadWorker(base.Worker):
                 requests = h2_conn.receive_data()
 
                 for req in requests:
-                    if req.stream.state is StreamState.CLOSED:
-                        # Reset by the peer before it could be served
-                        h2_conn.cleanup_stream(req.stream.stream_id)
-                        continue
-                    try:
-                        self.handle_http2_request(req, conn, h2_conn)
-                    except (HTTP2StreamError, HTTP2ConnectionError) as e:
-                        # The peer reset the stream, stalled past the
-                        # timeout, or the socket is gone; nothing to answer.
-                        self.log.debug("HTTP/2 stream closed: %s", e)
-                    except Exception as e:
-                        self.log.exception("Error handling HTTP/2 request")
-                        try:
-                            h2_conn.send_error(req.stream.stream_id, 500, str(e))
-                        except Exception as err:
-                            self.log.debug("HTTP/2 error response failed: %s", err)
-                    finally:
-                        # Cleanup stream after processing
-                        h2_conn.cleanup_stream(req.stream.stream_id)
+                    self._serve_http2_stream(req, conn, h2_conn)
+                    last_served = req.stream.stream_id
 
-                # Check if we need to close
                 if not self.alive:
-                    h2_conn.close()
+                    # Requests already queued behind a body read are
+                    # served, then GOAWAY names the last one so the peer
+                    # can retry anything after it.
+                    for req in h2_conn.receive_data(b""):
+                        self._serve_http2_stream(req, conn, h2_conn)
+                        last_served = req.stream.stream_id
+                    h2_conn.close(last_stream_id=last_served)
                     break
 
         except http.errors.NoMoreData:
             self.log.debug("HTTP/2 connection closed by client")
         except HTTP2ConnectionError as e:
             self.log.debug("HTTP/2 connection closed: %s", e)
+        except HTTP2ProtocolError as e:
+            self.log.debug("HTTP/2 protocol error from peer: %s", e)
         except ssl.SSLError as e:
             if e.args[0] == ssl.SSL_ERROR_EOF:
                 self.log.debug("HTTP/2 SSL connection closed")

--- a/tests/docker/asgi_compliance/Dockerfile.gunicorn
+++ b/tests/docker/asgi_compliance/Dockerfile.gunicorn
@@ -33,6 +33,7 @@ if [ "$USE_SSL" = "1" ]; then\n\
         --worker-connections 1000 \\\n\
         --certfile "/certs/server.crt" \\\n\
         --keyfile "/certs/server.key" \\\n\
+        --http-protocols "h2,h1" \\\n\
         --asgi-disconnect-grace-period 0 \\\n\
         --log-level "debug" \\\n\
         --access-logfile "-" \\\n\

--- a/tests/docker/asgi_compliance/test_http2_asgi.py
+++ b/tests/docker/asgi_compliance/test_http2_asgi.py
@@ -438,3 +438,43 @@ class TestHTTP2Direct:
         )
         assert response.status_code == 200
         assert len(response.content) == 100000
+
+
+# ============================================================================
+# Direct to gunicorn over TLS with ALPN: this is gunicorn's own HTTP/2
+# implementation on the wire. The nginx tests above only reach it over
+# HTTP/1.1, since nginx proxies upstream as HTTP/1.1.
+# ============================================================================
+
+class TestHTTP2DirectToGunicorn:
+    def test_http2_is_negotiated(self, http2_client, gunicorn_ssl_url):
+        response = http2_client.get(f"{gunicorn_ssl_url}/http/")
+        assert response.status_code == 200
+        assert response.http_version == "HTTP/2"
+
+    def test_scope_reports_http2(self, http2_client, gunicorn_ssl_url):
+        response = http2_client.get(f"{gunicorn_ssl_url}/http/scope")
+        assert response.status_code == 200
+        assert response.json()["http_version"] == "2"
+
+    def test_post_echo(self, http2_client, gunicorn_ssl_url):
+        payload = b"x" * 200_000
+        response = http2_client.post(f"{gunicorn_ssl_url}/http/echo", content=payload)
+        assert response.status_code == 200
+        assert response.http_version == "HTTP/2"
+        assert response.content == payload
+
+    def test_streaming_response(self, http2_client, gunicorn_ssl_url):
+        with http2_client.stream("GET", f"{gunicorn_ssl_url}/http/stream") as response:
+            assert response.http_version == "HTTP/2"
+            chunks = list(response.iter_bytes())
+        assert b"".join(chunks)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_streams(self, async_http_client_factory, gunicorn_ssl_url):
+        import asyncio
+        async with await async_http_client_factory(http2=True) as client:
+            responses = await asyncio.gather(
+                *(client.get(f"{gunicorn_ssl_url}/http/") for _ in range(20)))
+        assert {r.status_code for r in responses} == {200}
+        assert {r.http_version for r in responses} == {"HTTP/2"}

--- a/tests/support/http2_live_app.py
+++ b/tests/support/http2_live_app.py
@@ -1,0 +1,88 @@
+"""WSGI and ASGI applications for the live HTTP/2 tests."""
+
+import asyncio
+
+BIG = b"x" * (4 * 1024 * 1024)
+
+
+def wsgi(environ, start_response):
+    path = environ["PATH_INFO"]
+    if path == "/echo":
+        body = environ["wsgi.input"].read()
+        start_response("200 OK", [("content-type", "application/octet-stream")])
+        return [body]
+    if path == "/big":
+        start_response("200 OK", [("content-type", "application/octet-stream")])
+        return [BIG[i:i + 65536] for i in range(0, len(BIG), 65536)]
+    if path == "/explode":
+        start_response("200 OK", [("content-type", "text/plain")])
+
+        def gen():
+            yield b"first"
+            raise RuntimeError("boom after headers")
+        return gen()
+    if path == "/headers":
+        start_response("200 OK", [("content-type", "text/plain"), ("x-marker", "present")])
+        return [b"ok"]
+    if path == "/chunks":
+        start_response("200 OK", [("content-type", "text/plain")])
+        return [b"a", b"b", b""]
+    start_response("200 OK", [("content-type", "text/plain")])
+    return [b"ok"]
+
+
+async def asgi(scope, receive, send):
+    if scope["type"] != "http":
+        return
+    path = scope["path"]
+
+    async def start(status=200, headers=()):
+        await send({"type": "http.response.start", "status": status,
+                    "headers": [(b"content-type", b"text/plain")] + list(headers)})
+
+    if path == "/echo":
+        body = b""
+        while True:
+            msg = await receive()
+            body += msg.get("body", b"")
+            if not msg.get("more_body"):
+                break
+        await start()
+        await send({"type": "http.response.body", "body": body})
+        return
+    if path == "/big":
+        await start()
+        for i in range(0, len(BIG), 65536):
+            await send({"type": "http.response.body", "body": BIG[i:i + 65536],
+                        "more_body": True})
+        await send({"type": "http.response.body", "body": b""})
+        return
+    if path == "/explode":
+        await start()
+        await send({"type": "http.response.body", "body": b"first", "more_body": True})
+        raise RuntimeError("boom after headers")
+    if path == "/headers":
+        await start(headers=[(b"x-marker", b"present")])
+        await send({"type": "http.response.body", "body": b"ok"})
+        return
+    if path == "/chunks":
+        await start()
+        await send({"type": "http.response.body", "body": b"a", "more_body": True})
+        await send({"type": "http.response.body", "body": b"b", "more_body": True})
+        await send({"type": "http.response.body", "body": b""})
+        return
+    if path == "/listen":
+        async def listen():
+            while True:
+                msg = await receive()
+                if msg["type"] == "http.disconnect":
+                    return
+        task = asyncio.get_running_loop().create_task(listen())
+        await asyncio.sleep(0.2)
+        await start()
+        await send({"type": "http.response.body", "body": b"ok"})
+        task.cancel()
+        return
+    await receive()
+    await start()
+    await send({"type": "http.response.body", "body": b"ok"})

--- a/tests/test_asgi_http2_response.py
+++ b/tests/test_asgi_http2_response.py
@@ -33,6 +33,9 @@ def make_request():
     req = mock.Mock()
     req.method = "GET"
     req.stream.stream_id = 1
+    req.stream.disconnected = False
+    req.stream.expect_continue = False
+    req.stream.response_headers_sent = False
     req.path = "/"
     req.query = ""
     req.headers = []
@@ -47,10 +50,10 @@ async def run_app(app, method="GET"):
     """Drive _handle_http2_request and report what reached the wire."""
     proto, worker = make_protocol(app)
     h2 = mock.AsyncMock()
-    h2.streams = {1: mock.Mock()}
     h2.h2_conn = mock.Mock()
     req = make_request()
     req.method = method
+    h2.streams = {1: req.stream}
     await proto._handle_http2_request(
         req, h2, ("127.0.0.1", 8000), ("127.0.0.1", 1))
     assert not worker.log.exception.called, (

--- a/tests/test_http2_async_connection.py
+++ b/tests/test_http2_async_connection.py
@@ -1623,3 +1623,107 @@ class TestAsyncEmptyFinalChunk:
         writer.clear()
         assert await conn.send_data(1, b"", end_stream=False) is True
         assert writer.get_written_data() == b""
+
+
+class TestWriteDrain:
+    """The drain is bounded and does not hold the connection write lock."""
+
+    async def _conn(self, writer, timeout=30):
+        import types
+        from gunicorn.http2.async_connection import AsyncHTTP2Connection
+
+        cfg = MockConfig()
+        reader = MockAsyncReader()
+        conn = AsyncHTTP2Connection(cfg, reader, writer, ('127.0.0.1', 12345))
+        await conn.initiate_connection()
+        client = create_client_connection()
+        reader.set_data(client.data_to_send())
+        await conn.receive_data()
+        client.receive_data(writer.get_written_data())
+        client.send_headers(1, [
+            (':method', 'GET'), (':path', '/'),
+            (':scheme', 'https'), (':authority', 'localhost'),
+        ], end_stream=True)
+        reader.set_data(client.data_to_send())
+        await conn.receive_data()
+        writer.clear()
+        # After setup: cfg.timeout takes floats here, the validator does not
+        conn.cfg = types.SimpleNamespace(timeout=timeout)
+        return conn, client, reader
+
+    @pytest.mark.asyncio
+    async def test_a_stalled_drain_does_not_hold_the_lock(self):
+        """The receive loop keeps running while a stream waits on the transport."""
+
+        class BlockingWriter(MockAsyncWriter):
+            def __init__(self):
+                super().__init__()
+                self.release = asyncio.Event()
+                self.blocking = False
+
+            async def drain(self):
+                if self.blocking:
+                    await self.release.wait()
+
+        writer = BlockingWriter()
+        conn, client, reader = await self._conn(writer)
+        assert await conn.send_response_headers(1, [(':status', '200')]) is True
+
+        writer.blocking = True
+        sender = asyncio.get_running_loop().create_task(
+            conn.send_data(1, b"payload", end_stream=True))
+        await asyncio.sleep(0.02)
+        assert not sender.done()
+
+        # The write lock is free while the sender waits on the transport,
+        # so the receive loop and the other streams are not held hostage.
+        assert not conn._lock().locked()
+
+        async def take_lock():
+            async with conn._lock():
+                return True
+
+        assert await asyncio.wait_for(take_lock(), timeout=1) is True
+
+        writer.release.set()
+        assert await asyncio.wait_for(sender, timeout=1) is True
+
+    @pytest.mark.asyncio
+    async def test_a_peer_that_never_reads_is_dropped_after_timeout(self):
+        from gunicorn.http2.errors import HTTP2ConnectionError
+
+        class DeafWriter(MockAsyncWriter):
+            blocking = False
+
+            async def drain(self):
+                if self.blocking:
+                    await asyncio.Event().wait()   # never resumes
+
+        writer = DeafWriter()
+        conn, client, reader = await self._conn(writer, timeout=0.2)
+        writer.blocking = True
+        with pytest.raises(HTTP2ConnectionError):
+            await conn.send_response_headers(1, [(':status', '200')])
+        assert conn.is_closed is True
+        assert conn.streams[1].disconnected is True
+
+    @pytest.mark.asyncio
+    async def test_timeout_zero_waits_for_the_transport(self):
+        class SlowWriter(MockAsyncWriter):
+            def __init__(self):
+                super().__init__()
+                self.release = asyncio.Event()
+
+            async def drain(self):
+                await self.release.wait()
+
+        writer = SlowWriter()
+        writer.release.set()          # transport keeps up during setup
+        conn, client, reader = await self._conn(writer, timeout=0)
+        writer.release.clear()
+        sender = asyncio.get_running_loop().create_task(
+            conn.send_response_headers(1, [(':status', '200')]))
+        await asyncio.sleep(0.3)
+        assert not sender.done()
+        writer.release.set()
+        assert await asyncio.wait_for(sender, timeout=1) is True

--- a/tests/test_http2_async_connection.py
+++ b/tests/test_http2_async_connection.py
@@ -1628,8 +1628,17 @@ class TestAsyncEmptyFinalChunk:
 class TestWriteDrain:
     """The drain is bounded and does not hold the connection write lock."""
 
+    class _Timeout:
+        """The real config with cfg.timeout overridden, floats included."""
+
+        def __init__(self, cfg, timeout):
+            self._cfg = cfg
+            self.timeout = timeout
+
+        def __getattr__(self, name):
+            return getattr(self._cfg, name)
+
     async def _conn(self, writer, timeout=30):
-        import types
         from gunicorn.http2.async_connection import AsyncHTTP2Connection
 
         cfg = MockConfig()
@@ -1647,8 +1656,7 @@ class TestWriteDrain:
         reader.set_data(client.data_to_send())
         await conn.receive_data()
         writer.clear()
-        # After setup: cfg.timeout takes floats here, the validator does not
-        conn.cfg = types.SimpleNamespace(timeout=timeout)
+        conn.cfg = self._Timeout(conn.cfg, timeout)
         return conn, client, reader
 
     @pytest.mark.asyncio
@@ -1687,6 +1695,62 @@ class TestWriteDrain:
 
         writer.release.set()
         assert await asyncio.wait_for(sender, timeout=1) is True
+
+    @pytest.mark.asyncio
+    async def test_the_receive_loop_runs_while_a_drain_is_stalled(self):
+        """Bodies, resets and window updates keep flowing for other streams."""
+
+        class BlockingWriter(MockAsyncWriter):
+            def __init__(self):
+                super().__init__()
+                self.release = asyncio.Event()
+                self.blocking = False
+
+            async def drain(self):
+                if self.blocking:
+                    await self.release.wait()
+
+        writer = BlockingWriter()
+        conn, client, reader = await self._conn(writer)
+        assert await conn.send_response_headers(1, [(':status', '200')]) is True
+
+        writer.blocking = True
+        sender = asyncio.get_running_loop().create_task(
+            conn.send_data(1, b"payload", end_stream=True))
+        await asyncio.sleep(0.02)
+        assert not sender.done()
+
+        # A new request and a PING arrive while the sender waits
+        client.send_headers(3, [
+            (':method', 'POST'), (':path', '/other'),
+            (':scheme', 'https'), (':authority', 'localhost'),
+        ], end_stream=False)
+        client.send_data(3, b"body", end_stream=True)
+        client.ping(b"12345678")
+        reader.set_data(client.data_to_send())
+
+        requests = await asyncio.wait_for(conn.receive_data(), timeout=1)
+        assert [r.stream.stream_id for r in requests] == [3]
+        assert await asyncio.wait_for(requests[0].stream.read_body_chunk(), 1) == b"body"
+
+        writer.release.set()
+        assert await asyncio.wait_for(sender, timeout=1) is True
+
+    @pytest.mark.asyncio
+    async def test_nothing_to_write_does_not_wait_on_the_transport(self):
+        """A flush with no bytes queued must not touch a stalled transport."""
+
+        class CountingWriter(MockAsyncWriter):
+            drains = 0
+
+            async def drain(self):
+                type(self).drains += 1
+
+        writer = CountingWriter()
+        conn, client, reader = await self._conn(writer)
+        CountingWriter.drains = 0
+        await conn._send_pending_data()      # h2 has nothing queued
+        assert CountingWriter.drains == 0
 
     @pytest.mark.asyncio
     async def test_a_peer_that_never_reads_is_dropped_after_timeout(self):

--- a/tests/test_http2_config.py
+++ b/tests/test_http2_config.py
@@ -353,3 +353,45 @@ class TestHttp2WindowValidation:
         c = Config()
         with pytest.raises(ValueError):
             c.set("http_protocols", "h2,h3")
+
+
+class TestConfigValidate:
+    """Cross-setting checks run once the whole configuration is loaded."""
+
+    def test_h2_without_the_package_is_a_config_error(self):
+        from unittest import mock
+        from gunicorn.errors import ConfigError
+        from gunicorn import http2
+
+        c = Config()
+        c.set("http_protocols", "h2,h1")
+        c.set("certfile", "/dev/null")
+        with mock.patch.object(http2, "is_http2_available", return_value=False):
+            with pytest.raises(ConfigError):
+                c.validate()
+
+    def test_h2_without_tls_or_cleartext_warns(self, capsys):
+        from unittest import mock
+        from gunicorn import http2
+
+        c = Config()
+        c.set("http_protocols", "h2,h1")
+        with mock.patch.object(http2, "is_http2_available", return_value=True):
+            c.validate()
+        assert "never be negotiated" in capsys.readouterr().err
+
+    def test_h2_over_cleartext_is_quiet(self, capsys):
+        from unittest import mock
+        from gunicorn import http2
+
+        c = Config()
+        c.set("http_protocols", "h2,h1")
+        c.set("http2_cleartext", "prior-knowledge")
+        with mock.patch.object(http2, "is_http2_available", return_value=True):
+            c.validate()
+        assert capsys.readouterr().err == ""
+
+    def test_h1_only_is_quiet(self, capsys):
+        c = Config()
+        c.validate()
+        assert capsys.readouterr().err == ""

--- a/tests/test_http2_config.py
+++ b/tests/test_http2_config.py
@@ -109,16 +109,11 @@ class TestHttp2MaxConcurrentStreams:
         with pytest.raises(ValueError):
             c.set("http2_max_concurrent_streams", -1)
 
-    def test_zero_value(self):
-        # Zero is technically valid for positive int validator
-        # It may have special meaning (use h2 default)
+    def test_zero_value_is_rejected(self):
+        """0 would advertise a connection that can open no streams."""
         c = Config()
-        c.set("http2_max_concurrent_streams", 0)
-        assert c.http2_max_concurrent_streams == 0
-
-
-class TestHttp2InitialWindowSize:
-    """Test http2_initial_window_size configuration setting."""
+        with pytest.raises(ValueError):
+            c.set("http2_max_concurrent_streams", 0)
 
     def test_default_value(self):
         c = Config()
@@ -341,3 +336,20 @@ class TestValidateHttp2FrameSize:
         """Negative values should raise ValueError."""
         with pytest.raises(ValueError):
             config.validate_http2_frame_size(-1)
+
+
+class TestHttp2WindowValidation:
+    def test_window_above_2_31_is_rejected(self):
+        c = Config()
+        with pytest.raises(ValueError):
+            c.set("http2_initial_window_size", 2 ** 31)
+
+    def test_window_at_the_limit_is_accepted(self):
+        c = Config()
+        c.set("http2_initial_window_size", 2 ** 31 - 1)
+        assert c.http2_initial_window_size == 2 ** 31 - 1
+
+    def test_h3_is_rejected(self):
+        c = Config()
+        with pytest.raises(ValueError):
+            c.set("http_protocols", "h2,h3")

--- a/tests/test_http2_connection.py
+++ b/tests/test_http2_connection.py
@@ -2049,16 +2049,33 @@ class TestStreamFloods:
         assert 3 not in conn.streams
         assert conn.receive_data(b"") == []
 
-    def test_flood_of_reset_pairs_leaves_nothing_behind(self):
+    def test_reset_pairs_below_the_rate_limit_leave_nothing_behind(self):
+        from gunicorn.http2 import connection as connmod
         conn, client, sock, req = self._open_post()
-        for sid in range(3, 3 + 2 * 500, 2):
+        for sid in range(3, 3 + 2 * (connmod.RST_STREAM_RATE_LIMIT - 1), 2):
             self._get(client, sid)
             client.reset_stream(sid, error_code=h2.errors.ErrorCodes.CANCEL)
         data = client.data_to_send()
         for i in range(0, len(data), 65536):
-            conn.pump(1) if False else conn.receive_data(data[i:i + 65536])
+            conn.receive_data(data[i:i + 65536])
         assert list(conn.streams) == [1]
         assert not conn.pending_requests
+        assert conn.is_closed is False
+
+    def test_reset_flood_gets_enhance_your_calm(self):
+        from gunicorn.http2 import connection as connmod
+        conn, client, sock, req = self._open_post()
+        for sid in range(3, 3 + 2 * (connmod.RST_STREAM_RATE_LIMIT + 1), 2):
+            self._get(client, sid)
+            client.reset_stream(sid, error_code=h2.errors.ErrorCodes.CANCEL)
+        data = client.data_to_send()
+        before = len(sock.get_sent_data())
+        with pytest.raises(HTTP2ProtocolError):
+            for i in range(0, len(data), 65536):
+                conn.receive_data(data[i:i + 65536])
+        assert conn.is_closed is True
+        kinds = frame_types(sock.get_sent_data()[before:])
+        assert "GoAwayFrame" in kinds
 
 
 class TestEmptyFinalChunk:
@@ -2105,3 +2122,130 @@ class TestEmptyFinalChunk:
         assert conn.end_stream(1) is True
         events = client.receive_data(sock.get_sent_data()[before:])
         assert "StreamEnded" in [type(e).__name__ for e in events]
+
+
+class TestBadRequestsAreStreamErrors:
+    """A request gunicorn cannot accept resets its stream, nothing more."""
+
+    def _open(self, **cfg_values):
+        from gunicorn.http2.connection import HTTP2ServerConnection
+
+        cfg = MockConfig()
+        for k, v in cfg_values.items():
+            cfg.set(k, v)
+        sock = MockSocket()
+        conn = HTTP2ServerConnection(cfg, sock, ('127.0.0.1', 12345))
+        conn.initiate_connection()
+        client = create_client_connection()
+        conn.receive_data(client.data_to_send())
+        client.receive_data(sock.get_sent_data())
+        return conn, client, sock
+
+    def _resets(self, client, sock, since):
+        events = client.receive_data(sock.get_sent_data()[since:])
+        return [(e.stream_id, e.error_code) for e in events
+                if isinstance(e, h2.events.StreamReset)]
+
+    def test_control_character_in_a_value_resets_only_that_stream(self):
+        conn, client, sock = self._open()
+        for sid, value in ((1, "ok"), (3, "bad\x01value"), (5, "ok")):
+            client.send_headers(sid, [
+                (':method', 'GET'), (':path', '/'),
+                (':scheme', 'https'), (':authority', 'localhost'),
+                ('x-thing', value),
+            ], end_stream=True)
+        before = len(sock.get_sent_data())
+        requests = conn.receive_data(client.data_to_send())
+        assert [r.stream.stream_id for r in requests] == [1, 5]
+        assert 3 not in conn.streams
+        assert self._resets(client, sock, before) == [(3, h2.errors.ErrorCodes.PROTOCOL_ERROR)]
+        assert conn.is_closed is False
+
+    def test_request_line_and_field_limits_apply(self):
+        conn, client, sock = self._open(limit_request_line=64, limit_request_fields=3,
+                                        limit_request_field_size=40)
+        base = [(':method', 'GET'), (':scheme', 'https'), (':authority', 'localhost')]
+        client.send_headers(1, base + [(':path', '/' + 'a' * 100)], end_stream=True)
+        client.send_headers(3, base + [(':path', '/'), ('a', '1'), ('b', '2'), ('c', '3'), ('d', '4')],
+                            end_stream=True)
+        client.send_headers(5, base + [(':path', '/'), ('x-long', 'v' * 60)], end_stream=True)
+        client.send_headers(7, base + [(':path', '/fine'), ('x', '1')], end_stream=True)
+        before = len(sock.get_sent_data())
+        requests = conn.receive_data(client.data_to_send())
+        assert [r.stream.stream_id for r in requests] == [7]
+        assert sorted(sid for sid, _ in self._resets(client, sock, before)) == [1, 3, 5]
+
+    def test_method_must_be_a_token(self):
+        conn, client, sock = self._open()
+        client.send_headers(1, [
+            (':method', 'g e t'), (':path', '/'),
+            (':scheme', 'https'), (':authority', 'localhost'),
+        ], end_stream=True)
+        before = len(sock.get_sent_data())
+        assert conn.receive_data(client.data_to_send()) == []
+        assert self._resets(client, sock, before) == [(1, h2.errors.ErrorCodes.PROTOCOL_ERROR)]
+
+    def test_forbidden_trailers_are_dropped(self):
+        conn, client, sock = self._open()
+        client.send_headers(1, [
+            (':method', 'POST'), (':path', '/'),
+            (':scheme', 'https'), (':authority', 'localhost'),
+        ], end_stream=False)
+        req = conn.receive_data(client.data_to_send())[0]
+        client.send_data(1, b"x", end_stream=False)
+        client.send_headers(1, [('content-length', '99'), ('x-sum', 'abc')], end_stream=True)
+        sock.set_recv_data(client.data_to_send())
+        assert req.body.read() == b"x"
+        assert req.trailers == [('X-SUM', 'abc')]
+
+    def test_outbound_chunks_respect_the_peer_frame_size(self):
+        """Our own max_frame_size is for inbound frames; the peer's rules ours."""
+        conn, client, sock = self._open(http2_max_frame_size=32768)
+        client.send_headers(1, [
+            (':method', 'GET'), (':path', '/'),
+            (':scheme', 'https'), (':authority', 'localhost'),
+        ], end_stream=True)
+        conn.receive_data(client.data_to_send())
+        before = len(sock.get_sent_data())
+        assert conn.send_response(1, 200, [], b"x" * 20000) is True
+        kinds = frame_types(sock.get_sent_data()[before:])
+        assert kinds.count("DataFrame") == 2
+
+    def test_header_list_size_zero_is_not_advertised(self):
+        from gunicorn.http2.connection import HTTP2ServerConnection
+
+        cfg = MockConfig()
+        cfg.set("http2_max_header_list_size", 0)
+        conn = HTTP2ServerConnection(cfg, MockSocket(), ('127.0.0.1', 12345))
+        conn.initiate_connection()
+        # Left at h2's own default rather than advertised as 0, which
+        # would refuse every request.
+        assert conn.h2_conn.local_settings.max_header_list_size
+
+
+class TestExpectContinue:
+    def test_100_is_sent_before_the_body_is_pulled(self):
+        from gunicorn.http2.connection import HTTP2ServerConnection
+
+        sock = MockSocket()
+        conn = HTTP2ServerConnection(MockConfig(), sock, ('127.0.0.1', 12345))
+        conn.initiate_connection()
+        client = create_client_connection()
+        conn.receive_data(client.data_to_send())
+        client.receive_data(sock.get_sent_data())
+        client.send_headers(1, [
+            (':method', 'POST'), (':path', '/'),
+            (':scheme', 'https'), (':authority', 'localhost'),
+            ('expect', '100-continue'),
+        ], end_stream=False)
+        req = conn.receive_data(client.data_to_send())[0]
+        assert req.stream.expect_continue is True
+
+        client.send_data(1, b"payload", end_stream=True)
+        sock.set_recv_data(client.data_to_send())
+        before = len(sock.get_sent_data())
+        assert req.body.read() == b"payload"
+        events = client.receive_data(sock.get_sent_data()[before:])
+        informational = [e for e in events if isinstance(e, h2.events.InformationalResponseReceived)]
+        assert [dict(e.headers)[b':status'] for e in informational] == [b'100']
+        assert req.stream.expect_continue is False

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -1669,7 +1669,6 @@ class TestH2CASGIStreamingPaths:
         finally:
             _asgi_h2_teardown(loop, proto)
 
-
     def test_protocol_error_mid_body_cancels_the_app(self):
         got = []
 
@@ -1764,7 +1763,6 @@ class TestH2CASGIResponseSendIsAtomic:
     def test_reset_during_drain_is_not_an_app_error(self):
         """Every send after the peer's reset stays inert, trailers included."""
         import h2.errors
-
 
         async def app(scope, receive, send):
             await receive()
@@ -2014,6 +2012,72 @@ class TestH2CASGIContract:
                     await asyncio.sleep(0.05)
             loop.run_until_complete(asyncio.wait_for(until_closed(), timeout=6))
             assert "GoAwayFrame" in frame_types(transport.written)
+        finally:
+            _asgi_h2_teardown(loop, proto)
+
+    def test_a_paused_transport_stops_reading_too(self):
+        """A peer that stops reading gets its frames left unparsed."""
+        seen = []
+
+        async def app(scope, receive, send):
+            await receive()
+            seen.append(scope["path"])
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        loop, worker, proto, transport, client = _asgi_h2_session(app)
+        try:
+            _post_headers(client, 1, "/first", end_stream=True)
+            proto.data_received(client.data_to_send())
+
+            async def race():
+                while not seen:
+                    await asyncio.sleep(0.005)
+                proto.pause_writing()
+                assert transport.paused is True
+
+                # PINGs arriving now must not be answered into a buffer
+                # that is already over its limit.
+                # A real transport stops delivering while reading is
+                # paused, so nothing new is parsed and nothing is queued.
+                queued = len(transport.written)
+                await asyncio.sleep(0.05)
+                assert len(transport.written) == queued
+
+                proto.resume_writing()
+                assert transport.paused is False
+                _post_headers(client, 3, "/second", end_stream=True)
+                proto.data_received(client.data_to_send())
+                while len(seen) < 2:
+                    await asyncio.sleep(0.005)
+            loop.run_until_complete(asyncio.wait_for(race(), timeout=5))
+            assert seen == ["/first", "/second"]
+            assert not worker.log.exception.called
+        finally:
+            _asgi_h2_teardown(loop, proto)
+
+    def test_reader_is_not_resumed_while_writing_is_paused(self):
+        async def app(scope, receive, send):
+            await receive()
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        loop, worker, proto, transport, client = _asgi_h2_session(app)
+        try:
+            _post_headers(client, 1, "/", end_stream=True)
+            proto.data_received(client.data_to_send())
+
+            async def check():
+                while proto._h2_writer_protocol is None:
+                    await asyncio.sleep(0.005)
+                proto.pause_writing()
+                assert transport.paused is True
+                # The receive loop must not undo the pause
+                proto._maybe_resume_reading()
+                assert transport.paused is True
+                proto.resume_writing()
+                assert transport.paused is False
+            loop.run_until_complete(asyncio.wait_for(check(), timeout=5))
         finally:
             _asgi_h2_teardown(loop, proto)
 

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -2292,33 +2292,3 @@ class TestUpgradeSettingsValidation:
         big = str(negotiation.H2C_UPGRADE_BODY_LIMIT + 1)
         assert negotiation.upgrade_settings(self._req(extra=[("CONTENT-LENGTH", big)])) is None
         assert negotiation.upgrade_settings(self._req(extra=[("CONTENT-LENGTH", "10")])) is not None
-
-
-class TestStartupCheck:
-    def test_h2_without_the_package_is_a_config_error(self):
-        from unittest import mock
-        from gunicorn.errors import ConfigError
-        from gunicorn import http2
-        cfg = h2c_config()
-        with mock.patch.object(http2, "is_http2_available", return_value=False):
-            with pytest.raises(ConfigError):
-                http2.check_config(cfg, mock.Mock())
-
-    def test_h2_without_tls_or_cleartext_warns(self):
-        from unittest import mock
-        from gunicorn.config import Config
-        from gunicorn import http2
-        cfg = Config()
-        cfg.set("http_protocols", "h2,h1")
-        log = mock.Mock()
-        with mock.patch.object(http2, "is_http2_available", return_value=True):
-            http2.check_config(cfg, log)
-        assert log.warning.called
-
-    def test_h1_only_is_silent(self):
-        from unittest import mock
-        from gunicorn.config import Config
-        from gunicorn import http2
-        log = mock.Mock()
-        http2.check_config(Config(), log)
-        assert not log.warning.called

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -1840,6 +1840,211 @@ class TestH2CASGIResponseSendIsAtomic:
         assert "_send_pending_data" not in src
 
 
+@pytest.mark.skipif(not H2_AVAILABLE, reason="h2 library not available")
+class TestH2CASGIContract:
+    """send() after a disconnect raises OSError; trailers; no-body framing."""
+
+    def test_send_after_reset_raises_oserror(self):
+        import h2.errors
+
+        caught = []
+
+        async def app(scope, receive, send):
+            await receive()
+            await send({"type": "http.response.start", "status": 200,
+                        "headers": []})
+            await send({"type": "http.response.body", "body": b"one",
+                        "more_body": True})
+            await asyncio.sleep(0.1)     # the reset lands here
+            try:
+                await send({"type": "http.response.body", "body": b"two",
+                            "more_body": True})
+            except OSError as e:
+                caught.append(type(e).__name__)
+                try:
+                    await send({"type": "http.response.body", "body": b""})
+                except OSError:
+                    caught.append("again")
+
+        loop, worker, proto, transport, client = _asgi_h2_session(app)
+        try:
+            _post_headers(client, 1, "/reset", end_stream=True)
+            proto.data_received(client.data_to_send())
+
+            async def later():
+                while b"one" not in transport.written:
+                    await asyncio.sleep(0.005)
+                client.reset_stream(1, error_code=h2.errors.ErrorCodes.CANCEL)
+                proto.data_received(client.data_to_send())
+                while proto._h2_tasks:
+                    await asyncio.sleep(0.005)
+            loop.run_until_complete(asyncio.wait_for(later(), timeout=5))
+            assert caught == ["ClientDisconnected", "again"]
+            assert not worker.log.exception.called
+        finally:
+            _asgi_h2_teardown(loop, proto)
+
+    def _run(self, app, path="/t"):
+        import h2.events
+        loop, worker, proto, transport, client = _asgi_h2_session(app)
+        try:
+            _post_headers(client, 1, path, end_stream=True)
+            proto.data_received(client.data_to_send())
+
+            async def until_done():
+                while proto._h2_tasks or not transport.written:
+                    await asyncio.sleep(0.005)
+                await asyncio.sleep(0.02)
+            loop.run_until_complete(asyncio.wait_for(until_done(), timeout=5))
+            events = client.receive_data(transport.written)
+            return events, worker
+        finally:
+            _asgi_h2_teardown(loop, proto)
+
+    def test_trailers_follow_the_body_and_end_the_stream(self):
+        import h2.events
+
+        async def app(scope, receive, send):
+            await receive()
+            await send({"type": "http.response.start", "status": 200,
+                        "headers": [], "trailers": True})
+            await send({"type": "http.response.body", "body": b"payload"})
+            await send({"type": "http.response.trailers",
+                        "headers": [(b"x-a", b"1")], "more_trailers": True})
+            await send({"type": "http.response.trailers",
+                        "headers": [(b"x-b", b"2")]})
+
+        events, worker = self._run(app)
+        kinds = [type(e).__name__ for e in events]
+        assert kinds[-2:] == ["TrailersReceived", "StreamEnded"], kinds
+        trailers = [e for e in events if isinstance(e, h2.events.TrailersReceived)][0]
+        assert dict(trailers.headers) == {"x-a": "1", "x-b": "2"}
+        assert not worker.log.exception.called
+
+    def test_announced_trailers_never_sent_still_end_the_stream(self):
+        async def app(scope, receive, send):
+            await receive()
+            await send({"type": "http.response.start", "status": 200,
+                        "headers": [], "trailers": True})
+            await send({"type": "http.response.body", "body": b"payload"})
+
+        events, worker = self._run(app)
+        kinds = [type(e).__name__ for e in events]
+        assert "TrailersReceived" not in kinds
+        assert kinds[-1] == "StreamEnded", kinds
+
+    def test_unannounced_trailers_are_an_app_error(self):
+        async def app(scope, receive, send):
+            await receive()
+            await send({"type": "http.response.start", "status": 200,
+                        "headers": []})
+            await send({"type": "http.response.body", "body": b"payload"})
+            await send({"type": "http.response.trailers", "headers": [(b"x", b"1")]})
+
+        events, worker = self._run(app)
+        assert worker.log.exception.called
+        assert "StreamEnded" in [type(e).__name__ for e in events]
+
+    def test_no_body_status_drops_framing_headers(self):
+        import h2.events
+
+        async def app(scope, receive, send):
+            await receive()
+            await send({"type": "http.response.start", "status": 204,
+                        "headers": [(b"content-length", b"12"),
+                                    (b"transfer-encoding", b"chunked"),
+                                    (b"x-keep", b"yes")]})
+            await send({"type": "http.response.body", "body": b""})
+
+        events, worker = self._run(app)
+        resp = [e for e in events if isinstance(e, h2.events.ResponseReceived)][0]
+        names = {name for name, _ in resp.headers}
+        assert "x-keep" in names
+        assert "content-length" not in names and "transfer-encoding" not in names
+
+    def test_expect_100_continue_is_answered_before_the_body_is_read(self):
+        import h2.events
+
+        async def app(scope, receive, send):
+            msg = await receive()
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": msg["body"]})
+
+        loop, worker, proto, transport, client = _asgi_h2_session(app)
+        try:
+            client.send_headers(1, [
+                (":method", "POST"), (":path", "/expect"),
+                (":scheme", "http"), (":authority", "x"),
+                ("expect", "100-continue"),
+            ], end_stream=False)
+            proto.data_received(client.data_to_send())
+
+            async def later():
+                # A 100 must arrive before any body is sent
+                while True:
+                    events = client.receive_data(b"")
+                    found = [e for e in client.receive_data(transport.written)
+                             if isinstance(e, h2.events.InformationalResponseReceived)]
+                    if found:
+                        break
+                    await asyncio.sleep(0.005)
+                client.send_data(1, b"payload", end_stream=True)
+                proto.data_received(client.data_to_send())
+                while b"payload" not in transport.written[-64:]:
+                    await asyncio.sleep(0.005)
+            loop.run_until_complete(asyncio.wait_for(later(), timeout=5))
+            assert not worker.log.exception.called
+        finally:
+            _asgi_h2_teardown(loop, proto)
+
+    def test_idle_connection_closes_after_keepalive(self):
+        async def app(scope, receive, send):
+            await receive()
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        loop, worker, proto, transport, client = _asgi_h2_session(app)
+        worker.cfg.set("keepalive", 1)
+        try:
+            _post_headers(client, 1, "/", end_stream=True)
+            proto.data_received(client.data_to_send())
+
+            async def until_closed():
+                while not transport.closed:
+                    await asyncio.sleep(0.05)
+            loop.run_until_complete(asyncio.wait_for(until_closed(), timeout=6))
+            assert "GoAwayFrame" in frame_types(transport.written)
+        finally:
+            _asgi_h2_teardown(loop, proto)
+
+    def test_drain_waits_while_the_transport_is_paused(self):
+        done = []
+
+        async def app(scope, receive, send):
+            await receive()
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"x" * 1000})
+            done.append(True)
+
+        loop, worker, proto, transport, client = _asgi_h2_session(app)
+        try:
+            _post_headers(client, 1, "/", end_stream=True)
+            proto.data_received(client.data_to_send())
+
+            async def race():
+                while proto._h2_writer_protocol is None:
+                    await asyncio.sleep(0.005)
+                proto.pause_writing()
+                await asyncio.sleep(0.1)
+                assert not done, "the send finished while the transport was paused"
+                proto.resume_writing()
+                while not done:
+                    await asyncio.sleep(0.005)
+            loop.run_until_complete(asyncio.wait_for(race(), timeout=5))
+        finally:
+            _asgi_h2_teardown(loop, proto)
+
+
 @pytest.mark.skipif(not H1C_AVAILABLE, reason="gunicorn_h1c not available")
 class TestH2CASGIUpgradeOversizedTail:
     """The fast parser caps remaining(); past the cap the tail is gone.

--- a/tests/test_http2_h2c.py
+++ b/tests/test_http2_h2c.py
@@ -2040,3 +2040,80 @@ class TestUpgradeSynthesis:
         finally:
             server.close()
             client.close()
+
+
+class TestUpgradeSettingsValidation:
+    """A bad HTTP2-Settings value must be refused before any 101 goes out."""
+
+    def _req(self, settings="AAMAAABkAAQCAAAAAAIAAAAA", connection="Upgrade, HTTP2-Settings",
+             version=(1, 1), extra=()):
+        from unittest import mock
+        req = mock.Mock()
+        req.version = version
+        req.headers = [("UPGRADE", "h2c"), ("CONNECTION", connection),
+                       ("HTTP2-SETTINGS", settings)] + list(extra)
+        return req
+
+    def test_valid_payload_is_returned(self):
+        from gunicorn.http2 import negotiation
+        assert negotiation.upgrade_settings(self._req()) == b"AAMAAABkAAQCAAAAAAIAAAAA"
+
+    def test_bad_base64_is_refused(self):
+        from gunicorn.http2 import negotiation
+        assert negotiation.upgrade_settings(self._req(settings="!!!")) is None
+
+    def test_wrong_length_is_refused(self):
+        from gunicorn.http2 import negotiation
+        assert negotiation.upgrade_settings(self._req(settings="AAMAAABkAAE")) is None
+
+    def test_window_above_2_31_is_refused(self):
+        import base64
+        from gunicorn.http2 import negotiation
+        raw = (4).to_bytes(2, "big") + (2 ** 31).to_bytes(4, "big")
+        payload = base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+        assert negotiation.upgrade_settings(self._req(settings=payload)) is None
+
+    def test_connection_tokens_are_matched_whole(self):
+        from gunicorn.http2 import negotiation
+        assert negotiation.upgrade_settings(
+            self._req(connection="keep-alive, x-upgrade-foo, http2-settings")) is None
+
+    def test_http_1_0_is_not_upgraded(self):
+        from gunicorn.http2 import negotiation
+        assert negotiation.upgrade_settings(self._req(version=(1, 0))) is None
+
+    def test_large_declared_body_is_not_upgraded(self):
+        from gunicorn.http2 import negotiation
+        big = str(negotiation.H2C_UPGRADE_BODY_LIMIT + 1)
+        assert negotiation.upgrade_settings(self._req(extra=[("CONTENT-LENGTH", big)])) is None
+        assert negotiation.upgrade_settings(self._req(extra=[("CONTENT-LENGTH", "10")])) is not None
+
+
+class TestStartupCheck:
+    def test_h2_without_the_package_is_a_config_error(self):
+        from unittest import mock
+        from gunicorn.errors import ConfigError
+        from gunicorn import http2
+        cfg = h2c_config()
+        with mock.patch.object(http2, "is_http2_available", return_value=False):
+            with pytest.raises(ConfigError):
+                http2.check_config(cfg, mock.Mock())
+
+    def test_h2_without_tls_or_cleartext_warns(self):
+        from unittest import mock
+        from gunicorn.config import Config
+        from gunicorn import http2
+        cfg = Config()
+        cfg.set("http_protocols", "h2,h1")
+        log = mock.Mock()
+        with mock.patch.object(http2, "is_http2_available", return_value=True):
+            http2.check_config(cfg, log)
+        assert log.warning.called
+
+    def test_h1_only_is_silent(self):
+        from unittest import mock
+        from gunicorn.config import Config
+        from gunicorn import http2
+        log = mock.Mock()
+        http2.check_config(Config(), log)
+        assert not log.warning.called

--- a/tests/test_http2_live.py
+++ b/tests/test_http2_live.py
@@ -1,0 +1,331 @@
+# -*- coding: utf-8 -
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+"""Adversarial HTTP/2 checks against a live gunicorn, per worker class.
+
+The docker suites drive cooperative clients on happy paths. These tests
+spawn gunicorn on a loopback port with cleartext prior-knowledge HTTP/2
+(no TLS needed) and speak raw frames through the h2 library: peers that
+reset, stall, flood, or send GOAWAY mid-request. Each case asserts on
+the wire and that the worker logged no traceback.
+"""
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+h2 = pytest.importorskip("h2")
+import h2.config  # noqa: E402
+import h2.connection  # noqa: E402
+import h2.errors  # noqa: E402
+import h2.events  # noqa: E402
+import h2.settings  # noqa: E402
+from hyperframe.frame import DataFrame, GoAwayFrame  # noqa: E402
+
+APPS = Path(__file__).parent / "support"
+
+WORKERS = ["gthread", "asgi"]
+try:
+    import gevent  # noqa: F401
+    WORKERS.append("gevent")
+except ImportError:
+    pass
+
+
+def _free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class Server:
+    """One gunicorn process serving the live app over h2c prior knowledge."""
+
+    def __init__(self, worker, timeout=2, keepalive=1):
+        self.worker = worker
+        self.port = _free_port()
+        app = "http2_live_app:asgi" if worker == "asgi" else "http2_live_app:wsgi"
+        self.log = Path(os.environ.get("PYTEST_TMP", "/tmp")) / f"gunicorn-h2-{worker}-{self.port}.log"
+        self.proc = subprocess.Popen(
+            [sys.executable, "-m", "gunicorn", app,
+             "--bind", f"127.0.0.1:{self.port}", "--workers", "1",
+             "--worker-class", worker, "--threads", "1",
+             "--http-protocols", "h2,h1", "--http2-cleartext", "prior-knowledge",
+             "--forwarded-allow-ips", "127.0.0.1",
+             "--timeout", str(timeout), "--keep-alive", str(keepalive),
+             "--graceful-timeout", "1", "--log-level", "info"],
+            cwd=str(APPS), stdout=self.log.open("w"), stderr=subprocess.STDOUT)
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            try:
+                with socket.create_connection(("127.0.0.1", self.port), timeout=0.2):
+                    return
+            except OSError:
+                if self.proc.poll() is not None:
+                    break
+                time.sleep(0.05)
+        self.stop()
+        raise RuntimeError(f"gunicorn did not start:\n{self.log.read_text()}")
+
+    def stop(self):
+        if self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(5)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait()
+
+    baseline = 0
+
+    def mark(self):
+        """Tracebacks logged before this test do not count against it."""
+        self.baseline = self.log.read_text().count("Traceback")
+
+    def tracebacks(self):
+        return self.log.read_text().count("Traceback") - self.baseline
+
+
+class Client:
+    """A raw h2 client over one TCP connection."""
+
+    def __init__(self, port):
+        self.sock = socket.create_connection(("127.0.0.1", port), timeout=5)
+        self.conn = h2.connection.H2Connection(
+            config=h2.config.H2Configuration(client_side=True, header_encoding="utf-8"))
+        self.conn.initiate_connection()
+        self.flush()
+        self.events = []
+        # Return credit for response data as a real client does; a test
+        # playing a slow reader turns this off.
+        self.ack = True
+
+    def flush(self):
+        data = self.conn.data_to_send()
+        if data:
+            self.sock.sendall(data)
+
+    def request(self, stream_id, method="GET", path="/", end_stream=True, extra=()):
+        self.conn.send_headers(stream_id, [
+            (":method", method), (":path", path),
+            (":scheme", "http"), (":authority", "localhost"),
+        ] + list(extra), end_stream=end_stream)
+        self.flush()
+
+    def read(self, until=None, timeout=3.0):
+        """Read frames until ``until(events)`` is true, EOF, or timeout."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if until is not None and until(self.events):
+                return self.events
+            self.sock.settimeout(max(0.05, deadline - time.monotonic()))
+            try:
+                data = self.sock.recv(65535)
+            except socket.timeout:
+                continue
+            except ConnectionResetError:
+                # gevent closes with unread bytes pending; same as EOF here
+                data = b""
+            if not data:
+                self.events.append("EOF")
+                return self.events
+            for event in self.conn.receive_data(data):
+                self.events.append(event)
+                if self.ack and isinstance(event, h2.events.DataReceived) and event.flow_controlled_length:
+                    self.conn.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
+            self.flush()
+        return self.events
+
+    def kinds(self):
+        return [e if isinstance(e, str) else type(e).__name__ for e in self.events]
+
+    def close(self):
+        self.sock.close()
+
+
+def _response_status(events, stream_id=1):
+    for e in events:
+        if isinstance(e, h2.events.ResponseReceived) and e.stream_id == stream_id:
+            return dict(e.headers)[":status"]
+    return None
+
+
+def _ended(stream_id=1):
+    return lambda evs: any(
+        isinstance(e, (h2.events.StreamEnded, h2.events.StreamReset)) and e.stream_id == stream_id
+        for e in evs) or "EOF" in evs
+
+
+def _reset_code(events, stream_id=1):
+    for e in events:
+        if isinstance(e, h2.events.StreamReset) and e.stream_id == stream_id:
+            return e.error_code
+    return None
+
+
+@pytest.fixture(scope="module", params=WORKERS)
+def server(request, tmp_path_factory):
+    os.environ["PYTEST_TMP"] = str(tmp_path_factory.mktemp("h2live"))
+    srv = Server(request.param)
+    yield srv
+    srv.stop()
+
+
+@pytest.fixture
+def client(server):
+    server.mark()
+    c = Client(server.port)
+    yield c
+    c.close()
+
+
+def test_plain_request(server, client):
+    client.request(1)
+    client.read(_ended())
+    assert _response_status(client.events) == "200"
+    assert server.tracebacks() == 0
+
+
+def test_streamed_upload_is_echoed_in_full(server, client):
+    client.request(1, "POST", "/echo", end_stream=False)
+    payload = os.urandom(300_000)
+    sent = 0
+    while sent < len(payload):
+        window = client.conn.local_flow_control_window(1)
+        if window <= 0:
+            client.read(lambda evs: client.conn.local_flow_control_window(1) > 0, timeout=3)
+            continue
+        size = min(window, client.conn.max_outbound_frame_size, len(payload) - sent)
+        client.conn.send_data(1, payload[sent:sent + size], end_stream=sent + size == len(payload))
+        client.flush()
+        sent += size
+    client.read(_ended(), timeout=10)
+    body = b"".join(e.data for e in client.events if isinstance(e, h2.events.DataReceived))
+    assert _response_status(client.events) == "200"
+    assert len(body) == len(payload) and body == payload
+    assert server.tracebacks() == 0
+
+
+def test_body_never_completing_is_bounded_by_the_window(server, client):
+    client.request(1, "POST", "/echo", end_stream=False)
+    client.conn.send_data(1, b"x" * 16384, end_stream=False)
+    client.flush()
+    # Only the initial windows worth is accepted before credit is returned
+    # on consumption; the app is reading, so credit does come back.
+    client.read(lambda evs: any(isinstance(e, h2.events.WindowUpdated) for e in evs), timeout=3)
+    assert any(isinstance(e, h2.events.WindowUpdated) for e in client.events)
+    assert server.tracebacks() == 0
+
+
+def test_goaway_followed_by_data_in_one_write(server, client):
+    client.request(1, "POST", "/echo", end_stream=False)
+    data = DataFrame(1, data=b"tail")
+    data.flags.add("END_STREAM")
+    client.sock.sendall(GoAwayFrame(0, last_stream_id=1, error_code=0).serialize() + data.serialize())
+    client.read(lambda evs: "EOF" in evs, timeout=5)
+    kinds = client.kinds()
+    assert _response_status(client.events) == "200"
+    assert "StreamEnded" in kinds
+    assert kinds[-1] == "EOF"
+    assert server.tracebacks() == 0
+
+
+def test_reset_while_the_app_reads_is_quiet(server, client):
+    client.request(1, "POST", "/echo", end_stream=False)
+    client.conn.send_data(1, b"part", end_stream=False)
+    client.conn.reset_stream(1, error_code=h2.errors.ErrorCodes.CANCEL)
+    client.flush()
+    client.request(3)
+    client.read(_ended(3))
+    assert _response_status(client.events, 3) == "200"
+    assert "Error" not in server.log.read_text()
+    assert server.tracebacks() == 0
+
+
+def test_slow_reader_is_cancelled_after_timeout(server, client):
+    client.ack = False
+    client.conn.update_settings({h2.settings.SettingCodes.INITIAL_WINDOW_SIZE: 1000})
+    client.flush()
+    client.request(1, path="/big")
+    start = time.monotonic()
+    client.read(_ended(), timeout=8)   # never widens the window
+    assert _reset_code(client.events) == h2.errors.ErrorCodes.CANCEL
+    assert time.monotonic() - start >= 1.5
+    assert server.tracebacks() == 0
+
+
+def test_idle_connection_is_closed_after_keepalive(server, client):
+    client.read(lambda evs: "EOF" in evs, timeout=5)
+    assert "EOF" in client.events
+    assert "ConnectionTerminated" in client.kinds()
+    assert server.tracebacks() == 0
+
+
+def test_headers_reset_flood_leaves_the_worker_serving(server, client):
+    client.request(1, "POST", "/echo", end_stream=False)
+    for sid in range(3, 3 + 2 * 150, 2):
+        client.request(sid)
+        client.conn.reset_stream(sid, error_code=h2.errors.ErrorCodes.CANCEL)
+    client.flush()
+    client.conn.send_data(1, b"done", end_stream=True)
+    client.flush()
+    client.read(_ended(1), timeout=5)
+    assert _response_status(client.events) == "200"
+    assert server.tracebacks() == 0
+
+
+def test_control_frame_flood_does_not_wedge_the_connection(server, client):
+    for _ in range(20000):
+        client.conn.ping(b"12345678")
+    client.flush()
+    client.request(1)
+    client.read(_ended(), timeout=10)
+    assert _response_status(client.events) == "200"
+    assert server.tracebacks() == 0
+
+
+def test_bad_request_resets_only_its_stream(server, client):
+    client.request(1, extra=[("x-bad", "ctl\x01char")], end_stream=True)
+    client.request(3)
+    client.read(_ended(3), timeout=5)
+    assert _reset_code(client.events, 1) == h2.errors.ErrorCodes.PROTOCOL_ERROR
+    assert _response_status(client.events, 3) == "200"
+    assert server.tracebacks() == 0
+
+
+def test_app_error_after_headers_does_not_poison_hpack(server, client):
+    client.request(1, path="/explode")
+    client.read(_ended(1), timeout=5)
+    assert _reset_code(client.events, 1) == h2.errors.ErrorCodes.INTERNAL_ERROR
+    client.request(3, path="/headers")
+    client.read(_ended(3), timeout=5)
+    resp = [e for e in client.events
+            if isinstance(e, h2.events.ResponseReceived) and e.stream_id == 3][0]
+    assert dict(resp.headers).get("x-marker") == "present"
+
+
+def test_empty_final_chunk_ends_the_stream(server, client):
+    client.request(1, path="/chunks")
+    client.read(_ended(), timeout=5)
+    assert "StreamEnded" in client.kinds()
+    assert server.tracebacks() == 0
+
+
+def test_disconnect_listener_does_not_spin(server, client):
+    if server.worker != "asgi":
+        pytest.skip("ASGI receive() semantics")
+    client.request(1, path="/listen")
+    client.read(_ended(), timeout=5)
+    assert _response_status(client.events) == "200"
+    # The worker is still responsive
+    client.request(3)
+    client.read(_ended(3), timeout=5)
+    assert _response_status(client.events, 3) == "200"
+    assert server.tracebacks() == 0

--- a/tests/test_http2_response.py
+++ b/tests/test_http2_response.py
@@ -153,3 +153,20 @@ class TestAbortedStream:
         conn.end_stream.return_value = False
         with pytest.raises(HTTP2StreamError):
             resp.close()
+
+
+class TestDefaultHeaders:
+    def test_server_and_date_are_added(self):
+        resp, conn = make_response()
+        conn.send_response_headers.return_value = True
+        resp.send_headers()
+        headers = dict(conn.send_response_headers.call_args[0][2])
+        assert headers.get("server") == resp.version
+        assert "date" in headers
+
+    def test_app_supplied_values_win(self):
+        resp, conn = make_response(headers=[("Server", "mine"), ("Date", "then")])
+        conn.send_response_headers.return_value = True
+        resp.send_headers()
+        names = [name.lower() for name, _ in conn.send_response_headers.call_args[0][2]]
+        assert names.count("server") == 1 and names.count("date") == 1

--- a/tests/test_http2_stream.py
+++ b/tests/test_http2_stream.py
@@ -928,3 +928,16 @@ class TestDisconnectWaiter:
         stream = HTTP2Stream(stream_id=1, connection=MockConnection())
         stream.close()
         assert stream.disconnected is False
+
+
+class TestUpgradeBodyCredit:
+    def test_no_credit_for_a_body_that_came_over_http1(self):
+        conn = MockConnection()
+        conn.acknowledge_data = mock.Mock()
+        stream = HTTP2Stream(stream_id=1, connection=conn)
+        stream.state = StreamState.OPEN
+        stream.receive_data(b"hello", end_stream=True)
+        stream.acked_size = stream.body_size
+        assert stream.pop_chunk() == b"hello"
+        conn.acknowledge_data.assert_not_called()
+        assert stream.acked_size == stream.body_size


### PR DESCRIPTION
Follow-up to #3717 covering the P2 findings of the HTTP/2 review, most of the P3s, and the testing gaps it exposed.

Protocol and connection level (all h2 workers):
- a bad request resets its own stream instead of the connection; request line and field limits and the method token rule apply; forbidden trailers are dropped
- `Expect: 100-continue` is answered before the body is pulled
- `RST_STREAM` floods close the connection with `ENHANCE_YOUR_CALM`
- outbound frames respect the peer's `SETTINGS_MAX_FRAME_SIZE`
- `HTTP2-Settings` is validated before the h2c `101`; oversized upgrade bodies are not upgraded
- `http2_initial_window_size` and `http2_max_concurrent_streams` are bounded at startup, `http2_max_header_list_size = 0` means unlimited, `h3` is rejected, `h2` without the h2 package is a `ConfigError`
- h2 raising `KeyError`/`StreamIDTooLowError` for a stream it already dropped is handled

gthread and gevent:
- the h2c-upgraded stream is served and cleaned up like any other; requests queued behind a body read are served before the `max_requests` GOAWAY, which names the last stream served
- peer protocol errors are logged at debug; gevent gets the early hints and trailers environ entries; responses carry `Server` and `Date`

ASGI:
- `send()` raises an `OSError` once the peer is gone (ASGI 2.4) instead of pretending to succeed
- trailers announced on `http.response.start` are sent after the body (`more_trailers` supported)
- no-body statuses drop framing headers; the body wait is bounded by `timeout`; write backpressure reaches `writer.drain()`; an idle connection closes after `keepalive`; oversized h2c upgrade bodies close the connection

Testing:
- `tests/test_http2_live.py`: spawns gunicorn over h2c prior knowledge per worker and drives raw frames (resets, stalls, floods, GOAWAY mid-request), asserting on the wire and on a clean worker log. It found the two h2 exception gaps above.
- the `asgi_compliance` TLS service now speaks HTTP/2, so `TestHTTP2DirectToGunicorn` exercises gunicorn's own ASGI h2 path (the nginx tests only reach it over HTTP/1.1).
- docs: guide corrections, changelog, regenerated settings reference.

Verified: unit suite on 3.14 (2546 passed) and 3.10 (2299 passed); docker `h2spec` 3/3, `http2` 35/35, `asgi_compliance` green; lint clean.
