### PR TITLE
fix: enforce the keepalive timeout on the ASGI worker

### DIFF
--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -13,6 +13,13 @@
   had already closed. The header is now sent whenever the connection will close
   ([#3726](https://github.com/benoitc/gunicorn/pull/3726)).
 
+- **ASGI worker never enforced `keepalive`**: a kept-alive HTTP/1.1 connection
+  that went idle was never closed by the server, whatever the `keepalive`
+  setting, so idle connections only went away when the client closed them and
+  could pile up on a worker. They are now closed after `keepalive` seconds, as
+  with the other workers
+  ([#3734](https://github.com/benoitc/gunicorn/discussions/3734)).
+
 ## 26.2.1 - 2026-09-05
 
 ### Bug Fixes

--- a/docs/content/news.md
+++ b/docs/content/news.md
@@ -13,6 +13,13 @@
   had already closed. The header is now sent whenever the connection will close
   ([#3726](https://github.com/benoitc/gunicorn/pull/3726)).
 
+- **ASGI worker never enforced `keepalive`**: a kept-alive HTTP/1.1 connection
+  that went idle was never closed by the server, whatever the `keepalive`
+  setting, so idle connections only went away when the client closed them and
+  could pile up on a worker. They are now closed after `keepalive` seconds, as
+  with the other workers
+  ([#3734](https://github.com/benoitc/gunicorn/discussions/3734)).
+
 ## 26.2.1 - 2026-09-05
 
 ### Bug Fixes

--- a/gunicorn/asgi/protocol.py
+++ b/gunicorn/asgi/protocol.py
@@ -859,6 +859,9 @@ class ASGIProtocol(asyncio.Protocol):
     def _keepalive_timeout(self):
         """Called when keepalive timeout expires."""
         self._close_transport()
+        # Wake _handle_connection up so it sees _closed and exits instead of
+        # waiting for the cancellation scheduled by connection_lost.
+        self._request_ready.set()
 
     def connection_lost(self, exc):
         """Called when the connection is lost or closed.
@@ -987,15 +990,19 @@ class ASGIProtocol(asyncio.Protocol):
 
             while not self._closed:
                 self.req_count += 1
-                self._cancel_keepalive_timer()
 
                 # Wait for headers to be parsed (callback sets the event and _current_request)
                 # Don't clear if request already arrived (data_received ran before us)
                 if not self._request_ready.is_set():
+                    # Arm the keepalive timer while we wait for the next
+                    # request to become available.
+                    if self.req_count > 1:
+                        self._arm_keepalive_timer()
                     try:
                         await self._request_ready.wait()
                     except asyncio.CancelledError:
                         break
+                self._cancel_keepalive_timer()
 
                 if self._closed or self._current_request is None:
                     break
@@ -1072,11 +1079,6 @@ class ASGIProtocol(asyncio.Protocol):
                 if pipelined:
                     if not self._feed_callback_parser(pipelined):
                         break
-
-                # Arm the idle keepalive timer only when nothing is ready yet;
-                # a fully pipelined request is processed on the next iteration.
-                if not self._request_ready.is_set():
-                    self._arm_keepalive_timer()
 
         except asyncio.CancelledError:
             pass

--- a/tests/test_asgi_keepalive_timeout.py
+++ b/tests/test_asgi_keepalive_timeout.py
@@ -1,0 +1,116 @@
+#
+# This file is part of gunicorn released under the MIT license.
+# See the NOTICE for more information.
+
+"""Keepalive timeout on the ASGI worker, against a live gunicorn.
+
+Regression for the bug where the ASGI worker never enforced ``keepalive``: the
+timer was armed at the end of one iteration of the connection loop and cancelled
+at the start of the next one without ever suspending in between, so an idle
+kept-alive connection stayed open until the client closed it.
+"""
+
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+APPS = Path(__file__).parent / "support"
+
+REQ = b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+KEEPALIVE = 1
+
+
+def _free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class Server:
+    def __init__(self, tmp_path):
+        self.port = _free_port()
+        self.log = tmp_path / f"gunicorn-keepalive-{self.port}.log"
+        self.proc = subprocess.Popen(
+            [sys.executable, "-m", "gunicorn", "http2_live_app:asgi",
+             "--bind", f"127.0.0.1:{self.port}", "--workers", "1",
+             "--worker-class", "asgi",
+             "--keep-alive", str(KEEPALIVE), "--graceful-timeout", "2",
+             "--log-level", "info"],
+            cwd=str(APPS), stdout=self.log.open("w"), stderr=subprocess.STDOUT)
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            try:
+                with socket.create_connection(("127.0.0.1", self.port), 0.3):
+                    return
+            except OSError:
+                if self.proc.poll() is not None:
+                    break
+                time.sleep(0.05)
+        self.stop()
+        raise RuntimeError(f"gunicorn did not start:\n{self.log.read_text()}")
+
+    def stop(self):
+        if self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(5)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait()
+
+
+def _read_response(sock):
+    """Read one complete chunked response and return its raw bytes."""
+    data = b""
+    while b"\r\n\r\n" not in data or b"0\r\n\r\n" not in data:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        data += chunk
+    return data
+
+
+def _wait_for_close(sock, timeout):
+    """Return how long the server took to close the idle connection, or None."""
+    sock.settimeout(timeout)
+    start = time.monotonic()
+    try:
+        data = sock.recv(1)
+    except socket.timeout:
+        return None
+    assert data == b"", f"unexpected data on idle connection: {data!r}"
+    return time.monotonic() - start
+
+
+def test_idle_keepalive_connection_is_closed(tmp_path):
+    srv = Server(tmp_path)
+    try:
+        sock = socket.create_connection(("127.0.0.1", srv.port), 5)
+        sock.settimeout(5)
+        sock.sendall(REQ)
+        assert _read_response(sock).startswith(b"HTTP/1.1 200")
+
+        closed_after = _wait_for_close(sock, KEEPALIVE * 4)
+        sock.close()
+        assert closed_after is not None, "idle connection was not closed by the server"
+        assert closed_after >= KEEPALIVE * 0.5, closed_after
+    finally:
+        srv.stop()
+
+
+def test_request_within_keepalive_window_is_served(tmp_path):
+    srv = Server(tmp_path)
+    try:
+        sock = socket.create_connection(("127.0.0.1", srv.port), 5)
+        sock.settimeout(5)
+        sock.sendall(REQ)
+        assert _read_response(sock).startswith(b"HTTP/1.1 200")
+
+        time.sleep(KEEPALIVE * 0.3)
+        sock.sendall(REQ)
+        assert _read_response(sock).startswith(b"HTTP/1.1 200")
+        sock.close()
+    finally:
+        srv.stop()


### PR DESCRIPTION
The ASGI worker never enforced `keepalive`: the idle timer was armed at the end of one iteration of the connection loop and cancelled at the start of the next one without ever suspending in between, so it never ran while the worker was actually waiting for the next request. A kept-alive HTTP/1.1 connection that went idle stayed open until the client closed it, and nothing bounds how many such connections a worker accumulates except the process file descriptor limit. The timer is now armed right before waiting for the next request and cancelled once one arrives, and the timeout wakes the loop so it exits as soon as the transport is closed. Idle connections are closed after `keepalive` seconds, as with the other workers.

Adds a regression test against a live worker (an idle kept-alive connection is closed after `keepalive`, and a second request within the window is still served; the first one fails on `master`) and a changelog entry.

One point I left open on purpose: a fresh connection that stays silent before its first request is not subject to the timer with this change, which is what `gthread` does today, while `gevent` applies `keepalive` to that first read as well. I don't know which one is the correct behaviour, so there is no test pinning it; happy to drop the condition if you prefer the gevent semantics.

Refs https://github.com/benoitc/gunicorn/discussions/3734
