### PR TITLE
Remove the legacy code which duplicated settings objects (1-line change)

### DIFF
--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -35,7 +35,7 @@ def make_settings(ignore=None):
         setting = s()
         if setting.name in ignore:
             continue
-        settings[setting.name] = setting.copy()
+        settings[setting.name] = setting
     return settings
 
 


### PR DESCRIPTION
According to the git history, it used to be that the KNOWN_SETTINGS would contain the settings objects, and so for different configs to have different objects, copying was necessary. However, through a re-write, this copoy mechanism continued but unnecessarily.