### PR TITLE
Prefer an absolute-form request-target's own authority over Host

### DIFF
--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -588,7 +588,13 @@ class Request(Message):
         self.path = parts.path or ""
         self.query = parts.query or ""
         self.fragment = parts.fragment or ""
-        self.authority = parts.netloc or None
+        # parts.scheme is only set for a genuine absolute-form request-target
+        # (e.g. "http://host/path"), never for origin-form, even one whose
+        # path or query happens to contain "://". An absolute-form target can
+        # still have an empty authority ("https://" with nothing after it),
+        # which is distinct from not being absolute-form at all, hence the
+        # separate None below rather than folding both into one falsy check.
+        self.authority = parts.netloc if parts.scheme else None
 
         # Version (validation done by C parser)
         self.version = (1, result['minor_version'])
@@ -924,9 +930,13 @@ class Request(Message):
         self.path = parts.path or ""
         self.query = parts.query or ""
         self.fragment = parts.fragment or ""
-        # populated only for absolute-form request-targets (parts.netloc is
-        # empty for origin-form, asterisk-form and CONNECT's authority-form)
-        self.authority = parts.netloc or None
+        # parts.scheme is only set for a genuine absolute-form request-target;
+        # it stays empty for origin-form, asterisk-form and CONNECT's
+        # authority-form. An absolute-form target can still have an empty
+        # authority ("https://" with nothing after it), so that case needs to
+        # stay distinguishable from "not absolute-form at all" rather than
+        # collapsing both into None on an empty-string check.
+        self.authority = parts.netloc if parts.scheme else None
 
         # Version
         match = VERSION_RE.fullmatch(bits[2])

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -482,6 +482,7 @@ class Request(Message):
         self.path = None
         self.query = None
         self.fragment = None
+        self.authority = None
 
         # get max request line size (0 means unlimited per documentation)
         self.limit_request_line = cfg.limit_request_line
@@ -587,6 +588,7 @@ class Request(Message):
         self.path = parts.path or ""
         self.query = parts.query or ""
         self.fragment = parts.fragment or ""
+        self.authority = parts.netloc or None
 
         # Version (validation done by C parser)
         self.version = (1, result['minor_version'])
@@ -922,6 +924,9 @@ class Request(Message):
         self.path = parts.path or ""
         self.query = parts.query or ""
         self.fragment = parts.fragment or ""
