### PR TITLE
Ignore a pidfile whose PID belongs to another process

### DIFF
--- a/docs/content/news.md
+++ b/docs/content/news.md
@@ -9,6 +9,9 @@
   started, because `sys.exit()` from the abort handler is a `BaseException`.
   Once headers are out we just close the connection.
   ([#3410](https://github.com/benoitc/gunicorn/issues/3410)).
+- A pidfile left behind after a crash no longer blocks restart when that PID
+  has been reused by an unrelated process
+  ([#3383](https://github.com/benoitc/gunicorn/issues/3383)).
 
 ## 26.2.0 - 2026-08-24
 

--- a/gunicorn/pidfile.py
+++ b/gunicorn/pidfile.py
@@ -111,11 +111,9 @@ class Pidfile:
                     if e.args[0] == errno.ESRCH:
                         return
                     raise
-                if not _is_gunicorn_process(wpid):
-                    # PID was reused by an unrelated process after a crash
-                    # left the pidfile behind (#3383).
-                    return
-                return wpid
+                # PID was reused by an unrelated process after a crash
+                # left the pidfile behind (#3383).
+                return wpid if _is_gunicorn_process(wpid) else None
         except OSError as e:
             if e.args[0] == errno.ENOENT:
                 return

--- a/gunicorn/pidfile.py
+++ b/gunicorn/pidfile.py
@@ -4,7 +4,38 @@
 
 import errno
 import os
+import subprocess
 import tempfile
+
+
+def _read_process_cmdline(pid):
+    """Return the process command line, or None if it cannot be inspected."""
+    proc_path = "/proc/%s/cmdline" % pid
+    try:
+        fd = os.open(proc_path, os.O_RDONLY)
+        try:
+            raw = os.read(fd, 4096)
+        finally:
+            os.close(fd)
+        return raw.replace(b"\x00", b" ").decode("utf-8", "replace")
+    except OSError:
+        pass
+    try:
+        out = subprocess.check_output(
+            ["ps", "-p", str(pid), "-o", "args="],
+            stderr=subprocess.DEVNULL,
+        )
+        return out.decode("utf-8", "replace")
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _is_gunicorn_process(pid):
+    """True if pid looks like gunicorn, or we cannot tell."""
+    cmdline = _read_process_cmdline(pid)
+    if cmdline is None:
+        return True
+    return "gunicorn" in cmdline.lower()
 
 
 class Pidfile:
@@ -74,13 +105,17 @@ class Pidfile:
 
                 try:
                     os.kill(wpid, 0)
-                    return wpid
                 except OSError as e:
                     if e.args[0] == errno.EPERM:
                         return wpid
                     if e.args[0] == errno.ESRCH:
                         return
                     raise
+                if not _is_gunicorn_process(wpid):
+                    # PID was reused by an unrelated process after a crash
+                    # left the pidfile behind (#3383).
+                    return
+                return wpid
         except OSError as e:
             if e.args[0] == errno.ENOENT:
                 return

--- a/tests/test_pidfile.py
+++ b/tests/test_pidfile.py
@@ -19,9 +19,10 @@ def test_validate_no_file(_open):
     assert pidfile.validate() is None
 
 
+@mock.patch('gunicorn.pidfile._is_gunicorn_process', return_value=True)
 @mock.patch(builtin('open'), new_callable=mock.mock_open, read_data='1')
 @mock.patch('os.kill')
-def test_validate_file_pid_exists(kill, _open):
+def test_validate_file_pid_exists(kill, _open, _is_gunicorn):
     pidfile = gunicorn.pidfile.Pidfile('test.pid')
     assert pidfile.validate() == 1
     assert kill.called
@@ -33,9 +34,10 @@ def test_validate_file_pid_malformed(_open):
     assert pidfile.validate() is None
 
 
+@mock.patch('gunicorn.pidfile._is_gunicorn_process', return_value=True)
 @mock.patch(builtin('open'), new_callable=mock.mock_open, read_data='1')
 @mock.patch('os.kill')
-def test_validate_file_pid_exists_kill_exception(kill, _open):
+def test_validate_file_pid_exists_kill_exception(kill, _open, _is_gunicorn):
     pidfile = gunicorn.pidfile.Pidfile('test.pid')
     kill.side_effect = OSError(errno.EPERM)
     assert pidfile.validate() == 1
@@ -47,3 +49,26 @@ def test_validate_file_pid_does_not_exist(kill, _open):
     pidfile = gunicorn.pidfile.Pidfile('test.pid')
     kill.side_effect = OSError(errno.ESRCH)
     assert pidfile.validate() is None
+
+
+@mock.patch('gunicorn.pidfile._is_gunicorn_process', return_value=False)
+@mock.patch(builtin('open'), new_callable=mock.mock_open, read_data='1')
+@mock.patch('os.kill')
+def test_validate_file_pid_reused_by_other_process(kill, _open, _is_gunicorn):
+    pidfile = gunicorn.pidfile.Pidfile('test.pid')
+    assert pidfile.validate() is None
+
+
+def test_is_gunicorn_process_from_cmdline():
+    with mock.patch(
+        'gunicorn.pidfile._read_process_cmdline',
+        return_value='/usr/bin/python -m gunicorn myapp:app',
+    ):
+        assert gunicorn.pidfile._is_gunicorn_process(42) is True
+    with mock.patch(
+        'gunicorn.pidfile._read_process_cmdline',
+        return_value='/usr/sbin/sshd',
+    ):
+        assert gunicorn.pidfile._is_gunicorn_process(42) is False
+    with mock.patch('gunicorn.pidfile._read_process_cmdline', return_value=None):
+        assert gunicorn.pidfile._is_gunicorn_process(42) is True


### PR DESCRIPTION
## Summary
After `kill -9` or a host crash, the pidfile can still contain a PID that a later unrelated process reused. `os.kill(pid, 0)` then succeeds and gunicorn refuses to start.

If the process exists, read its command line (`/proc/<pid>/cmdline`, then `ps`). If it is not gunicorn, treat the pidfile as stale and continue.

When the command line cannot be inspected, behavior is unchanged.

## Test plan
- [x] `tests/test_pidfile.py` (7 passed)

Fixes #3383