### PR TITLE
gunicorn 26.2.2

### DIFF
--- a/docs/content/2026-news.md
+++ b/docs/content/2026-news.md
@@ -1,7 +1,7 @@
 <span id="news-2026"></span>
 # Changelog - 2026
 
-## Unreleased
+## 26.2.2 - 2026-09-06
 
 ### Bug Fixes
 

--- a/docs/content/news.md
+++ b/docs/content/news.md
@@ -1,7 +1,7 @@
 <span id="news"></span>
 # Changelog
 
-## Unreleased
+## 26.2.2 - 2026-09-06
 
 ### Bug Fixes
 

--- a/gunicorn/__init__.py
+++ b/gunicorn/__init__.py
@@ -2,7 +2,7 @@
 # This file is part of gunicorn released under the MIT license.
 # See the NOTICE for more information.
 
-version_info = (26, 2, 1)
+version_info = (26, 2, 2)
 __version__ = ".".join([str(v) for v in version_info])
 SERVER = "gunicorn"
 SERVER_SOFTWARE = "%s/%s" % (SERVER, __version__)


### PR DESCRIPTION
Release 26.2.2.

Bumps `version_info` to `(26, 2, 2)` and finalizes the changelog. Bug-fix release: the ASGI worker now announces `Connection: close` when it will not reuse the connection (client close, keepalive disabled, worker shutdown, or `max_requests` recycling).