### PR TITLE
fix: announce Connection: close from the ASGI worker

### DIFF
--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -1,6 +1,18 @@
 <span id="news-2026"></span>
 # Changelog - 2026
 
+## Unreleased
+
+### Bug Fixes
+
+- **ASGI worker closed HTTP/1.1 connections without saying so**: when the
+  worker would not reuse a connection (the client sent `Connection: close`,
+  keepalive is disabled, the worker is shutting down, or the response trips
+  `max_requests`) it closed the socket without a `Connection: close` header, so
+  a client treated the response as persistent and reused a socket the server
+  had already closed. The header is now sent whenever the connection will close
+  ([#3726](https://github.com/benoitc/gunicorn/pull/3726)).
+
 ## 26.2.1 - 2026-09-05
 
 ### Bug Fixes

--- a/docs/content/news.md
+++ b/docs/content/news.md
@@ -1,6 +1,18 @@
 <span id="news"></span>
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- **ASGI worker closed HTTP/1.1 connections without saying so**: when the
+  worker would not reuse a connection (the client sent `Connection: close`,
+  keepalive is disabled, the worker is shutting down, or the response trips
+  `max_requests`) it closed the socket without a `Connection: close` header, so
+  a client treated the response as persistent and reused a socket the server
+  had already closed. The header is now sent whenever the connection will close
+  ([#3726](https://github.com/benoitc/gunicorn/pull/3726)).
+
 ## 26.2.1 - 2026-09-05
 
 ### Bug Fixes

--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -1308,7 +1308,10 @@ class ASGIProtocol(asyncio.Protocol):
                     uses_uwsgi and not has_content_length and not omits_body
                 )
 
-                self._send_response_start(response_status, response_headers, request)
+                self._send_response_start(
+                    response_status, response_headers, request,
+                    close=self._will_close(request, response_requires_close),
+                )
 
             elif msg_type == "http.response.body":
                 if not response_started:
@@ -1411,13 +1414,33 @@ class ASGIProtocol(asyncio.Protocol):
                 self.log.exception("Exception in post_request hook")
 
         # Determine keepalive
+        return not self._will_close(request, response_requires_close)
+
+    def _will_close(self, request, response_requires_close):
+        """Return True when the connection is closed after this response.
+
+        Single source of truth for the keepalive decision: ``send`` consults it
+        to emit ``Connection: close`` and ``_handle_http_request`` returns its
+        inverse, so the framing announced matches the framing used. Covers every
+        close reason knowable when the response headers are written.
+        """
         if response_requires_close:
-            return False
+            return True
 
         if request.should_close():
-            return False
+            return True
 
-        return self.worker.alive and self.cfg.keepalive
+        if not (self.worker.alive and self.cfg.keepalive):
+            return True
+
+        # This response trips max_requests recycling; the loop closes the
+        # connection right after it (nr is incremented once this request
+        # returns). max_requests is sys.maxsize when disabled, so this is inert
+        # unless the limit is set.
+        if self.worker.nr + 1 >= self.worker.max_requests:
+            return True
+
+        return False
 
     def _build_http_scope(self, request, sockname, peername):
         """Build ASGI HTTP scope from parsed request."""
@@ -1548,11 +1571,14 @@ class ASGIProtocol(asyncio.Protocol):
         response += "\r\n"
         self._safe_write(response.encode("latin-1"))
 
-    def _send_response_start(self, status, headers, request):
+    def _send_response_start(self, status, headers, request, close=False):
         """Send HTTP response status and headers.
 
         Uses cached status lines and headers for common cases to avoid
         repeated string formatting and encoding.
+
+        ``close`` announces that the connection ends after this response, as
+        RFC 9112 requires of a server that will not reuse it.
         """
         # Get cached status line bytes
         reason = self._get_reason_phrase(status)
@@ -1563,6 +1589,7 @@ class ASGIProtocol(asyncio.Protocol):
 
         has_date = False
         has_server = False
+        has_connection = False
 
         for name, value in headers:
             if isinstance(name, bytes):
@@ -1581,17 +1608,21 @@ class ASGIProtocol(asyncio.Protocol):
 
             parts.append(b"\r\n")
 
-            # Track if Date/Server headers are present
+            # Track if Date/Server/Connection headers are present
             if name_lower == b"date":
                 has_date = True
             elif name_lower == b"server":
                 has_server = True
+            elif name_lower == b"connection":
+                has_connection = True
 
         # Add default headers if not present
         if not has_server:
             parts.append(_CACHED_SERVER_HEADER)
         if not has_date:
             parts.append(_get_cached_date_header())
+        if close and not has_connection:
+            parts.append(b"Connection: close\r\n")
 
         parts.append(b"\r\n")
 

--- a/tests/test_asgi_connection_close.py
+++ b/tests/test_asgi_connection_close.py
@@ -1,0 +1,116 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+"""The ASGI worker announces Connection: close, against a live gunicorn.
+
+RFC 9112: a server that will not reuse a connection must say so. Spawns the
+ASGI worker over plain HTTP/1.1 and checks, on the wire, that the header is
+present exactly when the connection is closed and absent when it is kept alive.
+"""
+
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+APPS = Path(__file__).parent / "support"
+
+
+def _free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class Server:
+    def __init__(self, tmp_path, extra_args=()):
+        self.port = _free_port()
+        self.log = tmp_path / f"gunicorn-close-{self.port}.log"
+        self.proc = subprocess.Popen(
+            [sys.executable, "-m", "gunicorn", "http2_live_app:asgi",
+             "--bind", f"127.0.0.1:{self.port}", "--workers", "1",
+             "--worker-class", "asgi", "--graceful-timeout", "2",
+             "--log-level", "info", *extra_args],
+            cwd=str(APPS), stdout=self.log.open("w"), stderr=subprocess.STDOUT)
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            try:
+                with socket.create_connection(("127.0.0.1", self.port), 0.3):
+                    return
+            except OSError:
+                if self.proc.poll() is not None:
+                    break
+                time.sleep(0.05)
+        self.stop()
+        raise RuntimeError(f"gunicorn did not start:\n{self.log.read_text()}")
+
+    def stop(self):
+        if self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(5)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait()
+
+
+def _request(port, headers=""):
+    """Send one request and return the raw response bytes."""
+    sock = socket.create_connection(("127.0.0.1", port), 5)
+    sock.settimeout(5)
+    sock.sendall(f"GET / HTTP/1.1\r\nHost: localhost\r\n{headers}\r\n".encode())
+    data = b""
+    try:
+        while b"\r\n\r\n" not in data or b"0\r\n\r\n" not in data:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+    except socket.timeout:
+        pass
+    sock.close()
+    return data
+
+
+def test_client_connection_close_is_announced(tmp_path):
+    srv = Server(tmp_path)
+    try:
+        resp = _request(srv.port, "Connection: close\r\n")
+        assert resp.startswith(b"HTTP/1.1 200"), resp
+        assert b"\r\nConnection: close\r\n" in resp, resp
+    finally:
+        srv.stop()
+
+
+def test_keepalive_disabled_is_announced(tmp_path):
+    srv = Server(tmp_path, ["--keep-alive", "0"])
+    try:
+        resp = _request(srv.port)
+        assert resp.startswith(b"HTTP/1.1 200"), resp
+        assert b"\r\nConnection: close\r\n" in resp, resp
+    finally:
+        srv.stop()
+
+
+def test_max_requests_recycle_is_announced(tmp_path):
+    srv = Server(tmp_path, ["--max-requests", "1"])
+    try:
+        resp = _request(srv.port)
+        assert resp.startswith(b"HTTP/1.1 200"), resp
+        assert b"\r\nConnection: close\r\n" in resp, resp
+    finally:
+        srv.stop()
+
+
+def test_default_keepalive_is_not_announced(tmp_path):
+    srv = Server(tmp_path)
+    try:
+        resp = _request(srv.port)
+        assert resp.startswith(b"HTTP/1.1 200"), resp
+        assert b"connection: close" not in resp.lower(), resp
+    finally:
+        srv.stop()

--- a/tests/test_asgi_worker.py
+++ b/tests/test_asgi_worker.py
@@ -13,6 +13,7 @@ import asyncio
 import errno
 import os
 import socket
+import sys
 from unittest import mock
 
 import pytest
@@ -547,6 +548,79 @@ class TestASGIProtocol:
         assert protocol._get_reason_phrase(404) == "Not Found"
         assert protocol._get_reason_phrase(500) == "Internal Server Error"
         assert protocol._get_reason_phrase(999) == "Unknown"
+
+    @pytest.mark.parametrize(
+        "requires_close,req_close,alive,keepalive,nr,max_requests,expected",
+        [
+            (False, False, True, 2, 0, 1000, False),          # reusable
+            (True, False, True, 2, 0, 1000, True),            # framing forbids reuse
+            (False, True, True, 2, 0, 1000, True),            # client Connection: close
+            (False, False, False, 2, 0, 1000, True),          # worker shutting down
+            (False, False, True, 0, 0, 1000, True),           # keepalive disabled
+            (False, False, True, 2, 0, 1, True),              # this response trips max_requests
+            (False, False, True, 2, 0, 5, False),             # still below max_requests
+            (False, False, True, 2, 100, sys.maxsize, False),  # max_requests disabled
+        ],
+    )
+    def test_will_close_matches_keepalive_decision(
+        self, requires_close, req_close, alive, keepalive, nr, max_requests, expected
+    ):
+        """_will_close is the inverse of the keepalive decision, case for case."""
+        from gunicorn.asgi.protocol import ASGIProtocol
+
+        worker = mock.Mock()
+        worker.cfg = Config()
+        worker.cfg.set("keepalive", keepalive)
+        worker.alive = alive
+        worker.nr = nr
+        worker.max_requests = max_requests
+        worker.log = mock.Mock()
+        worker.asgi = mock.Mock()
+
+        protocol = ASGIProtocol(worker)
+        request = mock.Mock()
+        request.should_close.return_value = req_close
+
+        assert protocol._will_close(request, requires_close) is expected
+
+    @pytest.mark.parametrize("close", [True, False])
+    def test_response_start_announces_connection_close(self, close):
+        """RFC 9112: a server that will close the connection must say so."""
+        from gunicorn.asgi.protocol import ASGIProtocol
+
+        worker = mock.Mock()
+        worker.cfg = Config()
+        worker.log = mock.Mock()
+        worker.asgi = mock.Mock()
+
+        protocol = ASGIProtocol(worker)
+        request = mock.Mock()
+        request.version = (1, 1)
+
+        protocol._send_response_start(
+            200, [(b"content-type", b"text/plain")], request, close=close
+        )
+
+        assert (b"Connection: close\r\n" in protocol._response_buffer) is close
+
+    def test_response_start_keeps_app_connection_header(self):
+        """An app-supplied Connection header is not duplicated."""
+        from gunicorn.asgi.protocol import ASGIProtocol
+
+        worker = mock.Mock()
+        worker.cfg = Config()
+        worker.log = mock.Mock()
+        worker.asgi = mock.Mock()
+
+        protocol = ASGIProtocol(worker)
+        request = mock.Mock()
+        request.version = (1, 1)
+
+        protocol._send_response_start(
+            200, [(b"connection", b"close")], request, close=True
+        )
+
+        assert protocol._response_buffer.lower().count(b"connection:") == 1
 
     def test_scope_building(self):
         """Test HTTP scope building."""


### PR DESCRIPTION
When the ASGI worker will not reuse an HTTP/1.1 connection it closed the socket without a `Connection: close` header, so a client treated the response as persistent (RFC 9112) and reused a socket the server had already closed. A single predicate now decides the keepalive outcome and the response announces `Connection: close` whenever the connection will close: the client asked, keepalive is disabled, the worker is shutting down, or the response trips `max_requests` recycling. An app-supplied `Connection` header is left alone; HTTP/2 and error responses are unaffected.

Supersedes #3726 by @dylanpulver, which introduced the shared-predicate approach; this adds the `max_requests` case, decided after the response starts in the loop, so it is anticipated when the header is written.