### PR TITLE
Fix HTTP request smuggling via unsafe whitespace stripping

### DIFF
--- a/gunicorn/asgi/parser.py
+++ b/gunicorn/asgi/parser.py
@@ -580,11 +580,11 @@ class PythonProtocol:
             if colon == -1:
                 raise InvalidHeader("Missing colon in header")
 
-            name = line[:colon].strip()
+            name = line[:colon]
             if not self._is_valid_token(name):
                 raise InvalidHeaderName(name.decode('latin-1'))
 
-            value = line[colon + 1:].strip()
+            value = line[colon + 1:].strip(b" \t")
             if self._has_invalid_header_chars(value):
                 raise InvalidHeader("Invalid characters in header value")
 
@@ -638,7 +638,7 @@ class PythonProtocol:
             elif name == b'transfer-encoding':
                 # Properly parse comma-separated Transfer-Encoding values
                 # per RFC 9112 Section 6.1
-                vals = [v.strip() for v in value.split(b',')]
+                vals = [v.strip(b" \t") for v in value.split(b',')]
                 for val in vals:
                     val_lower = val.lower()
                     if val_lower == b'chunked':

--- a/gunicorn/http/message.py
+++ b/gunicorn/http/message.py
@@ -413,7 +413,7 @@ class Message(HeaderPolicy):
             elif name == "TRANSFER-ENCODING":
                 # T-E can be a list
                 # https://datatracker.ietf.org/doc/html/rfc9112#name-transfer-encoding
-                vals = [v.strip() for v in value.split(',')]
+                vals = [v.strip(" \t") for v in value.split(',')]
                 for val in vals:
                     if val.lower() == "chunked":
                         # DANGER: transfer codings stack, and stacked chunking is never intended


### PR DESCRIPTION
Fixes #3364.

This PR fixes an HTTP request smuggling vulnerability caused by unsafe whitespace stripping from `Transfer-Encoding` header values and other header fields.

Python`s `str.strip()` and `bytes.strip()` methods strip all ASCII or Unicode whitespace characters, including vertical tab (`\x0b`) and form feed (`\x0c`). This behavior incorrectly hides certain characters from Gunicorn`s header parsing, while they might be processed differently by a proxy.

This PR updates the parsing logic in `gunicorn/asgi/parser.py` and `gunicorn/http/message.py` to only strip standard HTTP whitespace (SP and HTAB) where appropriate, and avoids inappropriately stripping characters from header names.