+        # populated only for absolute-form request-targets (parts.netloc is
+        # empty for origin-form, asterisk-form and CONNECT's authority-form)
+        self.authority = parts.netloc or None
 
         # Version
         match = VERSION_RE.fullmatch(bits[2])

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -231,13 +231,20 @@ def create(req, sock, client, server, cfg, response_class=None,
 
     # rfc9112 3.2.2: an absolute-form request-target carries its own
     # authority, and a server receiving one MUST ignore any Host header the
-    # client also sent and use that authority instead. HTTP/2 has no such
-    # concept on the wire (its :authority pseudo-header already becomes the
-    # Host header above), so only HTTP/1's Request defines this attribute.
+    # client also sent and use that authority instead, even when the
+    # request-target's own authority is empty ("GET https:// HTTP/1.1" is
+    # supposed to result in an empty Host, not a fallback to whatever the
+    # client's Host header said). HTTP/2 has no such concept on the wire
+    # (its :authority pseudo-header already becomes the Host header above),
+    # so only HTTP/1's Request defines this attribute, and it's None rather
+    # than empty for anything that isn't actually absolute-form.
     authority = getattr(req, 'authority', None)
-    if authority:
-        host = authority
-        environ['HTTP_HOST'] = authority
+    if authority is not None:
+        # the authority component can carry userinfo ("user:pass@host"),
+        # which has no place in a Host value — rpartition just returns the
+        # string unchanged when there's no "@" to split on.
+        host = authority.rpartition('@')[2]
+        environ['HTTP_HOST'] = host
 
     # set the url scheme
     environ['wsgi.url_scheme'] = req.scheme

--- a/gunicorn/http/wsgi.py
+++ b/gunicorn/http/wsgi.py
@@ -229,6 +229,16 @@ def create(req, sock, client, server, cfg, response_class=None,
             hdr_value = "%s,%s" % (environ[key], hdr_value)
         environ[key] = hdr_value
 
+    # rfc9112 3.2.2: an absolute-form request-target carries its own
+    # authority, and a server receiving one MUST ignore any Host header the
+    # client also sent and use that authority instead. HTTP/2 has no such
+    # concept on the wire (its :authority pseudo-header already becomes the
+    # Host header above), so only HTTP/1's Request defines this attribute.
+    authority = getattr(req, 'authority', None)
+    if authority:
+        host = authority
+        environ['HTTP_HOST'] = authority
+
     # set the url scheme
     environ['wsgi.url_scheme'] = req.scheme
 

--- a/tests/test_absolute_form_host.py
+++ b/tests/test_absolute_form_host.py
@@ -46,3 +46,44 @@ def test_origin_form_still_uses_host_header(http_parser):
     assert req.authority is None
     environ = _environ_for(req, cfg)
     assert environ['HTTP_HOST'] == 'victim.com'
+
+
+def test_origin_form_query_string_containing_scheme_is_not_mistaken_for_absolute_form(http_parser):
+    # A path like this has "://" sitting right there in the query string,
+    # but it's still origin-form (it starts with "/"), so it must not be
+    # treated as if it carried its own authority.
+    raw = (b"GET /redirect?url=http://evil.com HTTP/1.1\r\n"
+           b"Host: victim.com\r\n"
+           b"\r\n")
+    req, cfg = _parse(raw, http_parser)
+    assert req.authority is None
+    environ = _environ_for(req, cfg)
+    assert environ['HTTP_HOST'] == 'victim.com'
+
+
+def test_absolute_form_with_empty_authority_sends_empty_host(http_parser):
+    # rfc9112 3.2.2 again: "if the request-target does not have an
+    # authority component, an empty Host header field will be sent in
+    # this case." Falling back to the client's Host header here would be
+    # exactly the bug this whole PR is about, just with an edge case
+    # authority instead of a missing one.
+    raw = (b"GET https:// HTTP/1.1\r\n"
+           b"Host: victim.com\r\n"
+           b"\r\n")
+    req, cfg = _parse(raw, http_parser)
+    assert req.authority == ''
+    environ = _environ_for(req, cfg)
+    assert environ['HTTP_HOST'] == ''
+
+
+def test_absolute_form_authority_strips_userinfo_before_becoming_host(http_parser):
+    # netloc includes userinfo when present, but Host has no such thing,
+    # so "user:pass@host:8080" needs to become "host:8080", not get
+    # copied into HTTP_HOST verbatim.
+    raw = (b"GET http://user:pass@host.example:8080/p HTTP/1.1\r\n"
+           b"Host: victim.com\r\n"
+           b"\r\n")
+    req, cfg = _parse(raw, http_parser)
+    assert req.authority == 'user:pass@host.example:8080'
+    environ = _environ_for(req, cfg)
+    assert environ['HTTP_HOST'] == 'host.example:8080'

--- a/tests/test_absolute_form_host.py
+++ b/tests/test_absolute_form_host.py
@@ -1,0 +1,48 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+from unittest import mock
+
+from gunicorn.config import Config
+from gunicorn.http.message import Request
+from gunicorn.http.unreader import IterUnreader
+from gunicorn.http.wsgi import create
+
+
+def _parse(raw, http_parser):
+    cfg = Config()
+    cfg.set('http_parser', http_parser)
+    unreader = IterUnreader([raw])
+    return Request(cfg, unreader, ('203.0.113.5', 51000)), cfg
+
+
+def _environ_for(req, cfg):
+    sock = mock.Mock()
+    sock.getsockname.return_value = ('127.0.0.1', 8000)
+    _, environ = create(req, sock, ('203.0.113.5', 51000), ('127.0.0.1', 8000), cfg)
+    return environ
+
+
+def test_absolute_form_authority_overrides_mismatched_host(http_parser):
+    # rfc9112 3.2.2: the origin server MUST ignore a Host header that
+    # disagrees with an absolute-form request-target's own authority.
+    raw = (b"GET http://evil.com/page HTTP/1.1\r\n"
+           b"Host: victim.com\r\n"
+           b"\r\n")
+    req, cfg = _parse(raw, http_parser)
+    assert req.authority == 'evil.com'
+    environ = _environ_for(req, cfg)
+    assert environ['HTTP_HOST'] == 'evil.com'
+
+
+def test_origin_form_still_uses_host_header(http_parser):
+    # An ordinary request (the overwhelming majority of traffic) has no
+    # authority of its own, so nothing here should change its behavior.
+    raw = (b"GET /page HTTP/1.1\r\n"
+           b"Host: victim.com\r\n"
+           b"\r\n")
+    req, cfg = _parse(raw, http_parser)
+    assert req.authority is None
+    environ = _environ_for(req, cfg)
+    assert environ['HTTP_HOST'] == 'victim.com'

--- a/tests/test_http2_request.py
+++ b/tests/test_http2_request.py
@@ -734,6 +734,7 @@ class TestHTTP2RequestWSGIEnviron:
         mock_req._expected_100_continue = False
         mock_req.proxy_protocol_info = None
         mock_req.body = mock.Mock()
+        mock_req.authority = None
 
         # Remove priority attributes to simulate HTTP/1 request
         del mock_req.priority_weight


### PR DESCRIPTION
Closes #3370.

When a request comes in as `GET http://evil.com/page HTTP/1.1` with a `Host: victim.com` header attached, RFC 9112 3.2.2 is pretty explicit that the origin server has to ignore the Host header entirely and go with the authority already sitting in the request-target. Gunicorn does parse that authority out (`split_request_uri` gives it back as `.netloc`), but nothing ever kept it around, so it just silently used the Host header instead in every case. That's exactly the mismatch reported in the issue: a proxy that forwards the absolute-form request-target as-is (which is legitimate, some do) ends up with the app seeing whatever Host value the client felt like sending, not the address that was actually requested.

Both request-line parsers (the Python one and the C-accelerated one) now hang onto that authority on the `Request` object as `.authority`, which stays `None` for every request-target form except absolute-form. `wsgi.create()` checks it after building the headers and, when it's set, uses it for `HTTP_HOST` and the local `host` variable instead of whatever came in on the Host header. HTTP/2 requests don't have this attribute at all (they have their own `:authority` pseudo-header story already handled separately), so that path is untouched.

Added `tests/test_absolute_form_host.py` with the exact mismatched-host scenario from the issue plus a control case confirming ordinary origin-form requests (the vast majority of traffic) still behave exactly as before. Ran it against both parser backends, along with the rest of the request-parsing and WSGI-environ suites, and pylint/pycodestyle on the touched files.