### PR TITLE
Clarify worker heartbeat timeout documentation

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -161,6 +161,7 @@ Randall Leeds <randall@meebo-inc.com>
 Raphaël Slinckx <rslinckx@gmail.com>
 Rhys Powell <rhys@rhyspowell.com>
 Rik <rvachterberg@gmail.com>
+Rolando Bosch <rbosch@lpci.ai>
 Ronan Amicel <ronan.amicel@gmail.com>
 Ryan Peck <ryan@rypeck.com>
 Ryuichi Watanabe <ryucrosskey@gmail.com>

--- a/docs/content/reference/settings.md
+++ b/docs/content/reference/settings.md
@@ -1933,6 +1933,9 @@ restarts to avoid all workers restarting at the same time.
 **Default:** `30`
 
 Workers silent for more than this many seconds are killed and restarted.
+The master checks each worker's heartbeat file; a worker that does not
+update it within this timeout is considered silent. Idle workers keep
+updating their heartbeat while waiting for requests.
 
 Value is a positive number or 0. Setting it to 0 has the effect of
 infinite timeouts by disabling timeouts for all workers entirely.

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -897,6 +897,9 @@ class Timeout(Setting):
     default = 30
     desc = """\
         Workers silent for more than this many seconds are killed and restarted.
+        The master checks each worker's heartbeat file; a worker that does not
+        update it within this timeout is considered silent. Idle workers keep
+        updating their heartbeat while waiting for requests.
 
         Value is a positive number or 0. Setting it to 0 has the effect of
         infinite timeouts by disabling timeouts for all workers entirely.


### PR DESCRIPTION
The `timeout` description says that silent workers are restarted, but does not explain what “silent” means. Clarify that the master checks the worker's heartbeat file and that a worker may remain idle without receiving a request during that interval.

Refs #3129. This changes the setting's documentation only, preserving its existing sync, non-sync, and HTTP/2 guidance. Adds the contributor credit requested by CONTRIBUTING.md.

Validation: strict `mkdocs build` and 55 configuration tests passed on the final change. The full suite passed before the final wording/generated-page update: 2,569 passed, 44 skipped (two warnings). Prepared with Codex assistance and reviewed with Claude plus an independent Codex review.

<!-- hermes-labs:attribution v1 -->
<!-- hermes-labs:selection autonomous -->
This contribution was autonomously selected and produced by agents through [Hermes Labs](https://hermes-labs.ai)’ engineering infrastructure. [Rolando Bosch](https://github.com/roli-lpci) is the responsible human contributor and authorized publication from his personal GitHub account.
<!-- /hermes-labs:attribution -->