### PR TITLE
docs: fix link from settings to worker types

### DIFF
--- a/docs/content/reference/settings.md
+++ b/docs/content/reference/settings.md
@@ -1845,7 +1845,7 @@ it is not defined, the default is ``1``.
 The type of workers to use.
 
 The default class (``sync``) should handle most "normal" types of
-workloads. You'll want to read :doc:`design` for information on when
+workloads. You'll want to read [worker-types](../design.md#worker-types) for information on when
 you might want to choose one of the other worker classes. Required
 libraries may be installed using setuptools' ``extras_require`` feature.
 

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -784,7 +784,7 @@ class WorkerClass(Setting):
         The type of workers to use.
 
         The default class (``sync``) should handle most "normal" types of
-        workloads. You'll want to read :doc:`design` for information on when
+        workloads. You'll want to read :ref:`worker-types` for information on when
         you might want to choose one of the other worker classes. Required
         libraries may be installed using setuptools' ``extras_require`` feature.
 

--- a/scripts/build_settings_doc.py
+++ b/scripts/build_settings_doc.py
@@ -73,6 +73,7 @@ REF_MAP = {
     "ssl-version": ("reference/settings.md", "ssl_version"),
     "blocking-os-fchmod": ("reference/settings.md", "blocking_os_fchmod"),
     "configuration_file": ("../configure.md", "configuration-file"),
+    "worker-types": ("../design.md", "worker-types"),
 }
 
 REF_PATTERN = re.compile(r":ref:`([^`]+)`")


### PR DESCRIPTION
Fixes a broken link in the [`worker_class` section of the Settings page](https://gunicorn.org/reference/settings/#worker_class):

<img width="356" height="37" alt="image" src="https://github.com/user-attachments/assets/a8890e39-49a5-4077-9f76-d5e83f78951b" />

